### PR TITLE
[codex] Prompt for YouTube permission reauth

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,8 @@ import { auth } from "@/auth";
 import { AuthButtons } from "@/components/auth-buttons";
 import { QuickNavGrid } from "@/components/quick-nav-grid";
 import { StickerBadge } from "@/components/sticker-badge";
+import { YoutubePermissionRetryButton } from "@/components/youtube-permission-retry-button";
+import { GOOGLE_ACCOUNT_SWITCH_HINT } from "@/lib/auth/google";
 import { env } from "@/lib/env";
 import type { YoutubeChannelLookupStatus } from "@/lib/google/youtube-channel";
 import {
@@ -92,19 +94,37 @@ function YoutubeLinkingNotice({
     status === "empty"
       ? "Nao encontrei nenhum canal do YouTube nesta conta."
       : status === "scope_missing"
-        ? "O login Google entrou sem permissao para consultar seu canal."
-        : "Nao consegui confirmar seu canal do YouTube nesta tentativa.";
+        ? "Faltou a permissão do YouTube para conectar sua conta."
+        : status === "authorization_required" || status === "insufficient_permissions"
+          ? "Preciso que você reautorize o acesso ao YouTube."
+        : "Não consegui confirmar seu canal do YouTube nesta tentativa.";
+  const ctaLabel =
+    status === "scope_missing" || status === "authorization_required" || status === "insufficient_permissions"
+      ? "Conceder acesso ao YouTube"
+      : "Tentar novamente com Google";
+  const whyItMatters =
+    status === "scope_missing" || status === "authorization_required" || status === "insufficient_permissions"
+      ? "Preciso da leitura do YouTube para descobrir qual canal deve receber seu saldo, ranking e recursos da live."
+      : "Sem confirmar o canal do YouTube, eu não consigo liberar com segurança a sessão vinculada da live.";
 
   return (
     <div className="card-poster mt-6 border-[3px] border-[var(--color-ink)] bg-[var(--color-pink)] p-4 text-[var(--color-accent-ink)]">
       <p className="mono text-[10px] uppercase tracking-[0.24em]">linking google/youtube</p>
       <p className="mt-2 text-lg font-black uppercase leading-tight">{title}</p>
       <p className="mt-3 text-sm font-bold leading-6">{message}</p>
+      <p className="mt-3 text-sm font-medium leading-6">{whyItMatters}</p>
       <p className="mt-3 text-xs font-medium leading-5">
-        Por seguranca, eu nao criei nem troquei automaticamente o viewer desta sessao enquanto esse
+        Por segurança, eu não criei nem troquei automaticamente o viewer desta sessão enquanto esse
         diagnostico nao for resolvido.
       </p>
+      <p className="mt-3 text-xs font-medium leading-5">{GOOGLE_ACCOUNT_SWITCH_HINT}</p>
       <div className="mt-4 flex flex-wrap gap-3">
+        <YoutubePermissionRetryButton
+          label={ctaLabel}
+          pendingLabel="Abrindo Google..."
+          variant="neutral"
+          size="sm"
+        />
         <a
           href={issueUrl}
           target="_blank"

--- a/src/components/youtube-permission-retry-button.tsx
+++ b/src/components/youtube-permission-retry-button.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { type ComponentProps, useTransition } from "react";
+import { signIn } from "next-auth/react";
+
+import { Button } from "@/components/ui/button";
+import { GOOGLE_REAUTHORIZATION_PARAMS } from "@/lib/auth/google";
+
+type YoutubePermissionRetryButtonProps = {
+  label?: string;
+  pendingLabel?: string;
+  callbackUrl?: string;
+} & Pick<ComponentProps<typeof Button>, "variant" | "size" | "className">;
+
+export function YoutubePermissionRetryButton({
+  label = "Conceder acesso ao YouTube",
+  pendingLabel = "Abrindo Google...",
+  callbackUrl = "/",
+  variant = "default",
+  size = "default",
+  className,
+}: YoutubePermissionRetryButtonProps) {
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <Button
+      type="button"
+      variant={variant}
+      size={size}
+      className={className}
+      disabled={isPending}
+      onClick={() => {
+        startTransition(() => {
+          void signIn("google", { callbackUrl }, GOOGLE_REAUTHORIZATION_PARAMS);
+        });
+      }}
+    >
+      {isPending ? pendingLabel : label}
+    </Button>
+  );
+}

--- a/src/lib/auth/google.test.ts
+++ b/src/lib/auth/google.test.ts
@@ -3,12 +3,18 @@ import { describe, expect, it } from "vitest";
 import {
   GOOGLE_ACCOUNT_SWITCH_HINT,
   GOOGLE_AUTHORIZATION_PARAMS,
+  GOOGLE_REAUTHORIZATION_PARAMS,
   GOOGLE_REQUIRED_SCOPES,
 } from "@/lib/auth/google";
 
 describe("GOOGLE_AUTHORIZATION_PARAMS", () => {
   it("always asks Google to show the account chooser", () => {
     expect(GOOGLE_AUTHORIZATION_PARAMS.prompt).toBe("select_account");
+  });
+
+  it("uses an explicit consent prompt when reauthorization is needed", () => {
+    expect(GOOGLE_REAUTHORIZATION_PARAMS.prompt).toBe("consent select_account");
+    expect(GOOGLE_REAUTHORIZATION_PARAMS.scope).toBe(GOOGLE_REQUIRED_SCOPES.join(" "));
   });
 
   it("keeps the scopes needed for profile and YouTube linking", () => {

--- a/src/lib/auth/google.ts
+++ b/src/lib/auth/google.ts
@@ -10,5 +10,10 @@ export const GOOGLE_AUTHORIZATION_PARAMS = {
   scope: GOOGLE_REQUIRED_SCOPES.join(" "),
 } as const;
 
+export const GOOGLE_REAUTHORIZATION_PARAMS = {
+  ...GOOGLE_AUTHORIZATION_PARAMS,
+  prompt: "consent select_account",
+} as const;
+
 export const GOOGLE_ACCOUNT_SWITCH_HINT =
   "Na proxima etapa, voce pode escolher outra conta sem limpar a sessao do navegador.";

--- a/src/lib/db/repository.test.ts
+++ b/src/lib/db/repository.test.ts
@@ -1344,6 +1344,44 @@ describe("ensureViewerFromSession", () => {
     expect(store.googleAccountViewers.some((entry: { viewerId: string }) => entry.viewerId === fallbackViewer?.id)).toBe(false);
   });
 
+  it("reuses an orphan synthetic fallback viewer instead of creating a duplicate session channel", async () => {
+    getDbMock.mockReturnValue(null);
+
+    const fallbackViewer = await ensureViewerFromSession({
+      googleUserId: "google_retry",
+      email: "retry@example.com",
+      name: "Retry",
+      image: null,
+    });
+
+    const store = (globalThis as typeof globalThis & {
+      __lojaDemoStore?: {
+        googleAccounts: Array<{ id: string; email: string; activeViewerId: string | null }>;
+        googleAccountViewers: Array<{ id: string; googleAccountId: string; viewerId: string; createdAt: string }>;
+      };
+    }).__lojaDemoStore;
+    const account = store?.googleAccounts.find((entry) => entry.email === "retry@example.com");
+    if (!store || !account || !fallbackViewer) {
+      throw new Error("Expected demo account and fallback viewer for retry@example.com.");
+    }
+
+    store.googleAccountViewers = store.googleAccountViewers.filter((entry) => entry.viewerId !== fallbackViewer.id);
+    account.activeViewerId = null;
+
+    const retriedViewer = await ensureViewerFromSession({
+      googleUserId: "google_retry",
+      email: "retry@example.com",
+      name: "Retry",
+      image: null,
+    });
+
+    expect(retriedViewer?.id).toBe(fallbackViewer.id);
+
+    const channels = await listViewerChannelsForGoogleAccount(account.id);
+    expect(channels).toHaveLength(1);
+    expect(channels[0]?.youtubeChannelId).toBe("session:google_retry");
+  });
+
   it("attaches an orphan chat viewer when the same user later logs in with Google", async () => {
     getDbMock.mockReturnValue(null);
 

--- a/src/lib/db/repository.ts
+++ b/src/lib/db/repository.ts
@@ -1496,6 +1496,10 @@ export async function ensureViewerFromSession(input: SessionBootstrapInput) {
   }
 
   const youtubeChannels = normalizeSessionYoutubeChannels(input.youtubeChannels);
+  const syntheticYoutubeChannelId = buildSyntheticYoutubeChannelId({
+    googleUserId: input.googleUserId,
+    email: input.email,
+  });
   const db = getDb();
   if (isDemoMode || !db) {
     const store = getDemoStore();
@@ -1590,20 +1594,20 @@ export async function ensureViewerFromSession(input: SessionBootstrapInput) {
           : activeViewer ?? listDemoViewersForGoogleAccount(store, googleAccount.id)[0] ?? null;
 
     if (!preferredViewer) {
-      preferredViewer = buildViewerRecord({
-        googleUserId: input.googleUserId,
-        email: input.email,
-        name: input.name,
-        image: input.image,
-        youtubeChannelId: buildSyntheticYoutubeChannelId({
+      preferredViewer = getDemoViewerByYoutubeChannelId(store, syntheticYoutubeChannelId);
+      if (!preferredViewer) {
+        preferredViewer = buildViewerRecord({
           googleUserId: input.googleUserId,
           email: input.email,
-        }),
-        youtubeDisplayName: input.name ?? input.email.split("@")[0],
-        isLinked: false,
-      });
-      store.viewers.push(preferredViewer);
-      getBalance(store, preferredViewer.id);
+          name: input.name,
+          image: input.image,
+          youtubeChannelId: syntheticYoutubeChannelId,
+          youtubeDisplayName: input.name ?? input.email.split("@")[0],
+          isLinked: false,
+        });
+        store.viewers.push(preferredViewer);
+        getBalance(store, preferredViewer.id);
+      }
     }
 
     preferredViewer.googleUserId = input.googleUserId;
@@ -1762,15 +1766,16 @@ export async function ensureViewerFromSession(input: SessionBootstrapInput) {
   }
 
   if (!preferredViewer) {
+    preferredViewer = await withViewerByYoutubeChannelId(syntheticYoutubeChannelId);
+  }
+
+  if (!preferredViewer) {
     preferredViewer = buildViewerRecord({
       googleUserId: input.googleUserId,
       email: input.email,
       name: input.name,
       image: input.image,
-      youtubeChannelId: buildSyntheticYoutubeChannelId({
-        googleUserId: input.googleUserId,
-        email: input.email,
-      }),
+      youtubeChannelId: syntheticYoutubeChannelId,
       youtubeDisplayName: input.name ?? input.email.split("@")[0],
       isLinked: false,
     });


### PR DESCRIPTION
## Summary
- explain why YouTube read access is needed when channel linking cannot be confirmed
- add a clear CTA that reopens Google sign-in with an explicit consent prompt
- reuse existing synthetic fallback viewers during retry flows so reauthorization does not fail on duplicate session channel inserts

## Why
When YouTube read permission was missing or not granted, the product could look blocked and the recovery path was unclear. On top of that, retries could crash on a duplicate `session:<googleUserId>` viewer insert, which made the permission prompt flow feel broken.

## Impact
- users now see clear feedback when YouTube linking is blocked by missing or insufficient permission
- the UI explains why the permission matters for linking saldo, ranking, and live features
- users can immediately retry authorization from the notice itself
- the fallback viewer bootstrap now reuses the existing synthetic viewer instead of hitting a unique constraint on retry

## Validation
- `npm.cmd run lint -- src/app/page.tsx src/components/youtube-permission-retry-button.tsx src/lib/auth/google.ts src/lib/auth/google.test.ts src/lib/db/repository.ts src/lib/db/repository.test.ts`
- `npm.cmd run test -- src/lib/db/repository.test.ts src/lib/auth/google.test.ts src/lib/google/youtube-channel.test.ts`

Closes #38