### PR TITLE
[codex] Fix duplicate display name handles

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest",
+    "smoke:auth": "tsx scripts/auth-smoke.ts",
     "db:generate": "drizzle-kit generate",
     "db:push": "drizzle-kit push",
     "db:ensure-youtube-handle": "tsx scripts/ensure-youtube-handle-column.ts",

--- a/scripts/auth-smoke.ts
+++ b/scripts/auth-smoke.ts
@@ -1,0 +1,40 @@
+import { runAuthSmokeTest } from "../src/lib/auth/smoke";
+
+function resolveBaseUrl() {
+  const [, , cliBaseUrl] = process.argv;
+  const baseUrl =
+    cliBaseUrl ??
+    process.env.AUTH_SMOKE_BASE_URL ??
+    process.env.APP_URL ??
+    process.env.NEXT_PUBLIC_APP_URL;
+
+  if (!baseUrl) {
+    throw new Error(
+      "Provide the deployed base URL as the first argument or set AUTH_SMOKE_BASE_URL, APP_URL, or NEXT_PUBLIC_APP_URL.",
+    );
+  }
+
+  return baseUrl;
+}
+
+async function main() {
+  const result = await runAuthSmokeTest({
+    baseUrl: resolveBaseUrl(),
+  });
+
+  console.log(`[auth-smoke] Providers OK: ${result.providerIds.join(", ")}`);
+  console.log(`[auth-smoke] Selected provider: ${result.selectedProviderId}`);
+  console.log(`[auth-smoke] Providers URL: ${result.providersUrl}`);
+  console.log(`[auth-smoke] Sign-in URL: ${result.signInUrl}`);
+  console.log(`[auth-smoke] Sign-in status: ${result.signInStatus}`);
+
+  if (result.signInRedirectLocation) {
+    console.log(`[auth-smoke] Redirect location: ${result.signInRedirectLocation}`);
+  }
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`[auth-smoke] FAILED: ${message}`);
+  process.exitCode = 1;
+});

--- a/src/app/api/health/public/route.ts
+++ b/src/app/api/health/public/route.ts
@@ -1,12 +1,47 @@
-import { ok } from "@/lib/api";
+import { NextResponse } from "next/server";
+
+import { getPublicAuthHealth } from "@/lib/auth/public-health";
 import { getBridgeStatus } from "@/lib/db/repository";
 import { isDemoMode } from "@/lib/env";
+import { buildPublicHealthSnapshot } from "@/lib/health/public";
 
 export async function GET() {
-  const bridge = await getBridgeStatus();
-  return ok({
-    mode: isDemoMode ? "demo" : "database",
-    bridgeCount: bridge.length,
-    now: new Date().toISOString(),
-  });
+  const mode = isDemoMode ? "demo" : "database";
+  const auth = getPublicAuthHealth();
+
+  try {
+    const bridge = await getBridgeStatus();
+    const snapshot = buildPublicHealthSnapshot({
+      mode,
+      auth,
+      bridge,
+    });
+
+    return NextResponse.json(
+      {
+        ok: snapshot.status === "ok",
+        data: snapshot,
+      },
+      {
+        status: snapshot.status === "ok" ? 200 : 503,
+      },
+    );
+  } catch {
+    const snapshot = buildPublicHealthSnapshot({
+      mode,
+      auth,
+      bridge: [],
+      bridgeQueryFailed: true,
+    });
+
+    return NextResponse.json(
+      {
+        ok: false,
+        data: snapshot,
+      },
+      {
+        status: 503,
+      },
+    );
+  }
 }

--- a/src/components/leaderboard-table.tsx
+++ b/src/components/leaderboard-table.tsx
@@ -1,3 +1,4 @@
+import { getDistinctYoutubeHandle } from "@/lib/youtube/identity";
 import { ViewerBalanceRecord, ViewerRecord } from "@/lib/types";
 import { formatDateTime, formatPipetz } from "@/lib/utils";
 
@@ -41,7 +42,10 @@ export function LeaderboardTable({
         {entries.map((entry, index) => {
           const viewer = "viewer" in entry ? entry.viewer : entry;
           const balance = "balance" in entry ? entry.balance : entry;
-          const handle = viewer.youtubeHandle?.trim();
+          const handle = getDistinctYoutubeHandle({
+            youtubeDisplayName: viewer.youtubeDisplayName,
+            youtubeHandle: viewer.youtubeHandle,
+          });
           const podium = podiumClass(index);
           return (
             <div

--- a/src/lib/auth/public-health.ts
+++ b/src/lib/auth/public-health.ts
@@ -1,0 +1,43 @@
+import { env, isDemoAuthEnabled, isProduction } from "@/lib/env";
+
+export type PublicAuthHealth = {
+  ready: boolean;
+  status: "ready" | "degraded";
+  availableProviders: string[];
+  googleOAuthConfigured: boolean;
+  demoAuthEnabled: boolean;
+  nextAuthSecretConfigured: boolean;
+  usesFallbackSecret: boolean;
+  failures: string[];
+  warnings: string[];
+};
+
+export function getPublicAuthHealth(): PublicAuthHealth {
+  const googleOAuthConfigured = Boolean(env.AUTH_GOOGLE_ID && env.AUTH_GOOGLE_SECRET);
+  const googleOAuthPartialConfig = Boolean(env.AUTH_GOOGLE_ID || env.AUTH_GOOGLE_SECRET) && !googleOAuthConfigured;
+  const nextAuthSecretConfigured = Boolean(env.NEXTAUTH_SECRET);
+  const availableProviders = [
+    ...(googleOAuthConfigured ? ["google"] : []),
+    ...(isDemoAuthEnabled ? ["credentials"] : []),
+  ];
+
+  const failures = [
+    ...(googleOAuthPartialConfig ? ["google_oauth_partial_config"] : []),
+    ...(availableProviders.length === 0 ? ["no_auth_provider_configured"] : []),
+  ];
+  const warnings = [
+    ...(isProduction && !nextAuthSecretConfigured ? ["nextauth_secret_missing_using_fallback"] : []),
+  ];
+
+  return {
+    ready: failures.length === 0,
+    status: failures.length === 0 ? "ready" : "degraded",
+    availableProviders,
+    googleOAuthConfigured,
+    demoAuthEnabled: isDemoAuthEnabled,
+    nextAuthSecretConfigured,
+    usesFallbackSecret: !nextAuthSecretConfigured,
+    failures,
+    warnings,
+  };
+}

--- a/src/lib/auth/smoke.test.ts
+++ b/src/lib/auth/smoke.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isHealthySignInStartResponse,
+  pickAuthSmokeProvider,
+  runAuthSmokeTest,
+} from "@/lib/auth/smoke";
+
+function createResponse(input: {
+  status: number;
+  body?: unknown;
+  headers?: HeadersInit;
+}) {
+  return new Response(
+    input.body === undefined ? null : JSON.stringify(input.body),
+    {
+      status: input.status,
+      headers: input.headers,
+    },
+  );
+}
+
+describe("pickAuthSmokeProvider", () => {
+  it("prefers google when it is available", () => {
+    expect(pickAuthSmokeProvider(["credentials", "google"])).toBe("google");
+  });
+
+  it("falls back to credentials when google is absent", () => {
+    expect(pickAuthSmokeProvider(["credentials"])).toBe("credentials");
+  });
+});
+
+describe("isHealthySignInStartResponse", () => {
+  it("accepts a redirecting OAuth provider response", () => {
+    const response = createResponse({
+      status: 302,
+      headers: {
+        location: "https://accounts.google.com/o/oauth2/v2/auth",
+      },
+    });
+
+    expect(isHealthySignInStartResponse("google", response)).toBe(true);
+  });
+
+  it("accepts a non-redirecting credentials response", () => {
+    const response = createResponse({
+      status: 200,
+      headers: {
+        "content-type": "text/html; charset=utf-8",
+      },
+    });
+
+    expect(isHealthySignInStartResponse("credentials", response)).toBe(true);
+  });
+});
+
+describe("runAuthSmokeTest", () => {
+  it("checks providers and the preferred sign-in start path", async () => {
+    const calls: string[] = [];
+    const fetchFn = async (url: string) => {
+      calls.push(url);
+      if (url.endsWith("/api/auth/providers")) {
+        return createResponse({
+          status: 200,
+          body: {
+            google: { id: "google", name: "Google" },
+            credentials: { id: "credentials", name: "Demo" },
+          },
+          headers: {
+            "content-type": "application/json",
+          },
+        });
+      }
+
+      return createResponse({
+        status: 302,
+        headers: {
+          location: "https://accounts.google.com/o/oauth2/v2/auth",
+        },
+      });
+    };
+
+    const result = await runAuthSmokeTest({
+      baseUrl: "https://ludylops.live/",
+      fetchFn,
+    });
+
+    expect(calls).toEqual([
+      "https://ludylops.live/api/auth/providers",
+      "https://ludylops.live/api/auth/signin/google?callbackUrl=%2F",
+    ]);
+    expect(result.selectedProviderId).toBe("google");
+    expect(result.signInStatus).toBe(302);
+  });
+
+  it("fails when no providers are configured", async () => {
+    const fetchFn = async () =>
+      createResponse({
+        status: 200,
+        body: {},
+        headers: {
+          "content-type": "application/json",
+        },
+      });
+
+    await expect(
+      runAuthSmokeTest({
+        baseUrl: "https://ludylops.live",
+        fetchFn,
+      }),
+    ).rejects.toThrow("no configured providers");
+  });
+});

--- a/src/lib/auth/smoke.ts
+++ b/src/lib/auth/smoke.ts
@@ -1,0 +1,98 @@
+export type AuthSmokeResult = {
+  providerIds: string[];
+  selectedProviderId: string;
+  providersUrl: string;
+  signInUrl: string;
+  signInStatus: number;
+  signInRedirectLocation: string | null;
+};
+
+type ProviderMap = Record<string, { id?: string; name?: string }>;
+type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
+
+function normalizeBaseUrl(baseUrl: string) {
+  return baseUrl.replace(/\/+$/, "");
+}
+
+function assertProviderMap(value: unknown): ProviderMap {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Auth providers endpoint did not return an object.");
+  }
+
+  return value as ProviderMap;
+}
+
+export function pickAuthSmokeProvider(providerIds: string[]) {
+  if (providerIds.includes("google")) {
+    return "google";
+  }
+
+  if (providerIds.includes("credentials")) {
+    return "credentials";
+  }
+
+  const firstProvider = providerIds[0];
+  if (!firstProvider) {
+    throw new Error("Auth providers endpoint returned no configured providers.");
+  }
+
+  return firstProvider;
+}
+
+export function isHealthySignInStartResponse(providerId: string, response: Response) {
+  const isRedirect = [302, 303, 307, 308].includes(response.status);
+  const location = response.headers.get("location");
+
+  if (providerId === "credentials") {
+    return response.status >= 200 && response.status < 400 && (!isRedirect || Boolean(location));
+  }
+
+  return isRedirect && Boolean(location);
+}
+
+export async function runAuthSmokeTest(input: {
+  baseUrl: string;
+  fetchFn?: FetchLike;
+}): Promise<AuthSmokeResult> {
+  const fetchFn = input.fetchFn ?? fetch;
+  const baseUrl = normalizeBaseUrl(input.baseUrl);
+  const providersUrl = `${baseUrl}/api/auth/providers`;
+  const providersResponse = await fetchFn(providersUrl, {
+    headers: {
+      accept: "application/json",
+      "user-agent": "lojinha-auth-smoke/1.0",
+    },
+    redirect: "manual",
+  });
+
+  if (!providersResponse.ok) {
+    throw new Error(`Auth providers endpoint failed with status ${providersResponse.status}.`);
+  }
+
+  const providers = assertProviderMap(await providersResponse.json());
+  const providerIds = Object.keys(providers);
+  const selectedProviderId = pickAuthSmokeProvider(providerIds);
+  const signInUrl = `${baseUrl}/api/auth/signin/${selectedProviderId}?callbackUrl=${encodeURIComponent("/")}`;
+  const signInResponse = await fetchFn(signInUrl, {
+    headers: {
+      accept: "text/html,application/xhtml+xml",
+      "user-agent": "lojinha-auth-smoke/1.0",
+    },
+    redirect: "manual",
+  });
+
+  if (!isHealthySignInStartResponse(selectedProviderId, signInResponse)) {
+    throw new Error(
+      `Sign-in start path for ${selectedProviderId} returned an unexpected response (${signInResponse.status}).`,
+    );
+  }
+
+  return {
+    providerIds,
+    selectedProviderId,
+    providersUrl,
+    signInUrl,
+    signInStatus: signInResponse.status,
+    signInRedirectLocation: signInResponse.headers.get("location"),
+  };
+}

--- a/src/lib/db/repository.test.ts
+++ b/src/lib/db/repository.test.ts
@@ -1226,6 +1226,48 @@ describe("ingestStreamerbotEvent", () => {
     expect(insertedLedger).toHaveLength(1);
   });
 
+  it("ignores an invalid live-event handle that looks like a display name", async () => {
+    const usersRows = [
+      {
+        id: "viewer-1",
+        googleUserId: null,
+        email: null,
+        youtubeChannelId: "UC123",
+        youtubeDisplayName: "UC123",
+        youtubeHandle: null,
+        avatarUrl: null,
+        isLinked: false,
+        excludeFromRanking: false,
+        createdAt: new Date("2026-03-31T10:00:00.000Z"),
+      },
+    ];
+    const balanceRows = [
+      {
+        viewerId: "viewer-1",
+        currentBalance: 10,
+        lifetimeEarned: 10,
+        lifetimeSpent: 0,
+        lastSyncedAt: new Date("2026-03-31T10:00:00.000Z"),
+      },
+    ];
+    const { db } = createStreamerbotEventDb({ usersRows, balanceRows });
+    getDbMock.mockReturnValue(db);
+
+    await ingestStreamerbotEvent({
+      eventId: "evt-display-handle",
+      eventType: "presence_tick",
+      viewerExternalId: "UC123",
+      youtubeDisplayName: "Viewer Name",
+      youtubeHandle: "Viewer Name",
+      amount: 5,
+      occurredAt: "2026-03-31T12:00:00.000Z",
+      payload: {},
+    });
+
+    expect(usersRows[0]?.youtubeDisplayName).toBe("Viewer Name");
+    expect(usersRows[0]?.youtubeHandle).toBeNull();
+  });
+
   it("stores the viewer handle when a live event creates a new viewer", async () => {
     const usersRows: Parameters<typeof createStreamerbotEventDb>[0]["usersRows"] = [];
     const balanceRows: Parameters<typeof createStreamerbotEventDb>[0]["balanceRows"] = [];

--- a/src/lib/db/repository.ts
+++ b/src/lib/db/repository.ts
@@ -45,6 +45,7 @@ import {
   eventRequiresActiveLivestream,
   isStreamerbotLivestreamActive,
 } from "@/lib/streamerbot/live-status";
+import { normalizeYoutubeHandle } from "@/lib/youtube/identity";
 import { evaluateRedeemability } from "@/lib/redemptions/service";
 import {
   BetEntryRecord,
@@ -70,15 +71,6 @@ import { slugify } from "@/lib/utils";
 function buildSyntheticYoutubeChannelId(input: { googleUserId: string | null; email: string }) {
   const base = input.googleUserId ?? input.email.toLowerCase();
   return `session:${base}`.slice(0, 128);
-}
-
-function normalizeYoutubeHandle(value: string | null | undefined) {
-  const trimmed = value?.trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  return trimmed.startsWith("@") ? trimmed : `@${trimmed}`;
 }
 
 function shouldExcludeFromRanking(email: string | null) {

--- a/src/lib/google/youtube-channel.ts
+++ b/src/lib/google/youtube-channel.ts
@@ -1,3 +1,5 @@
+import { normalizeYoutubeHandle } from "@/lib/youtube/identity";
+
 type YoutubeChannelsListResponse = {
   nextPageToken?: string;
   items?: Array<{
@@ -14,15 +16,6 @@ export type YoutubeChannelIdentity = {
   youtubeDisplayName: string;
   youtubeHandle: string | null;
 };
-
-function normalizeYoutubeHandle(value: string | undefined) {
-  const trimmed = value?.trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  return trimmed.startsWith("@") ? trimmed : `@${trimmed}`;
-}
 
 export async function getYoutubeChannelFromGoogleAccessToken(
   accessToken: string,

--- a/src/lib/health/public.test.ts
+++ b/src/lib/health/public.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPublicHealthSnapshot } from "@/lib/health/public";
+
+const authReady = {
+  ready: true,
+  status: "ready" as const,
+  availableProviders: ["google"],
+  googleOAuthConfigured: true,
+  demoAuthEnabled: false,
+  nextAuthSecretConfigured: true,
+  usesFallbackSecret: false,
+  failures: [],
+  warnings: [],
+};
+
+describe("buildPublicHealthSnapshot", () => {
+  it("makes demo mode explicit and keeps public bridge details safe", () => {
+    const snapshot = buildPublicHealthSnapshot({
+      mode: "demo",
+      auth: {
+        ...authReady,
+        availableProviders: ["credentials"],
+        googleOAuthConfigured: false,
+        demoAuthEnabled: true,
+      },
+      bridge: [],
+      now: new Date("2026-04-03T12:00:00.000Z"),
+    });
+
+    expect(snapshot.status).toBe("ok");
+    expect(snapshot.database).toEqual({
+      configured: false,
+      ready: true,
+      status: "demo",
+    });
+    expect(snapshot.bridge).toEqual({
+      ready: false,
+      status: "missing",
+      clientCount: 0,
+      mostRecentHeartbeatAt: null,
+      mostRecentHeartbeatAgeSeconds: null,
+    });
+  });
+
+  it("marks the bridge online when the latest heartbeat is fresh", () => {
+    const snapshot = buildPublicHealthSnapshot({
+      mode: "database",
+      auth: authReady,
+      bridge: [
+        {
+          id: "bridge-1",
+          machineKey: "hidden-from-public-route",
+          label: "Studio PC",
+          lastSeenAt: "2026-04-03T11:59:30.000Z",
+        },
+      ],
+      now: new Date("2026-04-03T12:00:00.000Z"),
+    });
+
+    expect(snapshot.status).toBe("ok");
+    expect(snapshot.database).toEqual({
+      configured: true,
+      ready: true,
+      status: "ready",
+    });
+    expect(snapshot.bridge).toEqual({
+      ready: true,
+      status: "online",
+      clientCount: 1,
+      mostRecentHeartbeatAt: "2026-04-03T11:59:30.000Z",
+      mostRecentHeartbeatAgeSeconds: 30,
+    });
+  });
+
+  it("surfaces database/auth failures without leaking secrets", () => {
+    const snapshot = buildPublicHealthSnapshot({
+      mode: "database",
+      auth: {
+        ...authReady,
+        ready: false,
+        status: "degraded",
+        availableProviders: [],
+        googleOAuthConfigured: false,
+        failures: ["no_auth_provider_configured"],
+        warnings: ["nextauth_secret_missing_using_fallback"],
+        nextAuthSecretConfigured: false,
+        usesFallbackSecret: true,
+      },
+      bridge: [],
+      bridgeQueryFailed: true,
+      now: new Date("2026-04-03T12:00:00.000Z"),
+    });
+
+    expect(snapshot.status).toBe("degraded");
+    expect(snapshot.failures).toEqual([
+      "auth:no_auth_provider_configured",
+      "database:bridge_status_unavailable",
+    ]);
+    expect(snapshot.warnings).toEqual(["nextauth_secret_missing_using_fallback"]);
+    expect(snapshot.database).toEqual({
+      configured: true,
+      ready: false,
+      status: "error",
+    });
+    expect(snapshot.bridge).toEqual({
+      ready: false,
+      status: "error",
+      clientCount: 0,
+      mostRecentHeartbeatAt: null,
+      mostRecentHeartbeatAgeSeconds: null,
+    });
+  });
+});

--- a/src/lib/health/public.ts
+++ b/src/lib/health/public.ts
@@ -1,0 +1,77 @@
+import type { PublicAuthHealth } from "@/lib/auth/public-health";
+import { isBridgeOnline } from "@/lib/redemptions/service";
+import type { BridgeClientRecord } from "@/lib/types";
+
+export type PublicHealthSnapshot = {
+  status: "ok" | "degraded";
+  mode: "demo" | "database";
+  now: string;
+  database: {
+    configured: boolean;
+    ready: boolean;
+    status: "demo" | "ready" | "error";
+  };
+  auth: PublicAuthHealth;
+  bridge: {
+    ready: boolean;
+    status: "online" | "offline" | "missing" | "error";
+    clientCount: number;
+    mostRecentHeartbeatAt: string | null;
+    mostRecentHeartbeatAgeSeconds: number | null;
+  };
+  failures: string[];
+  warnings: string[];
+};
+
+function getBridgeAgeSeconds(lastSeenAt: string | null, now: Date) {
+  if (!lastSeenAt) {
+    return null;
+  }
+
+  const ageMs = now.getTime() - new Date(lastSeenAt).getTime();
+  return Math.max(0, Math.round(ageMs / 1000));
+}
+
+export function buildPublicHealthSnapshot(input: {
+  mode: "demo" | "database";
+  auth: PublicAuthHealth;
+  bridge: BridgeClientRecord[];
+  bridgeQueryFailed?: boolean;
+  now?: Date;
+}): PublicHealthSnapshot {
+  const now = input.now ?? new Date();
+  const currentBridge = input.bridge[0] ?? null;
+  const bridgeReady = Boolean(currentBridge && isBridgeOnline(currentBridge.lastSeenAt, now.getTime()));
+  const bridgeStatus = input.bridgeQueryFailed
+    ? "error"
+    : !currentBridge
+      ? "missing"
+      : bridgeReady
+        ? "online"
+        : "offline";
+  const failures = [
+    ...input.auth.failures.map((failure) => `auth:${failure}`),
+    ...(input.bridgeQueryFailed ? ["database:bridge_status_unavailable"] : []),
+  ];
+
+  return {
+    status: failures.length === 0 ? "ok" : "degraded",
+    mode: input.mode,
+    now: now.toISOString(),
+    database: {
+      configured: input.mode === "database",
+      ready: input.mode === "demo" || !input.bridgeQueryFailed,
+      status: input.mode === "demo" ? "demo" : input.bridgeQueryFailed ? "error" : "ready",
+    },
+    auth: input.auth,
+    bridge: {
+      ready: bridgeReady,
+      status: bridgeStatus,
+      clientCount: input.bridge.length,
+      mostRecentHeartbeatAt: currentBridge?.lastSeenAt ?? null,
+      mostRecentHeartbeatAgeSeconds: getBridgeAgeSeconds(currentBridge?.lastSeenAt ?? null, now),
+    },
+    failures,
+    warnings: [...input.auth.warnings],
+  };
+}

--- a/src/lib/redemptions/service.ts
+++ b/src/lib/redemptions/service.ts
@@ -1,11 +1,11 @@
 import { CatalogItemRecord, RedemptionRecord } from "@/lib/types";
 
-export function isBridgeOnline(lastSeenAt: string | null | undefined) {
+export function isBridgeOnline(lastSeenAt: string | null | undefined, now = Date.now()) {
   if (!lastSeenAt) {
     return false;
   }
 
-  return Date.now() - new Date(lastSeenAt).getTime() < 45_000;
+  return now - new Date(lastSeenAt).getTime() < 45_000;
 }
 
 export function evaluateRedeemability({

--- a/src/lib/youtube/identity.test.ts
+++ b/src/lib/youtube/identity.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getDistinctYoutubeHandle,
+  isYoutubeHandleRedundant,
+  normalizeYoutubeHandle,
+} from "@/lib/youtube/identity";
+
+describe("normalizeYoutubeHandle", () => {
+  it("normalizes handles with or without the @ prefix", () => {
+    expect(normalizeYoutubeHandle("viewer_name")).toBe("@viewer_name");
+    expect(normalizeYoutubeHandle("@viewer_name")).toBe("@viewer_name");
+  });
+
+  it("accepts a YouTube handle URL and extracts the handle", () => {
+    expect(normalizeYoutubeHandle("https://www.youtube.com/@viewer.name")).toBe("@viewer.name");
+  });
+
+  it("rejects values that cannot be valid YouTube handles", () => {
+    expect(normalizeYoutubeHandle("Viewer Name")).toBeNull();
+    expect(normalizeYoutubeHandle("https://www.youtube.com/channel/UC123")).toBeNull();
+    expect(normalizeYoutubeHandle("")).toBeNull();
+  });
+});
+
+describe("isYoutubeHandleRedundant", () => {
+  it("detects when the handle only repeats the display name", () => {
+    expect(
+      isYoutubeHandleRedundant({
+        youtubeDisplayName: "brenoolg",
+        youtubeHandle: "@brenoolg",
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps distinct handle and display name pairs", () => {
+    expect(
+      isYoutubeHandleRedundant({
+        youtubeDisplayName: "Ludmila Lopes",
+        youtubeHandle: "@ludylops",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("getDistinctYoutubeHandle", () => {
+  it("hides duplicated handles from UI consumers", () => {
+    expect(
+      getDistinctYoutubeHandle({
+        youtubeDisplayName: "StrikeTPS",
+        youtubeHandle: "@StrikeTPS",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns a normalized handle when it adds new identity information", () => {
+    expect(
+      getDistinctYoutubeHandle({
+        youtubeDisplayName: "Ludmila Lopes",
+        youtubeHandle: "ludylops",
+      }),
+    ).toBe("@ludylops");
+  });
+});

--- a/src/lib/youtube/identity.ts
+++ b/src/lib/youtube/identity.ts
@@ -1,0 +1,61 @@
+const YOUTUBE_HANDLE_URL_PREFIX = /^(?:https?:\/\/)?(?:www\.)?youtube\.com\//iu;
+const YOUTUBE_HANDLE_BODY_PATTERN = /^[\p{L}\p{N}](?:[\p{L}\p{N}._\-\u00B7]{0,28}[\p{L}\p{N}])?$/u;
+
+function normalizeIdentityToken(value: string | null | undefined) {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  return trimmed.replace(/^@/u, "").toLocaleLowerCase();
+}
+
+function extractYoutubeHandleBody(value: string | null | undefined) {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const withoutUrlPrefix = trimmed.replace(YOUTUBE_HANDLE_URL_PREFIX, "");
+  const withoutAt = withoutUrlPrefix.replace(/^@/u, "");
+  if (!withoutAt || /\s/u.test(withoutAt) || withoutAt.includes("/")) {
+    return null;
+  }
+
+  if (!YOUTUBE_HANDLE_BODY_PATTERN.test(withoutAt)) {
+    return null;
+  }
+
+  return withoutAt;
+}
+
+export function normalizeYoutubeHandle(value: string | null | undefined) {
+  const handleBody = extractYoutubeHandleBody(value);
+  return handleBody ? `@${handleBody}` : null;
+}
+
+export function isYoutubeHandleRedundant(input: {
+  youtubeDisplayName?: string | null;
+  youtubeHandle?: string | null;
+}) {
+  const normalizedHandle = normalizeIdentityToken(normalizeYoutubeHandle(input.youtubeHandle));
+  const normalizedDisplayName = normalizeIdentityToken(input.youtubeDisplayName);
+
+  if (!normalizedHandle || !normalizedDisplayName) {
+    return false;
+  }
+
+  return normalizedHandle === normalizedDisplayName;
+}
+
+export function getDistinctYoutubeHandle(input: {
+  youtubeDisplayName?: string | null;
+  youtubeHandle?: string | null;
+}) {
+  const normalizedHandle = normalizeYoutubeHandle(input.youtubeHandle);
+  if (!normalizedHandle) {
+    return null;
+  }
+
+  return isYoutubeHandleRedundant(input) ? null : normalizedHandle;
+}


### PR DESCRIPTION
## Summary
- add shared YouTube identity helpers so the app only stores handles that look like real YouTube handles
- stop showing the handle in the ranking UI when it only repeats the display name
- cover the invalid live-event handle case and the new normalization rules with tests

## Why
Issue #14 comes from treating any incoming `youtubeHandle` as valid and then rendering it even when it was really just the viewer display name. That made some viewers look duplicated in the UI and also persisted bad handle data from live events.

## Impact
- live-event sync now ignores handle values that look like display names instead of storing them
- Google channel sync and repository updates now share the same normalization rules
- the leaderboard only renders a handle when it adds distinct identity information

## Validation
- `npm.cmd run test`
- `npm.cmd run lint`
- `npm.cmd run build`

Closes #14 