### PR TITLE
[codex] Charge 200 pipetz for new suggestions

### DIFF
--- a/src/app/api/me/game-suggestions/route.ts
+++ b/src/app/api/me/game-suggestions/route.ts
@@ -34,6 +34,7 @@ export async function POST(request: Request) {
       viewerId: session.user.activeViewerId,
       name: parsed.data.name,
       description: parsed.data.description,
+      source: "web",
     });
 
     return ok(suggestion, { status: 201 });

--- a/src/components/game-suggest-form.tsx
+++ b/src/components/game-suggest-form.tsx
@@ -6,11 +6,14 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { GAME_SUGGESTION_CREATION_COST } from "@/lib/game-suggestions/constants";
 import { validateGameSuggestionDraft } from "@/lib/game-suggestions/service";
 import { formatPipetz } from "@/lib/utils";
 
 function mapSuggestionError(message: string) {
   switch (message) {
+    case "saldo_insuficiente":
+      return `Voce precisa de ${formatPipetz(GAME_SUGGESTION_CREATION_COST)} para criar uma sugestao.`;
     case "suggestion_already_exists":
       return "Esse jogo ja esta na lista aberta.";
     case "invalid_name":
@@ -34,6 +37,11 @@ export function GameSuggestForm({
   const [description, setDescription] = useState("");
   const [feedback, setFeedback] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+  const hasInsufficientBalance =
+    typeof viewerBalance === "number" && viewerBalance < GAME_SUGGESTION_CREATION_COST;
+  const missingBalance = hasInsufficientBalance
+    ? GAME_SUGGESTION_CREATION_COST - (viewerBalance ?? 0)
+    : 0;
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -49,6 +57,11 @@ export function GameSuggestForm({
 
     if (!canSuggest) {
       setFeedback(loggedIn ? "Sua conta ainda nao esta pronta para sugerir." : "Faca login para sugerir.");
+      return;
+    }
+
+    if (hasInsufficientBalance) {
+      setFeedback(`Faltam ${formatPipetz(missingBalance)} para criar uma sugestao.`);
       return;
     }
 
@@ -73,7 +86,7 @@ export function GameSuggestForm({
 
       setName("");
       setDescription("");
-      setFeedback("Sugestao enviada.");
+      setFeedback(`Sugestao enviada. ${formatPipetz(GAME_SUGGESTION_CREATION_COST)} debitados.`);
       router.refresh();
     });
   }
@@ -97,12 +110,20 @@ export function GameSuggestForm({
             <p className="mt-2 text-sm text-[var(--color-ink-soft)]">
               Se tiver algo que voce quer muito me ver jogando, manda aqui.
             </p>
+            <p className="mt-2 text-xs font-bold uppercase tracking-[0.12em] text-[var(--color-ink-soft)]">
+              cada nova sugestao custa {formatPipetz(GAME_SUGGESTION_CREATION_COST)}. boost continua separado.
+            </p>
           </div>
-          {typeof viewerBalance === "number" ? (
-            <span className="retro-label neutral-chip">
-              saldo {formatPipetz(viewerBalance)}
+          <div className="flex flex-wrap items-center justify-end gap-2">
+            <span className="retro-label accent-chip">
+              custa {formatPipetz(GAME_SUGGESTION_CREATION_COST)}
             </span>
-          ) : null}
+            {typeof viewerBalance === "number" ? (
+              <span className="retro-label neutral-chip">
+                saldo {formatPipetz(viewerBalance)}
+              </span>
+            ) : null}
+          </div>
         </div>
 
         <div className="mt-4 grid gap-3">
@@ -125,17 +146,25 @@ export function GameSuggestForm({
           />
           <Button
             type="submit"
-            disabled={isPending}
+            disabled={isPending || hasInsufficientBalance}
             size="lg"
             className="w-full sm:w-fit"
           >
-            {isPending ? "Enviando..." : "Enviar sugestao"}
+            {isPending
+              ? "Enviando..."
+              : `Enviar sugestao por ${formatPipetz(GAME_SUGGESTION_CREATION_COST)}`}
           </Button>
         </div>
 
         {!loggedIn ? (
           <p className="mt-3 text-xs font-bold uppercase tracking-[0.12em] text-[var(--color-ink-soft)]">
             faca login para sugerir e dar boost
+          </p>
+        ) : null}
+
+        {loggedIn && hasInsufficientBalance ? (
+          <p className="mt-3 text-xs font-bold uppercase tracking-[0.12em] text-[var(--color-ink-soft)]">
+            faltam {formatPipetz(missingBalance)} para liberar uma nova sugestao
           </p>
         ) : null}
 

--- a/src/lib/db/repository.test.ts
+++ b/src/lib/db/repository.test.ts
@@ -30,6 +30,7 @@ import {
   users,
   viewerBalances,
 } from "@/lib/db/schema";
+import { GAME_SUGGESTION_CREATION_COST } from "@/lib/game-suggestions/constants";
 import {
   boostGameSuggestion,
   cancelBet,
@@ -1092,10 +1093,16 @@ describe("game suggestions", () => {
   });
 
   it("creates a new game suggestion in demo mode", async () => {
+    const before = await getViewerDashboard("viewer_ana");
+    expect(before).not.toBeNull();
+    const beforeBalance = before?.balance.currentBalance ?? 0;
+    const beforeSpent = before?.balance.lifetimeSpent ?? 0;
+
     const created = await createGameSuggestion({
       viewerId: "viewer_ana",
       name: "Balatro",
       description: "Me deixa te ver quebrando a run.",
+      source: "web",
     });
 
     expect(created).toMatchObject({
@@ -1107,6 +1114,29 @@ describe("game suggestions", () => {
 
     const suggestions = await listGameSuggestions("viewer_ana");
     expect(suggestions.some((entry) => entry.name === "Balatro")).toBe(true);
+
+    const after = await getViewerDashboard("viewer_ana");
+    expect(after?.balance.currentBalance).toBe(beforeBalance - GAME_SUGGESTION_CREATION_COST);
+    expect(after?.balance.lifetimeSpent).toBe(beforeSpent + GAME_SUGGESTION_CREATION_COST);
+
+    const store = (globalThis as typeof globalThis & {
+      __lojaDemoStore?: {
+        ledger: Array<{
+          viewerId: string;
+          kind: string;
+          amount: number;
+          source: string;
+          metadata: Record<string, unknown>;
+        }>;
+      };
+    }).__lojaDemoStore;
+    expect(store?.ledger[0]).toMatchObject({
+      viewerId: "viewer_ana",
+      kind: "game_suggestion_creation",
+      amount: -GAME_SUGGESTION_CREATION_COST,
+      source: "web",
+      metadata: { suggestionId: created.id },
+    });
   });
 
   it("rejects duplicate open suggestions by slug", async () => {
@@ -1116,6 +1146,31 @@ describe("game suggestions", () => {
         name: "Hades II",
       }),
     ).rejects.toThrow("suggestion_already_exists");
+  });
+
+  it("blocks new suggestions when the viewer has insufficient balance", async () => {
+    void (await getViewerDashboard("viewer_lia"));
+    const store = (globalThis as typeof globalThis & {
+      __lojaDemoStore?: {
+        balances: Array<{
+          viewerId: string;
+          currentBalance: number;
+        }>;
+      };
+    }).__lojaDemoStore;
+
+    const balance = store?.balances.find((entry) => entry.viewerId === "viewer_lia");
+    if (!balance) {
+      throw new Error("Expected viewer_lia balance in the demo store.");
+    }
+    balance.currentBalance = GAME_SUGGESTION_CREATION_COST - 1;
+
+    await expect(
+      createGameSuggestion({
+        viewerId: "viewer_lia",
+        name: "Signalis",
+      }),
+    ).rejects.toThrow("saldo_insuficiente");
   });
 
   it("spends balance and increases votes when boosting", async () => {

--- a/src/lib/db/repository.ts
+++ b/src/lib/db/repository.ts
@@ -46,6 +46,7 @@ import {
   demoViewers,
 } from "@/lib/demo-data";
 import { adminEmails, isDemoMode } from "@/lib/env";
+import { GAME_SUGGESTION_CREATION_COST } from "@/lib/game-suggestions/constants";
 import {
   eventRequiresActiveLivestream,
   isStreamerbotLivestreamActive,
@@ -2111,6 +2112,7 @@ export async function createGameSuggestion(input: {
   name: string;
   description?: string | null;
   linkUrl?: string | null;
+  source?: string;
 }) {
   const viewer = await withViewerById(input.viewerId);
   if (!viewer) {
@@ -2125,6 +2127,8 @@ export async function createGameSuggestion(input: {
     throw new Error("invalid_name");
   }
 
+  const source = input.source ?? "web";
+  const suggestionId = randomUUID();
   const db = getDb();
   if (isDemoMode || !db) {
     const store = getDemoStore();
@@ -2135,9 +2139,18 @@ export async function createGameSuggestion(input: {
       throw new Error("suggestion_already_exists");
     }
 
+    const balance = getBalance(store, input.viewerId);
+    if (balance.currentBalance < GAME_SUGGESTION_CREATION_COST) {
+      throw new Error("saldo_insuficiente");
+    }
+
     const createdAt = new Date().toISOString();
+    balance.currentBalance -= GAME_SUGGESTION_CREATION_COST;
+    balance.lifetimeSpent += GAME_SUGGESTION_CREATION_COST;
+    balance.lastSyncedAt = createdAt;
+
     const suggestion: GameSuggestionRecord = {
-      id: randomUUID(),
+      id: suggestionId,
       viewerId: input.viewerId,
       slug,
       name,
@@ -2149,33 +2162,75 @@ export async function createGameSuggestion(input: {
       updatedAt: createdAt,
     };
     store.gameSuggestions.unshift(suggestion);
+
+    createLedgerEntry(store, {
+      viewerId: input.viewerId,
+      kind: "game_suggestion_creation",
+      amount: -GAME_SUGGESTION_CREATION_COST,
+      source,
+      externalEventId: null,
+      metadata: { suggestionId, slug },
+      createdAt,
+    });
+
     return buildGameSuggestionWithMeta({ suggestion, viewer, boosts: [] });
   }
 
-  const [existing] = await db
-    .select()
-    .from(gameSuggestions)
-    .where(and(eq(gameSuggestions.slug, slug), inArray(gameSuggestions.status, ["open", "accepted"])))
-    .limit(1);
-  if (existing) {
-    throw new Error("suggestion_already_exists");
-  }
-
   const createdAt = new Date();
-  await db.insert(gameSuggestions).values({
-    id: randomUUID(),
-    viewerId: input.viewerId,
-    slug,
-    name,
-    description,
-    linkUrl,
-    status: "open",
-    totalVotes: 0,
-    createdAt,
-    updatedAt: createdAt,
+  await db.transaction(async (tx) => {
+    const [existing] = await tx
+      .select()
+      .from(gameSuggestions)
+      .where(and(eq(gameSuggestions.slug, slug), inArray(gameSuggestions.status, ["open", "accepted"])))
+      .limit(1);
+    if (existing) {
+      throw new Error("suggestion_already_exists");
+    }
+
+    const [debited] = await tx
+      .update(viewerBalances)
+      .set({
+        currentBalance: sql`${viewerBalances.currentBalance} - ${GAME_SUGGESTION_CREATION_COST}`,
+        lifetimeSpent: sql`${viewerBalances.lifetimeSpent} + ${GAME_SUGGESTION_CREATION_COST}`,
+        lastSyncedAt: createdAt,
+      })
+      .where(
+        and(
+          eq(viewerBalances.viewerId, input.viewerId),
+          gte(viewerBalances.currentBalance, GAME_SUGGESTION_CREATION_COST),
+        ),
+      )
+      .returning({ viewerId: viewerBalances.viewerId });
+    if (!debited) {
+      throw new Error("saldo_insuficiente");
+    }
+
+    await tx.insert(gameSuggestions).values({
+      id: suggestionId,
+      viewerId: input.viewerId,
+      slug,
+      name,
+      description,
+      linkUrl,
+      status: "open",
+      totalVotes: 0,
+      createdAt,
+      updatedAt: createdAt,
+    });
+
+    await tx.insert(pointLedger).values({
+      id: randomUUID(),
+      viewerId: input.viewerId,
+      kind: "game_suggestion_creation",
+      amount: -GAME_SUGGESTION_CREATION_COST,
+      source,
+      externalEventId: null,
+      metadata: { suggestionId, slug },
+      createdAt,
+    });
   });
 
-  const created = (await listGameSuggestions(input.viewerId)).find((entry) => entry.slug === slug);
+  const created = (await listGameSuggestions(input.viewerId)).find((entry) => entry.id === suggestionId);
   if (!created) {
     throw new Error("Falha ao criar sugestao.");
   }

--- a/src/lib/game-suggestions/constants.ts
+++ b/src/lib/game-suggestions/constants.ts
@@ -1,0 +1,1 @@
+export const GAME_SUGGESTION_CREATION_COST = 200;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,6 +14,7 @@ export type LedgerKind =
   | "bet_debit"
   | "bet_payout"
   | "bet_refund"
+  | "game_suggestion_creation"
   | "game_suggestion_boost";
 
 export type BetStatus =


### PR DESCRIPTION
## Summary
- charge 200 pipetz when a viewer creates a new game suggestion
- show the creation cost in the suggestion form and block submission when balance is too low
- record the debit in the ledger while keeping suggestion boosts as a separate spend path

## Why
Creating a suggestion was free, which made suggestions low-friction in a way that did not match the intended community investment. This change makes each new suggestion a real pipetz spend with clear user feedback and backend enforcement.

## Impact
- viewers now need at least 200 pipetz to submit a new suggestion
- successful suggestion creation debits 200 pipetz immediately
- boosts still work independently after a suggestion exists

## Validation
- `npm.cmd run test -- src/lib/db/repository.test.ts`
- `npm.cmd run lint -- src/components/game-suggest-form.tsx src/app/api/me/game-suggestions/route.ts src/lib/db/repository.ts src/lib/db/repository.test.ts src/lib/game-suggestions/constants.ts src/lib/types.ts`

Closes #31