### PR TITLE
Fix production build for YouTube linking flow

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import { AuthButtons } from "@/components/auth-buttons";
 import { QuickNavGrid } from "@/components/quick-nav-grid";
 import { StickerBadge } from "@/components/sticker-badge";
 import { env } from "@/lib/env";
+import type { YoutubeChannelLookupStatus } from "@/lib/google/youtube-channel";
 import {
   Card,
   CardContent,
@@ -42,10 +43,10 @@ type FeatureCard = {
 const DEFAULT_GITHUB_ISSUES_URL =
   "https://github.com/ludmila-omlopes/ludylops-youtube-dashboard/issues/new";
 
+type YoutubeLinkingStatusKind = YoutubeChannelLookupStatus["kind"];
+
 function buildYoutubeLinkingIssueUrl(input: {
-  status: NonNullable<
-    NonNullable<Awaited<ReturnType<typeof auth>>["user"]>["youtubeLinkingStatus"]
-  >;
+  status: YoutubeLinkingStatusKind;
   message: string;
   isLinked: boolean;
   hasActiveViewer: boolean;
@@ -80,9 +81,7 @@ function YoutubeLinkingNotice({
   message,
   issueUrl,
 }: {
-  status: NonNullable<
-    NonNullable<Awaited<ReturnType<typeof auth>>["user"]>["youtubeLinkingStatus"]
-  >;
+  status: YoutubeLinkingStatusKind;
   message: string;
   issueUrl: string;
 }) {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -9,6 +9,7 @@ import {
   canBootstrapViewerFromYoutubeLookup,
   getYoutubeChannelFromGoogleAccessToken,
   getYoutubeChannelLookupMessage,
+  isYoutubeChannelLookupStatusKind,
 } from "@/lib/google/youtube-channel";
 
 const providers = [];
@@ -184,7 +185,7 @@ export const authOptions = {
         if (typeof token.isLinked === "boolean") {
           session.user.isLinked = token.isLinked;
         }
-        if (typeof token.youtubeLinkingStatus === "string") {
+        if (typeof token.youtubeLinkingStatus === "string" && isYoutubeChannelLookupStatusKind(token.youtubeLinkingStatus)) {
           session.user.youtubeLinkingStatus = token.youtubeLinkingStatus;
         }
         if (typeof token.youtubeLinkingMessage === "string") {

--- a/src/lib/google/youtube-channel.ts
+++ b/src/lib/google/youtube-channel.ts
@@ -1,5 +1,3 @@
-import { normalizeYoutubeHandle } from "@/lib/youtube/identity";
-
 type YoutubeChannelsListResponse = {
   nextPageToken?: string;
   items?: Array<{
@@ -24,6 +22,135 @@ export type YoutubeChannelIdentity = {
   youtubeDisplayName: string;
   youtubeHandle: string | null;
 };
+
+export type YoutubeChannelLookupStatus =
+  | {
+      kind: "channels_found";
+      channelCount: number;
+    }
+  | {
+      kind: "empty";
+    }
+  | {
+      kind: "scope_missing";
+      grantedScopes: string[];
+    }
+  | {
+      kind: "authorization_required";
+      httpStatus: number;
+      errorReason: string | null;
+    }
+  | {
+      kind: "insufficient_permissions";
+      httpStatus: number;
+      errorReason: string | null;
+    }
+  | {
+      kind: "http_error";
+      httpStatus: number;
+      errorReason: string | null;
+    }
+  | {
+      kind: "network_error";
+      errorMessage: string;
+    };
+
+export type YoutubeChannelLookupResult = {
+  channels: YoutubeChannelIdentity[];
+  status: YoutubeChannelLookupStatus;
+};
+
+const YOUTUBE_READONLY_SCOPE = "https://www.googleapis.com/auth/youtube.readonly";
+const YOUTUBE_CHANNEL_LOOKUP_STATUS_KINDS = [
+  "channels_found",
+  "empty",
+  "scope_missing",
+  "authorization_required",
+  "insufficient_permissions",
+  "http_error",
+  "network_error",
+] as const;
+
+function normalizeYoutubeHandle(value: string | undefined) {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  return trimmed.startsWith("@") ? trimmed : `@${trimmed}`;
+}
+
+function parseScopes(scope: string | null | undefined) {
+  return (scope ?? "")
+    .split(/\s+/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function classifyLookupFailure(input: {
+  httpStatus: number;
+  errorReason: string | null;
+}): YoutubeChannelLookupStatus {
+  if (input.httpStatus === 401 || input.errorReason === "authorizationRequired") {
+    return {
+      kind: "authorization_required",
+      httpStatus: input.httpStatus,
+      errorReason: input.errorReason,
+    };
+  }
+
+  if (
+    input.httpStatus === 403 &&
+    (input.errorReason === "insufficientPermissions" || input.errorReason === "forbidden")
+  ) {
+    return {
+      kind: "insufficient_permissions",
+      httpStatus: input.httpStatus,
+      errorReason: input.errorReason,
+    };
+  }
+
+  return {
+    kind: "http_error",
+    httpStatus: input.httpStatus,
+    errorReason: input.errorReason,
+  };
+}
+
+export function getYoutubeChannelLookupMessage(status: YoutubeChannelLookupStatus) {
+  switch (status.kind) {
+    case "channels_found":
+      return null;
+    case "empty":
+      return "Sua conta Google entrou, mas o YouTube nao retornou nenhum canal para vincular.";
+    case "scope_missing":
+      return "O login Google nao concedeu a permissao youtube.readonly necessaria para descobrir seu canal.";
+    case "authorization_required":
+      return `O YouTube recusou a consulta do canal nesta tentativa (${status.httpStatus}).`;
+    case "insufficient_permissions":
+      return "O token Google nao teve permissao suficiente para consultar seu canal do YouTube.";
+    case "http_error":
+      return `O YouTube respondeu com erro ${status.httpStatus} ao consultar seu canal.`;
+    case "network_error":
+      return "Nao foi possivel falar com a API do YouTube para descobrir seu canal nesta tentativa.";
+  }
+}
+
+export function isYoutubeChannelLookupStatusKind(value: string): value is YoutubeChannelLookupStatus["kind"] {
+  return YOUTUBE_CHANNEL_LOOKUP_STATUS_KINDS.includes(value as YoutubeChannelLookupStatus["kind"]);
+}
+
+export function canBootstrapViewerFromYoutubeLookup(
+  result: YoutubeChannelLookupResult | null,
+): result is YoutubeChannelLookupResult & {
+  status: {
+    kind: "channels_found";
+    channelCount: number;
+  };
+  channels: [YoutubeChannelIdentity, ...YoutubeChannelIdentity[]];
+} {
+  return result?.status.kind === "channels_found" && result.channels.length > 0;
+}
 
 export async function getYoutubeChannelFromGoogleAccessToken(
   accessToken: string,


### PR DESCRIPTION
## Summary
- restore the missing YouTube lookup status helpers that `src/auth.ts` imports during the Google linking flow
- replace the homepage's fragile `ReturnType<typeof auth>` status typing with the explicit YouTube lookup status union
- add a status-kind guard so NextAuth session assignment narrows correctly under Next 16/TypeScript

## Validation
- `vitest run src/lib/google/youtube-channel.test.ts`
- `next build`
- deployed to Vercel production successfully
- verified `https://ludylops.live/privacy` returns 200 after deploy

## Production
- fixed deployment: `https://ludylops-youtube-dashboard-ntskuf0ng-definns-projects.vercel.app`
- production alias now points to that deployment