### PR TITLE
[codex] Add chat command to check viewer points

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,83 @@ Referencias oficiais:
 - Variaveis em C#: [docs.streamer.bot/faq/variables-in-csharp](https://docs.streamer.bot/faq/variables-in-csharp)
 - Resposta no chat do YouTube: [docs.streamer.bot/api/csharp/methods/youtube/chat/send-youtube-message-to-latest-monitored](https://docs.streamer.bot/api/csharp/methods/youtube/chat/send-youtube-message-to-latest-monitored)
 
+### Saldo por comando de chat
+
+Para permitir que cada viewer consulte os proprios pipetz no chat do YouTube via Streamer.bot, use:
+
+- `POST /api/internal/streamerbot/points`
+
+Headers obrigatorios:
+
+- `x-timestamp`
+- `x-signature`
+
+Assinatura:
+
+- HMAC SHA-256 de `timestamp.body`
+- Secret: `STREAMERBOT_SHARED_SECRET`
+
+Payload recomendado para `!pontos`, `!saldo` ou `!pipetz`:
+
+```json
+{
+  "viewerExternalId": "UCxxxxxxxx",
+  "youtubeDisplayName": "Nome do canal",
+  "youtubeHandle": "@meucanal",
+  "source": "streamerbot_chat"
+}
+```
+
+Notas:
+
+- A consulta e read-only: ela nao cria viewer, nao ajusta saldo e nao altera nomes/handles salvos.
+- Se o viewer ainda nao existir no backend, a rota responde com mensagem clara para indicar que a conta ainda nao esta pronta para consulta.
+- O response inclui `replyMessage`, pensado para o Streamer.bot reutilizar direto no chat.
+
+#### Setup rapido do Streamer.bot
+
+O setup pronto para colar no `Execute C# Code` esta em:
+
+- [get-points-from-chat.cs](/D:/Codigos_Diversos/lojinha-youtube/streamerbot/get-points-from-chat.cs)
+
+Passo a passo operacional:
+
+1. Crie estas Global Variables no Streamer.bot:
+
+- `lojaneon.appBaseUrl`
+  Valor: `https://seu-app.vercel.app`
+- `lojaneon.streamerbotSharedSecret`
+  Valor: o mesmo `STREAMERBOT_SHARED_SECRET` do app
+- `lojaneon.useBotAccount`
+  Valor: `true`
+
+2. Crie um comando do YouTube com regex:
+
+```regex
+^!(?:pontos|saldo|pipetz)$
+```
+
+3. Na action desse comando, adicione `Core > C# > Execute C# Code`.
+
+4. Cole o conteudo de [get-points-from-chat.cs](/D:/Codigos_Diversos/lojinha-youtube/streamerbot/get-points-from-chat.cs).
+
+5. O proprio script responde no chat com `CPH.SendYouTubeMessageToLatestMonitored(...)`, entao nao precisa de um segundo sub-action.
+
+Troubleshooting rapido:
+
+- `Assinatura invalida no comando de saldo.`
+  Verifique `lojaneon.streamerbotSharedSecret`, o relogio da maquina do Streamer.bot e se a action esta chamando a URL correta.
+- `Nao consegui identificar seu canal do YouTube para consultar seus pipetz.`
+  Verifique se o evento/comando do Streamer.bot expoe um dos argumentos aceitos pelo script: `id`, `userId`, `fromId`, `authorId`, `channelId`, `youtubeUserId` ou `targetUserId`.
+- `Ainda nao encontrei sua conta da live para consultar seus pipetz.`
+  Esse comando nao cria cadastro novo. Aguarde o viewer aparecer no backend pelos eventos da live ou confirme se a integracao que registra viewers no chat ja esta funcionando.
+
+Referencias oficiais:
+
+- Variaveis e argumentos: [docs.streamer.bot/guide/variables](https://docs.streamer.bot/guide/variables)
+- Variaveis em C#: [docs.streamer.bot/api/csharp/guide/variables](https://docs.streamer.bot/api/csharp/guide/variables)
+- Resposta no chat do YouTube: [docs.streamer.bot/api/sub-actions/youtube/send-message-to-channel](https://docs.streamer.bot/api/sub-actions/youtube/send-message-to-channel/)
+
 ### Quotes por comando de chat
 
 Para criar e chamar quotes pelo chat do YouTube via Streamer.bot, use:

--- a/src/app/api/internal/streamerbot/points/route.ts
+++ b/src/app/api/internal/streamerbot/points/route.ts
@@ -1,0 +1,94 @@
+import { NextResponse } from "next/server";
+
+import { ok } from "@/lib/api";
+import { getViewerBalanceFromChatCommand } from "@/lib/db/repository";
+import { env } from "@/lib/env";
+import { streamerbotViewerBalanceCommandSchema } from "@/lib/streamerbot/schemas";
+import { verifySignedRequest } from "@/lib/streamerbot/security";
+import { formatPipetz } from "@/lib/utils";
+
+function mapViewerBalanceReply(message: string, viewerName?: string) {
+  const prefix = viewerName ? `${viewerName}, ` : "";
+
+  switch (message) {
+    case "viewer_external_id_required":
+      return "Nao consegui identificar seu canal do YouTube para consultar seus pipetz.";
+    case "viewer_not_ready":
+      return `${prefix}ainda nao encontrei sua conta da live para consultar seus pipetz.`;
+    default:
+      return `${prefix}nao consegui consultar seus pipetz agora.`;
+  }
+}
+
+export async function POST(request: Request) {
+  const raw = await request.text();
+  const timestamp = request.headers.get("x-timestamp");
+  const signature = request.headers.get("x-signature");
+
+  const valid = verifySignedRequest({
+    body: raw,
+    timestamp,
+    signature,
+    secret: env.STREAMERBOT_SHARED_SECRET,
+  });
+  if (!valid) {
+    console.warn("[streamerbot/points] Invalid signature.", {
+      hasSecret: Boolean(env.STREAMERBOT_SHARED_SECRET),
+      hasTimestamp: Boolean(timestamp),
+      hasSignature: Boolean(signature),
+    });
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "Invalid signature.",
+        replyMessage: "Assinatura invalida no comando de saldo.",
+      },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const payload = streamerbotViewerBalanceCommandSchema.parse(JSON.parse(raw));
+    const result = await getViewerBalanceFromChatCommand(payload);
+    const viewerName = payload.youtubeDisplayName?.trim() || result.viewer.youtubeDisplayName;
+    const replyMessage = `${viewerName}, seu saldo atual e ${formatPipetz(result.balance.currentBalance)} pipetz.`;
+
+    console.info("[streamerbot/points] Processed balance lookup.", {
+      viewerId: result.viewer.id,
+      viewerExternalId: payload.viewerExternalId,
+      source: payload.source,
+      balance: result.balance.currentBalance,
+    });
+
+    return ok({
+      viewerId: result.viewer.id,
+      viewerExternalId: result.viewer.youtubeChannelId,
+      balance: result.balance.currentBalance,
+      lifetimeEarned: result.balance.lifetimeEarned,
+      lifetimeSpent: result.balance.lifetimeSpent,
+      lastSyncedAt: result.balance.lastSyncedAt,
+      replyMessage,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Falha ao consultar saldo.";
+    const viewerName =
+      (() => {
+        try {
+          const payload = JSON.parse(raw) as { youtubeDisplayName?: string };
+          return payload.youtubeDisplayName?.trim() || undefined;
+        } catch {
+          return undefined;
+        }
+      })() ?? undefined;
+
+    console.error("[streamerbot/points] Failed to process payload.", error);
+    return NextResponse.json(
+      {
+        ok: false,
+        error: message,
+        replyMessage: mapViewerBalanceReply(message, viewerName),
+      },
+      { status: 400 },
+    );
+  }
+}

--- a/src/lib/db/repository.test.ts
+++ b/src/lib/db/repository.test.ts
@@ -41,6 +41,7 @@ import {
   ensureViewerFromSession,
   getViewerDashboard,
   getSessionViewerState,
+  getViewerBalanceFromChatCommand,
   ingestStreamerbotEvent,
   listAdminProductRecommendations,
   listBets,
@@ -1024,6 +1025,79 @@ describe("placeBetFromChatCommand", () => {
         source: "streamerbot_chat",
       }),
     ).rejects.toThrow("multiple_open_bets");
+  });
+});
+
+describe("getViewerBalanceFromChatCommand", () => {
+  beforeEach(() => {
+    getDbMock.mockReset();
+    getDbMock.mockReturnValue(null);
+    delete (globalThis as typeof globalThis & { __lojaDemoStore?: unknown }).__lojaDemoStore;
+  });
+
+  it("returns the current balance for an existing chat viewer without mutating the store", async () => {
+    const before = await getViewerDashboard("viewer_lia");
+    const beforeStore = structuredClone(
+      (globalThis as typeof globalThis & {
+        __lojaDemoStore?: {
+          viewers: Array<{
+            id: string;
+            youtubeChannelId: string | null;
+            youtubeDisplayName: string;
+          }>;
+          balances: Array<{
+            viewerId: string;
+            currentBalance: number;
+          }>;
+        };
+      }).__lojaDemoStore,
+    );
+
+    const result = await getViewerBalanceFromChatCommand({
+      viewerExternalId: "yt_lia",
+      youtubeDisplayName: "Lia Pixel Renomeada",
+      source: "streamerbot_chat",
+    });
+
+    const after = await getViewerDashboard("viewer_lia");
+    const afterStore = (globalThis as typeof globalThis & {
+      __lojaDemoStore?: {
+        viewers: Array<{
+          id: string;
+          youtubeChannelId: string | null;
+          youtubeDisplayName: string;
+        }>;
+        balances: Array<{
+          viewerId: string;
+          currentBalance: number;
+        }>;
+      };
+    }).__lojaDemoStore;
+
+    expect(result.viewer.id).toBe("viewer_lia");
+    expect(result.balance.currentBalance).toBe(520);
+    expect(after?.balance.currentBalance).toBe(before?.balance.currentBalance);
+    expect(afterStore).toEqual(beforeStore);
+  });
+
+  it("returns a clear error when the chat viewer does not exist yet", async () => {
+    await expect(
+      getViewerBalanceFromChatCommand({
+        viewerExternalId: "yt_novo",
+        youtubeDisplayName: "Viewer Novo",
+        source: "streamerbot_chat",
+      }),
+    ).rejects.toThrow("viewer_not_ready");
+
+    const store = (globalThis as typeof globalThis & {
+      __lojaDemoStore?: {
+        viewers: Array<{
+          youtubeChannelId: string | null;
+        }>;
+      };
+    }).__lojaDemoStore;
+
+    expect(store?.viewers.some((entry) => entry.youtubeChannelId === "yt_novo")).toBe(false);
   });
 });
 

--- a/src/lib/db/repository.ts
+++ b/src/lib/db/repository.ts
@@ -2882,6 +2882,34 @@ export async function placeBetFromChatCommand(input: {
   };
 }
 
+export async function getViewerBalanceFromChatCommand(input: {
+  viewerExternalId: string;
+  youtubeDisplayName?: string | null;
+  youtubeHandle?: string | null;
+  source: string;
+}) {
+  const viewerExternalId = input.viewerExternalId.trim();
+  if (!viewerExternalId) {
+    throw new Error("viewer_external_id_required");
+  }
+
+  const viewer = await withViewerByYoutubeChannelId(viewerExternalId);
+  if (!viewer) {
+    throw new Error("viewer_not_ready");
+  }
+
+  const dashboard = await getViewerDashboard(viewer.id);
+  if (!dashboard) {
+    throw new Error("viewer_not_ready");
+  }
+
+  return {
+    viewer: dashboard.viewer,
+    balance: dashboard.balance,
+    source: input.source,
+  };
+}
+
 export async function runQuoteCommandFromChat(input: {
   action: "create" | "get";
   viewerExternalId?: string;

--- a/src/lib/streamerbot/schemas.ts
+++ b/src/lib/streamerbot/schemas.ts
@@ -51,6 +51,13 @@ export const streamerbotChatBetSchema = z
     path: ["optionId"],
   });
 
+export const streamerbotViewerBalanceCommandSchema = z.object({
+  viewerExternalId: z.string().min(1),
+  youtubeDisplayName: z.string().min(1).optional(),
+  youtubeHandle: z.string().min(1).optional(),
+  source: z.string().default("streamerbot_chat"),
+});
+
 export const streamerbotQuoteCommandSchema = z
   .object({
     action: z.enum(["create", "get"]),

--- a/streamerbot/get-points-from-chat.cs
+++ b/streamerbot/get-points-from-chat.cs
@@ -1,0 +1,314 @@
+using System;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+
+public class CPHInline
+{
+    private static readonly string[] ViewerIdArgCandidates =
+    {
+        "id",
+        "userId",
+        "fromId",
+        "authorId",
+        "channelId",
+        "youtubeUserId",
+        "targetUserId",
+    };
+
+    private static readonly string[] DisplayNameArgCandidates =
+    {
+        "display",
+        "displayName",
+        "user",
+        "userName",
+        "authorName",
+        "channelName",
+    };
+
+    private static readonly string[] HandleArgCandidates =
+    {
+        "userName",
+        "handle",
+        "youtubeHandle",
+    };
+
+    private static readonly HttpClient Http = new HttpClient
+    {
+        Timeout = TimeSpan.FromSeconds(10),
+    };
+
+    public bool Execute()
+    {
+        string appBaseUrl = ReadRequiredGlobal("lojaneon.appBaseUrl");
+        string sharedSecret = ReadRequiredGlobal("lojaneon.streamerbotSharedSecret");
+        bool useBotAccount = ReadOptionalBoolGlobal("lojaneon.useBotAccount", true);
+
+        if (string.IsNullOrWhiteSpace(appBaseUrl) || string.IsNullOrWhiteSpace(sharedSecret))
+        {
+            return false;
+        }
+
+        string viewerExternalId = GetFirstArgString(ViewerIdArgCandidates);
+        if (string.IsNullOrWhiteSpace(viewerExternalId))
+        {
+            CPH.LogError(string.Format(
+                "[Loja Neon] Nao consegui descobrir o id do viewer. Args testados: {0}. Args disponiveis: {1}.",
+                string.Join(", ", ViewerIdArgCandidates),
+                ListAvailableArgs()
+            ));
+            Reply("Nao consegui identificar seu canal do YouTube para consultar seus pipetz.", useBotAccount);
+            return false;
+        }
+
+        string displayName = GetFirstArgString(DisplayNameArgCandidates);
+        string youtubeHandle = NormalizeHandle(GetFirstArgString(HandleArgCandidates));
+        string body = BuildRequestBody(viewerExternalId, displayName, youtubeHandle, "streamerbot_chat");
+        string timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString();
+        string signature = BuildSignature(body, timestamp, sharedSecret);
+
+        try
+        {
+            using (var request = new HttpRequestMessage(
+                HttpMethod.Post,
+                string.Format("{0}/api/internal/streamerbot/points", appBaseUrl.TrimEnd('/'))
+            ))
+            {
+                request.Headers.TryAddWithoutValidation("x-timestamp", timestamp);
+                request.Headers.TryAddWithoutValidation("x-signature", signature);
+                request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+
+                using (HttpResponseMessage response = Http.SendAsync(request).GetAwaiter().GetResult())
+                {
+                    string responseText = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+                    string replyMessage = ExtractReplyMessage(responseText);
+
+                    if (string.IsNullOrWhiteSpace(replyMessage))
+                    {
+                        replyMessage = response.IsSuccessStatusCode
+                            ? string.Format("{0}, nao consegui montar a resposta completa do saldo.", displayName ?? "Viewer")
+                            : "Nao consegui consultar seus pipetz agora.";
+                    }
+
+                    Reply(replyMessage, useBotAccount);
+
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        CPH.LogWarn(string.Format(
+                            "[Loja Neon] Falha ao consultar saldo: HTTP {0} - {1}",
+                            (int)response.StatusCode,
+                            responseText
+                        ));
+                    }
+
+                    return response.IsSuccessStatusCode;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            CPH.LogError(string.Format("[Loja Neon] Erro ao chamar API de saldo: {0}", ex));
+            Reply("Nao consegui consultar seus pipetz agora.", useBotAccount);
+            return false;
+        }
+    }
+
+    private void Reply(string message, bool useBot)
+    {
+        CPH.SendYouTubeMessageToLatestMonitored(message, useBot, true);
+    }
+
+    private string ReadRequiredGlobal(string variableName)
+    {
+        string value = ReadOptionalGlobal(variableName);
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            return value;
+        }
+
+        CPH.LogError(string.Format("[Loja Neon] Global obrigatoria ausente: {0}", variableName));
+        return string.Empty;
+    }
+
+    private string ReadOptionalGlobal(string variableName)
+    {
+        try
+        {
+            return CPH.GetGlobalVar<string>(variableName, true) ?? string.Empty;
+        }
+        catch
+        {
+            return string.Empty;
+        }
+    }
+
+    private bool ReadOptionalBoolGlobal(string variableName, bool defaultValue)
+    {
+        try
+        {
+            return CPH.GetGlobalVar<bool>(variableName, true);
+        }
+        catch
+        {
+            return defaultValue;
+        }
+    }
+
+    private string GetFirstArgString(params string[] argNames)
+    {
+        if (argNames == null)
+        {
+            return null;
+        }
+
+        foreach (string argName in argNames)
+        {
+            string value = GetArgString(argName);
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+
+        return null;
+    }
+
+    private string GetArgString(string argName)
+    {
+        if (args != null && args.ContainsKey(argName) && args[argName] != null)
+        {
+            return args[argName].ToString().Trim();
+        }
+
+        if (CPH.TryGetArg(argName, out string value) && !string.IsNullOrWhiteSpace(value))
+        {
+            return value.Trim();
+        }
+
+        return null;
+    }
+
+    private string ListAvailableArgs()
+    {
+        if (args == null || args.Count == 0)
+        {
+            return "(nenhum)";
+        }
+
+        return string.Join(", ", args.Keys);
+    }
+
+    private string NormalizeHandle(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        string trimmed = value.Trim();
+        return trimmed.StartsWith("@") ? trimmed : string.Format("@{0}", trimmed);
+    }
+
+    private string BuildSignature(string body, string timestamp, string secret)
+    {
+        using (var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret)))
+        {
+            byte[] hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(string.Format("{0}.{1}", timestamp, body)));
+            return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+        }
+    }
+
+    private string ExtractReplyMessage(string responseText)
+    {
+        if (string.IsNullOrWhiteSpace(responseText))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            Match replyMatch = Regex.Match(
+                responseText,
+                "\"replyMessage\"\\s*:\\s*\"(?<value>(?:\\\\.|[^\"])*)\"",
+                RegexOptions.Singleline
+            );
+            if (replyMatch.Success)
+            {
+                return JsonUnescape(replyMatch.Groups["value"].Value);
+            }
+
+            Match errorMatch = Regex.Match(
+                responseText,
+                "\"error\"\\s*:\\s*\"(?<value>(?:\\\\.|[^\"])*)\"",
+                RegexOptions.Singleline
+            );
+            if (errorMatch.Success)
+            {
+                return JsonUnescape(errorMatch.Groups["value"].Value);
+            }
+        }
+        catch (Exception ex)
+        {
+            CPH.LogWarn(string.Format("[Loja Neon] Nao consegui ler a resposta do saldo: {0}", ex.Message));
+        }
+
+        return string.Empty;
+    }
+
+    private string BuildRequestBody(
+        string viewerExternalId,
+        string displayName,
+        string youtubeHandle,
+        string source
+    )
+    {
+        var builder = new StringBuilder();
+        builder.Append("{");
+        builder.AppendFormat("\"viewerExternalId\":\"{0}\"", JsonEscape(viewerExternalId));
+
+        if (!string.IsNullOrWhiteSpace(displayName))
+        {
+            builder.AppendFormat(",\"youtubeDisplayName\":\"{0}\"", JsonEscape(displayName));
+        }
+
+        if (!string.IsNullOrWhiteSpace(youtubeHandle))
+        {
+            builder.AppendFormat(",\"youtubeHandle\":\"{0}\"", JsonEscape(youtubeHandle));
+        }
+
+        builder.AppendFormat(",\"source\":\"{0}\"", JsonEscape(source));
+        builder.Append("}");
+        return builder.ToString();
+    }
+
+    private string JsonEscape(string value)
+    {
+        if (value == null)
+        {
+            return string.Empty;
+        }
+
+        return value
+            .Replace("\\", "\\\\")
+            .Replace("\"", "\\\"")
+            .Replace("\r", "\\r")
+            .Replace("\n", "\\n")
+            .Replace("\t", "\\t");
+    }
+
+    private string JsonUnescape(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        return value
+            .Replace("\\\"", "\"")
+            .Replace("\\\\", "\\")
+            .Replace("\\r", "\r")
+            .Replace("\\n", "\n")
+            .Replace("\\t", "\t");
+    }
+}


### PR DESCRIPTION
## Summary
- add a signed Streamer.bot endpoint for viewers to check their current pipetz balance from chat
- keep the lookup read-only so it does not create viewers or mutate economy state during consultation
- document the Streamer.bot setup and add a ready-to-paste C# action script for `!pontos` / `!saldo`

## Why
Viewers needed a simple way to check their own points during the live without logging into the site or risking unwanted balance changes.

## Impact
- viewers can check their balance directly from YouTube chat
- Streamer.bot gets a reusable `replyMessage` response for chat replies
- operators have documented setup steps and a script to wire the command quickly

## Validation
- `node_modules\\.bin\\vitest.cmd run --root .worktrees\\issue-13 --config vitest.config.ts src/lib/db/repository.test.ts`
- `node_modules\\.bin\\eslint.cmd --config .worktrees\\issue-13\\eslint.config.mjs .worktrees\\issue-13\\src\\lib\\db\\repository.ts .worktrees\\issue-13\\src\\lib\\db\\repository.test.ts .worktrees\\issue-13\\src\\lib\\streamerbot\\schemas.ts .worktrees\\issue-13\\src\\app\\api\\internal\\streamerbot\\points\\route.ts`

Closes #13