### PR TITLE
Fix Streamerbot chat bet and unlisted live diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Assinatura:
 - HMAC SHA-256 de `timestamp.body`
 - Secret: `STREAMERBOT_SHARED_SECRET`
 
-Eventos automáticos da live (`presence_tick` e `chat_bonus`) so entram no banco quando o canal monitorado estiver ao vivo. O backend usa `YOUTUBE_API_KEY` e, por padrao, o `youtube_channel_id` da conta admin vinculada; se preferir, configure `STREAM_YOUTUBE_CHANNEL_ID`.
+Eventos automáticos da live (`presence_tick` e `chat_bonus`) so entram no banco quando o canal monitorado estiver ao vivo. O backend usa `YOUTUBE_API_KEY` e, por padrao, o `youtube_channel_id` da conta admin vinculada; se preferir, configure `STREAM_YOUTUBE_CHANNEL_ID`. Se o Streamer.bot enviar `payload.isLive`, o backend usa esse sinal explicitamente antes de cair no fallback por API, o que ajuda em lives nao listadas.
 
 Payload base:
 
@@ -127,7 +127,12 @@ Payload base:
   "youtubeHandle": "@meucanal",
   "amount": 5,
   "occurredAt": "2026-04-01T22:30:00.000Z",
-  "payload": {}
+  "payload": {
+    "reason": "present_viewers",
+    "source": "streamerbot",
+    "isLive": true,
+    "broadcastId": "abc123"
+  }
 }
 ```
 
@@ -135,6 +140,8 @@ Notas:
 
 - `youtubeHandle` e opcional, mas recomendado para o ranking mostrar `@handle` em vez do channel id.
 - Pode ser enviado com ou sem `@`; o backend normaliza antes de salvar.
+- Se a live for `Unlisted`, inclua `payload.isLive = true` no request do Streamer.bot para evitar depender apenas da busca publica da API do YouTube.
+- A rota responde `200` mesmo quando ignora um evento live-gated; nesses casos o body inclui `ignoredReason`, entao o script do Streamer.bot deve logar o body mesmo em sucesso.
 
 ### Apostas por comando de chat
 
@@ -208,8 +215,20 @@ Notas:
 
 - O fluxo simples assume apenas uma aposta `open` por vez.
 - Se voce abrir varias apostas ao mesmo tempo, preencha `lojaneon.activeBetId` com o `betId` da rodada atual.
+- O script aceita `betId` vindo da propria action do Streamer.bot e usa esse valor antes da Global Variable.
 - O script tenta descobrir o id do viewer usando `userId`, `fromId`, `authorId`, `channelId`, `youtubeUserId` e `targetUserId`.
 - Se sua instancia do Streamer.bot usar outro nome de argumento, ajuste o array `ViewerIdArgCandidates` no script.
+
+Troubleshooting rapido:
+
+- `Assinatura invalida no comando de aposta.`
+  Verifique `lojaneon.streamerbotSharedSecret`, o relogio da maquina do Streamer.bot e se a action esta chamando a URL correta.
+- `Nao consegui identificar seu canal do YouTube para apostar.`
+  Verifique se o evento/comando do Streamer.bot expoe um dos argumentos aceitos pelo script: `id`, `userId`, `fromId`, `authorId`, `channelId`, `youtubeUserId` ou `targetUserId`.
+- `Ha mais de uma aposta aberta...`
+  Preencha `lojaneon.activeBetId` com o `betId` da rodada atual ou envie `betId` explicitamente na action.
+- `Opcao invalida.`
+  Confirme que o regex captura `optionIndex` corretamente e que o numero informado bate com a ordem das opcoes abertas.
 
 Referencias oficiais:
 

--- a/src/app/api/internal/streamerbot/bets/place/route.ts
+++ b/src/app/api/internal/streamerbot/bets/place/route.ts
@@ -22,7 +22,7 @@ function mapChatBetReply(message: string, viewerName?: string) {
     case "invalid_option":
       return "Opcao invalida. Use o numero ou nome exibido na aposta.";
     case "multiple_open_bets":
-      return "Ha mais de uma aposta aberta. Informe o betId no webhook do Streamer.bot.";
+      return "Ha mais de uma aposta aberta. Configure lojaneon.activeBetId ou envie betId no comando do Streamer.bot.";
     case "Aposta nao encontrada.":
       return "Nenhuma aposta aberta foi encontrada para esse comando.";
     default:
@@ -85,17 +85,34 @@ export async function POST(request: Request) {
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Falha ao registrar aposta.";
-    const viewerName =
+    const payloadSnapshot =
       (() => {
         try {
-          const payload = JSON.parse(raw) as { youtubeDisplayName?: string };
-          return payload.youtubeDisplayName;
+          const payload = JSON.parse(raw) as {
+            youtubeDisplayName?: string;
+            viewerExternalId?: string;
+            betId?: string;
+            optionId?: string;
+            optionIndex?: number;
+            optionLabel?: string;
+            amount?: number;
+          };
+          return payload;
         } catch {
-          return undefined;
+          return null;
         }
-      })() ?? undefined;
+      })();
+    const viewerName = payloadSnapshot?.youtubeDisplayName ?? undefined;
 
-    console.error("[streamerbot/bets/place] Failed to process payload.", error);
+    console.error("[streamerbot/bets/place] Failed to process payload.", {
+      error,
+      viewerExternalId: payloadSnapshot?.viewerExternalId ?? null,
+      betId: payloadSnapshot?.betId ?? null,
+      optionId: payloadSnapshot?.optionId ?? null,
+      optionIndex: payloadSnapshot?.optionIndex ?? null,
+      optionLabel: payloadSnapshot?.optionLabel ?? null,
+      amount: payloadSnapshot?.amount ?? null,
+    });
     return NextResponse.json(
       {
         ok: false,

--- a/src/lib/db/repository.test.ts
+++ b/src/lib/db/repository.test.ts
@@ -1597,6 +1597,69 @@ describe("ingestStreamerbotEvent", () => {
     expect(balanceRows[0]?.currentBalance).toBe(10);
   });
 
+  it("trusts an explicit payload isLive flag for unlisted live events", async () => {
+    isStreamerbotLivestreamActiveMock.mockResolvedValue(false);
+
+    const usersRows = [
+      {
+        id: "viewer-1",
+        googleUserId: null,
+        email: null,
+        youtubeChannelId: "UC123",
+        youtubeDisplayName: "Viewer Name",
+        avatarUrl: null,
+        isLinked: false,
+        excludeFromRanking: false,
+        createdAt: new Date("2026-03-31T10:00:00.000Z"),
+      },
+    ];
+    const balanceRows = [
+      {
+        viewerId: "viewer-1",
+        currentBalance: 10,
+        lifetimeEarned: 10,
+        lifetimeSpent: 0,
+        lastSyncedAt: new Date("2026-03-31T10:00:00.000Z"),
+      },
+    ];
+    const { db, insertedEvents, insertedLedger } = createStreamerbotEventDb({ usersRows, balanceRows });
+    getDbMock.mockReturnValue(db);
+
+    const result = await ingestStreamerbotEvent({
+      eventId: "evt-unlisted-live",
+      eventType: "presence_tick",
+      viewerExternalId: "UC123",
+      youtubeDisplayName: "Viewer Name",
+      amount: 5,
+      occurredAt: "2026-03-31T12:00:00.000Z",
+      payload: {
+        isLive: true,
+        reason: "present_viewers",
+        source: "streamerbot",
+      },
+    });
+
+    expect(result).toMatchObject({
+      mode: "database",
+      deduped: false,
+      eventLogInserted: true,
+      balanceUpdated: true,
+      ledgerInserted: true,
+      viewerId: "viewer-1",
+    });
+    expect(insertedEvents).toHaveLength(1);
+    expect(insertedLedger).toHaveLength(1);
+    expect(insertedLedger[0]).toMatchObject({
+      externalEventId: "evt-unlisted-live",
+      amount: 5,
+      metadata: {
+        isLive: true,
+        reason: "present_viewers",
+        source: "streamerbot",
+      },
+    });
+  });
+
 });
 
 describe("product recommendations", () => {

--- a/src/lib/db/repository.ts
+++ b/src/lib/db/repository.ts
@@ -971,6 +971,25 @@ function resolveChatBetOption(input: {
   throw new Error("invalid_option");
 }
 
+function parseExplicitLivestreamState(payload: Record<string, unknown>) {
+  const raw = payload.isLive;
+  if (typeof raw === "boolean") {
+    return raw;
+  }
+
+  if (typeof raw === "string") {
+    const normalized = raw.trim().toLowerCase();
+    if (normalized === "true" || normalized === "1" || normalized === "yes") {
+      return true;
+    }
+    if (normalized === "false" || normalized === "0" || normalized === "no") {
+      return false;
+    }
+  }
+
+  return null;
+}
+
 function listDemoBets(viewer: ViewerRecord | null) {
   const store = getDemoStore();
   return store.bets
@@ -3741,7 +3760,11 @@ export async function ingestStreamerbotEvent(input: {
   }
 
   if (eventRequiresActiveLivestream(input.eventType)) {
-    const isLive = await isStreamerbotLivestreamActive();
+    const explicitLivestreamState = parseExplicitLivestreamState(input.payload);
+    const isLive =
+      explicitLivestreamState === null
+        ? await isStreamerbotLivestreamActive()
+        : explicitLivestreamState;
     if (!isLive) {
       return {
         mode: "database" as const,

--- a/streamerbot/place-bet-from-chat.cs
+++ b/streamerbot/place-bet-from-chat.cs
@@ -6,6 +6,41 @@ using System.Text.RegularExpressions;
 
 public class CPHInline
 {
+    private static readonly string[] ViewerIdArgCandidates =
+    {
+        "id",
+        "userId",
+        "fromId",
+        "authorId",
+        "channelId",
+        "youtubeUserId",
+        "targetUserId",
+    };
+
+    private static readonly string[] DisplayNameArgCandidates =
+    {
+        "display",
+        "displayName",
+        "user",
+        "userName",
+        "authorName",
+        "channelName",
+    };
+
+    private static readonly string[] HandleArgCandidates =
+    {
+        "userName",
+        "handle",
+        "youtubeHandle",
+    };
+
+    private static readonly string[] BetIdArgCandidates =
+    {
+        "betId",
+        "activeBetId",
+        "bet_id",
+    };
+
     private static readonly HttpClient Http = new HttpClient
     {
         Timeout = TimeSpan.FromSeconds(10),
@@ -33,17 +68,23 @@ public class CPHInline
             return false;
         }
 
-        string viewerExternalId = GetArgString("id");
+        string viewerExternalId = GetFirstArgString(ViewerIdArgCandidates);
         if (string.IsNullOrWhiteSpace(viewerExternalId))
         {
-            CPH.LogError("[Loja Neon] Nao consegui descobrir o id do viewer no argumento 'id'.");
+            CPH.LogError(string.Format(
+                "[Loja Neon] Nao consegui descobrir o id do viewer. Args testados: {0}. Args disponiveis: {1}.",
+                string.Join(", ", ViewerIdArgCandidates),
+                ListAvailableArgs()
+            ));
             Reply("Nao consegui identificar seu canal do YouTube para apostar.", true);
             return false;
         }
 
-        string displayName = GetArgString("display");
-        string youtubeHandle = NormalizeHandle(GetArgString("userName"));
-        string activeBetId = ReadOptionalGlobal("lojaneon.activeBetId");
+        string displayName = GetFirstArgString(DisplayNameArgCandidates);
+        string youtubeHandle = NormalizeHandle(GetFirstArgString(HandleArgCandidates));
+        string requestedBetId = GetFirstArgString(BetIdArgCandidates);
+        string configuredBetId = ReadOptionalGlobal("lojaneon.activeBetId");
+        string activeBetId = !string.IsNullOrWhiteSpace(requestedBetId) ? requestedBetId : configuredBetId;
         bool useBotAccount = ReadOptionalBoolGlobal("lojaneon.useBotAccount", true);
 
         string body = BuildRequestBody(
@@ -163,6 +204,25 @@ public class CPHInline
         return false;
     }
 
+    private string GetFirstArgString(params string[] argNames)
+    {
+        if (argNames == null)
+        {
+            return null;
+        }
+
+        foreach (string argName in argNames)
+        {
+            string value = GetArgString(argName);
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+
+        return null;
+    }
+
     private string GetArgString(string argName)
     {
         if (args != null && args.ContainsKey(argName) && args[argName] != null)
@@ -176,6 +236,16 @@ public class CPHInline
         }
 
         return null;
+    }
+
+    private string ListAvailableArgs()
+    {
+        if (args == null || args.Count == 0)
+        {
+            return "(nenhum)";
+        }
+
+        return string.Join(", ", args.Keys);
     }
 
     private string NormalizeHandle(string value)

--- a/streamerbot/presence-tick-from-present-viewers.cs
+++ b/streamerbot/presence-tick-from-present-viewers.cs
@@ -1,0 +1,271 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+
+public class CPHInline
+{
+    private static readonly HttpClient Http = new HttpClient
+    {
+        Timeout = TimeSpan.FromSeconds(10),
+    };
+
+    public bool Execute()
+    {
+        string appBaseUrl = ReadRequiredGlobal("lojaneon.appBaseUrl");
+        string sharedSecret = ReadRequiredGlobal("lojaneon.streamerbotSharedSecret");
+        int pointsPerCycle = 5;
+
+        if (string.IsNullOrWhiteSpace(appBaseUrl) || string.IsNullOrWhiteSpace(sharedSecret))
+        {
+            return false;
+        }
+
+        if (!args.ContainsKey("users") || args["users"] == null)
+        {
+            CPH.LogWarn("[Loja Pipetz] Present Viewers trigger had no users list.");
+            return false;
+        }
+
+        var users = args["users"] as List<Dictionary<string, object>>;
+        if (users == null)
+        {
+            CPH.LogWarn("[Loja Pipetz] users was not a List<Dictionary<string, object>>.");
+            return false;
+        }
+
+        string broadcastId = GetArgString("broadcastId");
+        bool isLive = ReadBoolArg("isLive");
+        int sent = 0;
+        int failed = 0;
+        int ignored = 0;
+
+        foreach (var user in users)
+        {
+            string viewerExternalId = GetString(user, "id");
+            string youtubeDisplayName = GetString(user, "display");
+            string youtubeUserName = GetString(user, "userName");
+
+            if (string.IsNullOrWhiteSpace(viewerExternalId))
+            {
+                failed++;
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(youtubeDisplayName))
+            {
+                youtubeDisplayName = viewerExternalId;
+            }
+
+            string timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString();
+            string occurredAt = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
+            string eventId = string.Format("presence-{0}-{1}", viewerExternalId, timestamp);
+
+            string body = BuildRequestBody(
+                eventId,
+                viewerExternalId,
+                youtubeDisplayName,
+                youtubeUserName,
+                pointsPerCycle,
+                occurredAt,
+                broadcastId,
+                isLive
+            );
+
+            using (var request = new HttpRequestMessage(
+                HttpMethod.Post,
+                string.Format("{0}/api/internal/streamerbot/events", appBaseUrl.TrimEnd('/'))
+            ))
+            {
+                request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+                request.Headers.Add("x-timestamp", timestamp);
+                request.Headers.Add("x-signature", BuildSignature(sharedSecret, timestamp, body));
+
+                try
+                {
+                    HttpResponseMessage response = Http.SendAsync(request).GetAwaiter().GetResult();
+                    string responseBody = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+
+                    if (response.IsSuccessStatusCode)
+                    {
+                        sent++;
+                        if (!string.IsNullOrWhiteSpace(responseBody) && responseBody.Contains("\"ignoredReason\""))
+                        {
+                            ignored++;
+                            CPH.LogWarn(string.Format(
+                                "[Loja Pipetz] presence_tick returned ignored result for {0}: {1}",
+                                youtubeDisplayName,
+                                responseBody
+                            ));
+                        }
+                        else
+                        {
+                            CPH.LogInfo(string.Format(
+                                "[Loja Pipetz] presence_tick ok for {0}: {1}",
+                                youtubeDisplayName,
+                                responseBody
+                            ));
+                        }
+                    }
+                    else
+                    {
+                        failed++;
+                        CPH.LogWarn(string.Format(
+                            "[Loja Pipetz] presence_tick failed for {0}: status={1} body={2}",
+                            youtubeDisplayName,
+                            (int)response.StatusCode,
+                            responseBody
+                        ));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    failed++;
+                    CPH.LogWarn(string.Format(
+                        "[Loja Pipetz] presence_tick exception for {0}: {1}",
+                        youtubeDisplayName,
+                        ex.Message
+                    ));
+                }
+            }
+        }
+
+        CPH.LogInfo(string.Format(
+            "[Loja Pipetz] Present Viewers tick finished. sent={0} ignored={1} failed={2} total={3} isLive={4} broadcastId={5}",
+            sent,
+            ignored,
+            failed,
+            users.Count,
+            isLive,
+            string.IsNullOrWhiteSpace(broadcastId) ? "(none)" : broadcastId
+        ));
+
+        return failed == 0;
+    }
+
+    private string ReadRequiredGlobal(string variableName)
+    {
+        string value = ReadOptionalGlobal(variableName);
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            return value;
+        }
+
+        CPH.LogError(string.Format("[Loja Pipetz] Global obrigatoria ausente: {0}", variableName));
+        return string.Empty;
+    }
+
+    private string ReadOptionalGlobal(string variableName)
+    {
+        try
+        {
+            return CPH.GetGlobalVar<string>(variableName, true) ?? string.Empty;
+        }
+        catch
+        {
+            return string.Empty;
+        }
+    }
+
+    private bool ReadBoolArg(string argName)
+    {
+        if (CPH.TryGetArg(argName, out bool typedValue))
+        {
+            return typedValue;
+        }
+
+        if (CPH.TryGetArg(argName, out string rawValue))
+        {
+            if (string.Equals(rawValue, "true", StringComparison.OrdinalIgnoreCase) || rawValue == "1")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private string GetArgString(string argName)
+    {
+        if (args != null && args.ContainsKey(argName) && args[argName] != null)
+        {
+            return args[argName].ToString().Trim();
+        }
+
+        if (CPH.TryGetArg(argName, out string value) && !string.IsNullOrWhiteSpace(value))
+        {
+            return value.Trim();
+        }
+
+        return null;
+    }
+
+    private static string GetString(Dictionary<string, object> user, string key)
+    {
+        return user.ContainsKey(key) && user[key] != null ? user[key].ToString() : null;
+    }
+
+    private static string BuildSignature(string secret, string timestamp, string body)
+    {
+        using (var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret)))
+        {
+            byte[] hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(string.Format("{0}.{1}", timestamp, body)));
+            return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+        }
+    }
+
+    private static string BuildRequestBody(
+        string eventId,
+        string viewerExternalId,
+        string youtubeDisplayName,
+        string youtubeUserName,
+        int amount,
+        string occurredAt,
+        string broadcastId,
+        bool isLive
+    )
+    {
+        var builder = new StringBuilder();
+        builder.Append("{");
+        builder.AppendFormat("\"eventId\":\"{0}\"", Escape(eventId));
+        builder.Append(",\"eventType\":\"presence_tick\"");
+        builder.AppendFormat(",\"viewerExternalId\":\"{0}\"", Escape(viewerExternalId));
+        builder.AppendFormat(",\"youtubeDisplayName\":\"{0}\"", Escape(youtubeDisplayName));
+
+        if (!string.IsNullOrWhiteSpace(youtubeUserName))
+        {
+            builder.AppendFormat(",\"youtubeHandle\":\"{0}\"", Escape(youtubeUserName));
+        }
+
+        builder.AppendFormat(",\"amount\":{0}", amount);
+        builder.AppendFormat(",\"occurredAt\":\"{0}\"", occurredAt);
+        builder.Append(",\"payload\":{");
+        builder.Append("\"reason\":\"present_viewers\"");
+        builder.Append(",\"source\":\"streamerbot\"");
+        builder.AppendFormat(",\"isLive\":{0}", isLive ? "true" : "false");
+
+        if (!string.IsNullOrWhiteSpace(broadcastId))
+        {
+          builder.AppendFormat(",\"broadcastId\":\"{0}\"", Escape(broadcastId));
+        }
+
+        builder.Append("}}");
+        return builder.ToString();
+    }
+
+    private static string Escape(string value)
+    {
+        if (value == null)
+        {
+            return string.Empty;
+        }
+
+        return value
+            .Replace("\\", "\\\\")
+            .Replace("\"", "\\\"")
+            .Replace("\r", "\\r")
+            .Replace("\n", "\\n")
+            .Replace("\t", "\\t");
+    }
+}


### PR DESCRIPTION
## Summary
- make the Streamerbot chat bet script accept common viewer-id argument aliases and prefer an explicit etId from the action before falling back to lojaneon.activeBetId
- improve webhook diagnostics and chat replies for Streamerbot bet failures, especially when multiple bets are open
- allow live-gated Streamerbot events to trust payload.isLive so unlisted livestreams do not get ignored just because YouTube public search cannot see them
- add a ready-to-paste Present Viewers Streamerbot script that logs ignored 200 responses instead of treating them as invisible successes
- document the operational setup and troubleshooting path in the README

## Validation
- 
pm.cmd run lint -- src/lib/db/repository.ts src/lib/db/repository.test.ts src/app/api/internal/streamerbot/events/route.ts
- 
pm.cmd run test -- src/lib/db/repository.test.ts

## Root cause found
- the existing chat bet C# script only read id, while the operational docs already claimed it supported several aliases like userId and channelId
- presence_tick events could be silently ignored on unlisted livestreams because the backend fallback checked YouTube public live search rather than trusting a positive live signal from Streamerbot

Closes #30