### PR TITLE
[codex] Corrige acentuação e UTF-8 nas páginas do app

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Backlog playbook
-    url: https://github.com/ludmila-omlopes/ludylops-youtube-dashboard/blob/master/docs/backlog-playbook.md
+    url: https://github.com/ludmila-omlopes/ludylops-live/blob/master/docs/backlog-playbook.md
     about: Read the triage and priority rules before opening larger backlog items.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ copy bridge\\.env.example bridge\\.env
 - `AUTH_GOOGLE_SECRET`
 - `GOOGLE_RISC_ALLOWED_AUDIENCES` (opcional, se tiver mais de um OAuth client aceito pelo receiver)
 - `GOOGLE_RISC_RECEIVER_URL` (opcional, para fixar a URL HTTPS do receiver RISC)
-- `YOUTUBE_API_KEY` (usada apenas para fallback de status da live, nao para vincular login ao canal)
+- `YOUTUBE_API_KEY` (usada apenas para fallback de status da live, não para vincular login ao canal)
 - `ADMIN_EMAILS`
 - `STREAM_YOUTUBE_CHANNEL_ID` (opcional, se quiser forcar o canal monitorado em vez de usar a conta admin vinculada)
 
@@ -90,7 +90,7 @@ npm run google:risc -- status
 
 ## Google Cross-Account Protection
 
-O passo a passo completo de producao para o alerta de `Protecao entre contas`, incluindo service account, registro do stream RISC, teste de verificacao e checklist final no painel do Google, está em:
+O passo a passo completo de produção para o alerta de `Proteção entre contas`, incluindo service account, registro do stream RISC, teste de verificação e checklist final no painel do Google, está em:
 
 - [docs/google-cross-account-protection.md](/D:/Codigos_Diversos/lojinha-youtube/docs/google-cross-account-protection.md)
 
@@ -123,7 +123,7 @@ Assinatura:
 - HMAC SHA-256 de `timestamp.body`
 - Secret: `STREAMERBOT_SHARED_SECRET`
 
-Eventos automáticos da live (`presence_tick` e `chat_bonus`) so entram no banco quando o canal monitorado estiver ao vivo. O backend usa `YOUTUBE_API_KEY` e, por padrao, o `youtube_channel_id` da conta admin vinculada; se preferir, configure `STREAM_YOUTUBE_CHANNEL_ID`. Se o Streamer.bot enviar `payload.isLive`, o backend usa esse sinal explicitamente antes de cair no fallback por API, o que ajuda em lives nao listadas.
+Eventos automáticos da live (`presence_tick` e `chat_bonus`) só entram no banco quando o canal monitorado estiver ao vivo. O backend usa `YOUTUBE_API_KEY` e, por padrão, o `youtube_channel_id` da conta admin vinculada; se preferir, configure `STREAM_YOUTUBE_CHANNEL_ID`. Se o Streamer.bot enviar `payload.isLive`, o backend usa esse sinal explicitamente antes de cair no fallback por API, o que ajuda em lives não listadas.
 
 Payload base:
 
@@ -149,18 +149,18 @@ Notas:
 
 - `youtubeHandle` e opcional, mas recomendado para o ranking mostrar `@handle` em vez do channel id.
 - Pode ser enviado com ou sem `@`; o backend normaliza antes de salvar.
-- Se a live for `Unlisted`, inclua `payload.isLive = true` no request do Streamer.bot para evitar depender apenas da busca publica da API do YouTube.
-- A rota responde `200` mesmo quando ignora um evento live-gated; nesses casos o body inclui `ignoredReason`, entao o script do Streamer.bot deve logar o body mesmo em sucesso.
+- Se a live for `Unlisted`, inclua `payload.isLive = true` no request do Streamer.bot para evitar depender apenas da busca pública da API do YouTube.
+- A rota responde `200` mesmo quando ignora um evento live-gated; nesses casos o body inclui `ignoredReason`, então o script do Streamer.bot deve logar o body mesmo em sucesso.
 
 ### Vinculo da conta pelo chat
 
-O login do site nao consulta mais a API do YouTube para descobrir automaticamente o canal do usuario. Em vez disso, o vinculo entre a conta autenticada e o viewer do chat acontece com um codigo curto:
+O login do site não consulta mais a API do YouTube para descobrir automaticamente o canal do usuário. Em vez disso, o vínculo entre a conta autenticada e o viewer do chat acontece com um código curto:
 
 1. O viewer entra no site e abre `/me`.
-2. O app gera um codigo em `GET/POST /api/me/link-code`.
+2. O app gera um código em `GET/POST /api/me/link-code`.
 3. O viewer envia `!link CODIGO` no chat do YouTube.
 4. O Streamer.bot chama `POST /api/internal/streamerbot/link` com o `viewerExternalId` do autor da mensagem.
-5. O backend marca o viewer como vinculado e, se existir um viewer sintetico criado no login, faz o merge do saldo e historico.
+5. O backend marca o viewer como vinculado e, se existir um viewer sintético criado no login, faz o merge do saldo e histórico.
 
 Endpoint interno:
 
@@ -180,14 +180,14 @@ Payload recomendado:
 
 Notas:
 
-- `viewerExternalId` deve ser o identificador estavel do canal que o Streamer.bot expoe no evento ou comando do YouTube.
-- O backend invalida o codigo depois do primeiro uso e rejeita codigo expirado.
-- Se o login ja tiver acumulado saldo em um viewer sintetico, o backend faz merge automatico para o viewer real do chat.
-- O login Google agora pede apenas `openid email profile`; o vinculo com a live depende do chat, nao de `youtube.readonly`.
+- `viewerExternalId` deve ser o identificador estável do canal que o Streamer.bot expõe no evento ou comando do YouTube.
+- O backend invalida o código depois do primeiro uso e rejeita código expirado.
+- Se o login já tiver acumulado saldo em um viewer sintético, o backend faz merge automático para o viewer real do chat.
+- O login Google agora pede apenas `openid email profile`; o vínculo com a live depende do chat, não de `youtube.readonly`.
 
-#### Setup rapido do Streamer.bot
+#### Setup rápido do Streamer.bot
 
-O script pronto para colar no `Execute C# Code` esta em:
+O script pronto para colar no `Execute C# Code` está em:
 
 - [link-account-from-chat.cs](/D:/Codigos_Diversos/lojinha-youtube/streamerbot/link-account-from-chat.cs)
 
@@ -210,18 +210,18 @@ Passo a passo operacional:
 
 3. Na action desse comando, adicione `Core > C# > Execute C# Code`.
 
-4. Cole o conteudo de [link-account-from-chat.cs](/D:/Codigos_Diversos/lojinha-youtube/streamerbot/link-account-from-chat.cs).
+4. Cole o conteúdo de [link-account-from-chat.cs](/D:/Codigos_Diversos/lojinha-youtube/streamerbot/link-account-from-chat.cs).
 
-5. O proprio script responde no chat com `CPH.SendYouTubeMessageToLatestMonitored(...)`.
+5. O próprio script responde no chat com `CPH.SendYouTubeMessageToLatestMonitored(...)`.
 
-Troubleshooting rapido:
+Troubleshooting rápido:
 
 - `viewer_link_code_invalid`
-  Gere um novo codigo em `/me` e tente de novo no chat.
+  Gere um novo código em `/me` e tente de novo no chat.
 - `viewer_owned_by_other_account`
-  Esse canal ja esta vinculado a outra conta do app e precisa de ajuste manual.
-- `Nao consegui identificar seu canal do YouTube para vincular a conta.`
-  Verifique se o evento/comando do Streamer.bot expoe um dos argumentos aceitos pelo script: `id`, `userId`, `fromId`, `authorId`, `channelId`, `youtubeUserId` ou `targetUserId`.
+  Esse canal já está vinculado a outra conta do app e precisa de ajuste manual.
+- `Não consegui identificar seu canal do YouTube para vincular a conta.`
+  Verifique se o evento/comando do Streamer.bot expõe um dos argumentos aceitos pelo script: `id`, `userId`, `fromId`, `authorId`, `channelId`, `youtubeUserId` ou `targetUserId`.
 
 ### Apostas por comando de chat
 
@@ -257,12 +257,12 @@ Notas:
 - O backend aceita `optionIndex`, `optionId` ou `optionLabel`.
 - Se houver exatamente uma aposta aberta, `betId` pode ser omitido.
 - Se houver mais de uma aposta aberta, o endpoint retorna `multiple_open_bets`; para chat, o ideal é manter apenas uma aposta aberta por vez.
-- Aposta por chat nao exige login no site; ela usa o `viewerExternalId` do YouTube para identificar o viewer.
+- Aposta por chat não exige login no site; ela usa o `viewerExternalId` do YouTube para identificar o viewer.
 - O response inclui `replyMessage`, pensado para o Streamer.bot reutilizar na resposta do chat.
 
-#### Setup rapido do Streamer.bot
+#### Setup rápido do Streamer.bot
 
-O setup pronto para colar no `Execute C# Code` esta em:
+O setup pronto para colar no `Execute C# Code` está em:
 
 - [place-bet-from-chat.cs](/D:/Codigos_Diversos/lojinha-youtube/streamerbot/place-bet-from-chat.cs)
 
@@ -277,7 +277,7 @@ Passo a passo operacional:
 - `lojaneon.useBotAccount`
   Valor: `true`
 - `lojaneon.activeBetId`
-  Valor: opcional. Deixe vazio no fluxo simples. Use apenas se quiser forcar uma aposta especifica.
+  Valor: opcional. Deixe vazio no fluxo simples. Use apenas se quiser forçar uma aposta específica.
 
 2. Crie um comando do YouTube com regex:
 
@@ -287,28 +287,28 @@ Passo a passo operacional:
 
 3. Na action desse comando, adicione `Core > C# > Execute C# Code`.
 
-4. Cole o conteudo de [place-bet-from-chat.cs](/D:/Codigos_Diversos/lojinha-youtube/streamerbot/place-bet-from-chat.cs).
+4. Cole o conteúdo de [place-bet-from-chat.cs](/D:/Codigos_Diversos/lojinha-youtube/streamerbot/place-bet-from-chat.cs).
 
-5. O proprio script responde no chat com `CPH.SendYouTubeMessageToLatestMonitored(...)`, entao nao precisa de um segundo sub-action.
+5. O próprio script responde no chat com `CPH.SendYouTubeMessageToLatestMonitored(...)`, então não precisa de um segundo sub-action.
 
 Notas:
 
 - O fluxo simples assume apenas uma aposta `open` por vez.
-- Se voce abrir varias apostas ao mesmo tempo, preencha `lojaneon.activeBetId` com o `betId` da rodada atual.
-- O script aceita `betId` vindo da propria action do Streamer.bot e usa esse valor antes da Global Variable.
+- Se você abrir várias apostas ao mesmo tempo, preencha `lojaneon.activeBetId` com o `betId` da rodada atual.
+- O script aceita `betId` vindo da própria action do Streamer.bot e usa esse valor antes da Global Variable.
 - O script tenta descobrir o id do viewer usando `userId`, `fromId`, `authorId`, `channelId`, `youtubeUserId` e `targetUserId`.
-- Se sua instancia do Streamer.bot usar outro nome de argumento, ajuste o array `ViewerIdArgCandidates` no script.
+- Se sua instância do Streamer.bot usar outro nome de argumento, ajuste o array `ViewerIdArgCandidates` no script.
 
-Troubleshooting rapido:
+Troubleshooting rápido:
 
-- `Assinatura invalida no comando de aposta.`
-  Verifique `lojaneon.streamerbotSharedSecret`, o relogio da maquina do Streamer.bot e se a action esta chamando a URL correta.
-- `Nao consegui identificar seu canal do YouTube para apostar.`
-  Verifique se o evento/comando do Streamer.bot expoe um dos argumentos aceitos pelo script: `id`, `userId`, `fromId`, `authorId`, `channelId`, `youtubeUserId` ou `targetUserId`.
-- `Ha mais de uma aposta aberta...`
+- `Assinatura inválida no comando de aposta.`
+  Verifique `lojaneon.streamerbotSharedSecret`, o relógio da máquina do Streamer.bot e se a action está chamando a URL correta.
+- `Não consegui identificar seu canal do YouTube para apostar.`
+  Verifique se o evento/comando do Streamer.bot expõe um dos argumentos aceitos pelo script: `id`, `userId`, `fromId`, `authorId`, `channelId`, `youtubeUserId` ou `targetUserId`.
+- `Há mais de uma aposta aberta...`
   Preencha `lojaneon.activeBetId` com o `betId` da rodada atual ou envie `betId` explicitamente na action.
-- `Opcao invalida.`
-  Confirme que o regex captura `optionIndex` corretamente e que o numero informado bate com a ordem das opcoes abertas.
+- `Opção inválida.`
+  Confirme que o regex captura `optionIndex` corretamente e que o número informado bate com a ordem das opções abertas.
 
 Referencias oficiais:
 
@@ -346,11 +346,11 @@ Payload recomendado para consultar o contador de mortes do jogo atual:
   "scopeLabel": "Balatro",
 ### Saldo por comando de chat
 
-Para permitir que cada viewer consulte os proprios pipetz no chat do YouTube via Streamer.bot, use:
+Para permitir que cada viewer consulte os próprios pipetz no chat do YouTube via Streamer.bot, use:
 
 - `POST /api/internal/streamerbot/points`
 
-Headers obrigatorios:
+Headers obrigatórios:
 
 - `x-timestamp`
 - `x-signature`
@@ -374,24 +374,24 @@ Payload recomendado para `!pontos`, `!saldo` ou `!pipetz`:
 Notas:
 
 - `action` aceita `increment`, `decrement`, `get` e `reset`.
-- `scopeType` e opcional e assume `global`; para contadores por jogo, envie `scopeType = "game"` com um `scopeKey` estavel.
-- `scopeLabel` e opcional e so existe para deixar a resposta do chat mais humana, por exemplo `contador de mortes em Balatro`.
+- `scopeType` é opcional e assume `global`; para contadores por jogo, envie `scopeType = "game"` com um `scopeKey` estável.
+- `scopeLabel` é opcional e só existe para deixar a resposta do chat mais humana, por exemplo `contador de mortes em Balatro`.
 - `decrement` nunca deixa o contador negativo; se o valor atual for menor que o ajuste, ele para em `0`.
 - `reset` exige `confirmReset = true` para evitar zerar contador por acidente.
-- A consulta e read-only: ela nao cria viewer, nao ajusta saldo e nao altera nomes/handles salvos.
-- Se o viewer ainda nao existir no backend, a rota responde com mensagem clara para indicar que a conta ainda nao esta pronta para consulta.
+- A consulta é read-only: ela não cria viewer, não ajusta saldo e não altera nomes/handles salvos.
+- Se o viewer ainda não existir no backend, a rota responde com mensagem clara para indicar que a conta ainda não está pronta para consulta.
 - O response inclui `replyMessage`, pensado para o Streamer.bot reutilizar direto no chat.
 
-#### Setup rapido do Streamer.bot
+#### Setup rápido do Streamer.bot
 
-O script pronto para o fluxo inicial do issue esta em:
+O script pronto para o fluxo inicial do issue está em:
 
 - [death-counter-from-chat.cs](/D:/Codigos_Diversos/lojinha-youtube/streamerbot/death-counter-from-chat.cs)
 
 Passo a passo operacional:
 
 1. Reaproveite estas Global Variables no Streamer.bot:
-O setup pronto para colar no `Execute C# Code` esta em:
+O setup pronto para colar no `Execute C# Code` está em:
 
 - [get-points-from-chat.cs](/D:/Codigos_Diversos/lojinha-youtube/streamerbot/get-points-from-chat.cs)
 
@@ -408,9 +408,9 @@ Passo a passo operacional:
 - `lojaneon.counterGameKey`
   Valor: opcional. Quando preenchido, o script manda o contador como `scopeType = "game"` para esse jogo.
 - `lojaneon.counterGameLabel`
-  Valor: opcional. Nome legivel que volta no `replyMessage`, por exemplo `Balatro`.
+  Valor: opcional. Nome legível que volta no `replyMessage`, por exemplo `Balatro`.
 
-2. Crie tres comandos do YouTube:
+2. Crie três comandos do YouTube:
 
 ```regex
 ^!morte\+(?:\s+(?<amount>\d+))?$
@@ -420,14 +420,14 @@ Passo a passo operacional:
 
 3. Em cada action, adicione `Core > C# > Execute C# Code`.
 
-4. Cole o conteudo de [death-counter-from-chat.cs](/D:/Codigos_Diversos/lojinha-youtube/streamerbot/death-counter-from-chat.cs).
+4. Cole o conteúdo de [death-counter-from-chat.cs](/D:/Codigos_Diversos/lojinha-youtube/streamerbot/death-counter-from-chat.cs).
 
-5. O proprio script responde no chat com `CPH.SendYouTubeMessageToLatestMonitored(...)`, entao nao precisa de um segundo sub-action.
+5. O próprio script responde no chat com `CPH.SendYouTubeMessageToLatestMonitored(...)`, então não precisa de um segundo sub-action.
 
 Notas:
 
 - `!morte+` incrementa, `!morte-` decrementa e `!mortes` consulta.
-- Os comandos de soma e subtracao aceitam quantidade opcional, por exemplo `!morte+ 3`.
+- Os comandos de soma e subtração aceitam quantidade opcional, por exemplo `!morte+ 3`.
 - Quando `lojaneon.counterGameKey` estiver vazio, o contador funciona como global.
 - Para outros tipos de contador, reaproveite `POST /api/internal/streamerbot/counters` com outro `counterKey` e `counterLabel`.
 
@@ -439,18 +439,18 @@ Notas:
 
 3. Na action desse comando, adicione `Core > C# > Execute C# Code`.
 
-4. Cole o conteudo de [get-points-from-chat.cs](/D:/Codigos_Diversos/lojinha-youtube/streamerbot/get-points-from-chat.cs).
+4. Cole o conteúdo de [get-points-from-chat.cs](/D:/Codigos_Diversos/lojinha-youtube/streamerbot/get-points-from-chat.cs).
 
-5. O proprio script responde no chat com `CPH.SendYouTubeMessageToLatestMonitored(...)`, entao nao precisa de um segundo sub-action.
+5. O próprio script responde no chat com `CPH.SendYouTubeMessageToLatestMonitored(...)`, então não precisa de um segundo sub-action.
 
-Troubleshooting rapido:
+Troubleshooting rápido:
 
-- `Assinatura invalida no comando de saldo.`
-  Verifique `lojaneon.streamerbotSharedSecret`, o relogio da maquina do Streamer.bot e se a action esta chamando a URL correta.
-- `Nao consegui identificar seu canal do YouTube para consultar seus pipetz.`
-  Verifique se o evento/comando do Streamer.bot expoe um dos argumentos aceitos pelo script: `id`, `userId`, `fromId`, `authorId`, `channelId`, `youtubeUserId` ou `targetUserId`.
-- `Ainda nao encontrei sua conta da live para consultar seus pipetz.`
-  Esse comando nao cria cadastro novo. Aguarde o viewer aparecer no backend pelos eventos da live ou confirme se a integracao que registra viewers no chat ja esta funcionando.
+- `Assinatura inválida no comando de saldo.`
+  Verifique `lojaneon.streamerbotSharedSecret`, o relógio da máquina do Streamer.bot e se a action está chamando a URL correta.
+- `Não consegui identificar seu canal do YouTube para consultar seus pipetz.`
+  Verifique se o evento/comando do Streamer.bot expõe um dos argumentos aceitos pelo script: `id`, `userId`, `fromId`, `authorId`, `channelId`, `youtubeUserId` ou `targetUserId`.
+- `Ainda não encontrei sua conta da live para consultar seus pipetz.`
+  Esse comando não cria cadastro novo. Aguarde o viewer aparecer no backend pelos eventos da live ou confirme se a integração que registra viewers no chat já está funcionando.
 
 Referencias oficiais:
 
@@ -482,7 +482,7 @@ Payload recomendado para salvar uma quote com `!addquote`:
 }
 ```
 
-Payload recomendado para chamar uma quote aleatoria com `!quote`:
+Payload recomendado para chamar uma quote aleatória com `!quote`:
 
 ```json
 {
@@ -501,7 +501,7 @@ Payload recomendado para chamar uma quote especifica com `!quote 7`:
 }
 ```
 
-Payload recomendado para cobrar `50 pipetz` e exibir uma quote ja existente no overlay do OBS com `!quoteobs 7`:
+Payload recomendado para cobrar `50 pipetz` e exibir uma quote já existente no overlay do OBS com `!quoteobs 7`:
 
 ```json
 {
@@ -518,14 +518,14 @@ Payload recomendado para cobrar `50 pipetz` e exibir uma quote ja existente no o
 Notas:
 
 - `create` exige que o caller seja mod, broadcaster ou admin.
-- `get` aceita `quoteId`; se ele vier vazio, o backend devolve uma quote aleatoria.
-- `show` cobra `50 pipetz`, exige `quoteId` de uma quote ja cadastrada, usa um overlay unico por vez e falha com feedback se a tela ainda estiver ocupada.
+- `get` aceita `quoteId`; se ele vier vazio, o backend devolve uma quote aleatória.
+- `show` cobra `50 pipetz`, exige `quoteId` de uma quote já cadastrada, usa um overlay único por vez e falha com feedback se a tela ainda estiver ocupada.
 - O browser source do OBS deve apontar para `/obs/quotes`.
 - O response inclui `replyMessage`, pensado para o Streamer.bot reutilizar direto no chat.
 
-#### Setup rapido do Streamer.bot
+#### Setup rápido do Streamer.bot
 
-Os scripts prontos para colar no `Execute C# Code` estao em:
+Os scripts prontos para colar no `Execute C# Code` estão em:
 
 - [add-quote-from-chat.cs](/D:/Codigos_Diversos/lojinha-youtube/streamerbot/add-quote-from-chat.cs)
 - [get-quote-from-chat.cs](/D:/Codigos_Diversos/lojinha-youtube/streamerbot/get-quote-from-chat.cs)
@@ -550,7 +550,7 @@ Passo a passo operacional:
 
 3. Na action desse comando, adicione `Core > C# > Execute C# Code`.
 
-4. Cole o conteudo de [add-quote-from-chat.cs](/D:/Codigos_Diversos/lojinha-youtube/streamerbot/add-quote-from-chat.cs).
+4. Cole o conteúdo de [add-quote-from-chat.cs](/D:/Codigos_Diversos/lojinha-youtube/streamerbot/add-quote-from-chat.cs).
 
 5. Crie um segundo comando para buscar quotes com regex:
 
@@ -560,7 +560,7 @@ Passo a passo operacional:
 
 6. Na action desse comando, adicione `Core > C# > Execute C# Code`.
 
-7. Cole o conteudo de [get-quote-from-chat.cs](/D:/Codigos_Diversos/lojinha-youtube/streamerbot/get-quote-from-chat.cs).
+7. Cole o conteúdo de [get-quote-from-chat.cs](/D:/Codigos_Diversos/lojinha-youtube/streamerbot/get-quote-from-chat.cs).
 
 8. Crie um terceiro comando para quote paga no OBS com regex:
 
@@ -570,7 +570,7 @@ Passo a passo operacional:
 
 9. Na action desse comando, adicione `Core > C# > Execute C# Code`.
 
-10. Cole o conteudo de [show-quote-on-obs.cs](/D:/Codigos_Diversos/lojinha-youtube/streamerbot/show-quote-on-obs.cs).
+10. Cole o conteúdo de [show-quote-on-obs.cs](/D:/Codigos_Diversos/lojinha-youtube/streamerbot/show-quote-on-obs.cs).
 
 11. No OBS, crie um `Browser Source` apontando para:
 
@@ -583,12 +583,12 @@ Passo a passo operacional:
 
 Notas:
 
-- No Streamer.bot, o ideal e marcar `!addquote` como comando de moderacao tambem na UI, mesmo com a checagem extra do backend.
+- No Streamer.bot, o ideal é marcar `!addquote` como comando de moderação também na UI, mesmo com a checagem extra do backend.
 - O script de `!addquote` tenta descobrir o id do viewer usando `id`, `userId`, `fromId`, `authorId`, `channelId`, `youtubeUserId` e `targetUserId`.
 - O script de `!quoteobs` usa os mesmos candidatos de id do viewer do fluxo de apostas e responde no chat com o `replyMessage` devolvido pela API.
-- O modo pago de OBS nao cria quote nova; ele apenas mostra uma quote ja existente escolhida por numero.
+- O modo pago de OBS não cria quote nova; ele apenas mostra uma quote já existente escolhida por número.
 - Se quiser manter o `!quote` gratuito, deixe o comando pago separado como `!quoteobs`.
-- Se sua instancia do Streamer.bot usar outros nomes de argumento para permissao, ajuste `ModeratorArgCandidates`, `BroadcasterArgCandidates` e `AdminArgCandidates` no script.
+- Se sua instância do Streamer.bot usar outros nomes de argumento para permissão, ajuste `ModeratorArgCandidates`, `BroadcasterArgCandidates` e `AdminArgCandidates` no script.
 
 ### Bridge
 

--- a/docs/google-cross-account-protection.md
+++ b/docs/google-cross-account-protection.md
@@ -4,37 +4,37 @@ Este projeto agora possui um receiver de `Cross-Account Protection (RISC)` em:
 
 - `POST /api/internal/google/cross-account-protection`
 
-Quando o Google envia um evento RISC valido:
+Quando o Google envia um evento RISC válido:
 
-- o token JWT e validado contra o discovery document e as chaves JWKS do Google
+- o token JWT é validado contra o discovery document e as chaves JWKS do Google
 - o `aud` precisa bater com `AUTH_GOOGLE_ID` ou com `GOOGLE_RISC_ALLOWED_AUDIENCES`
-- eventos criticos atualizam o estado da conta Google no app
+- eventos críticos atualizam o estado da conta Google no app
 - eventos de `account-disabled` bloqueiam novo login Google
-- eventos de `sessions-revoked` e `account-disabled` com `reason=hijacking` invalidam sessoes JWT locais emitidas antes do evento
+- eventos de `sessions-revoked` e `account-disabled` com `reason=hijacking` invalidam sessões JWT locais emitidas antes do evento
 
-## Segredos e configuracao
+## Segredos e configuração
 
-Variaveis operacionais:
+Variáveis operacionais:
 
 - `AUTH_GOOGLE_ID`
   OAuth client ID do app Google Sign-In principal
 - `GOOGLE_RISC_ALLOWED_AUDIENCES`
-  Lista opcional, separada por virgula, com outros client IDs que tambem podem assinar eventos para este app
+  Lista opcional, separada por vírgula, com outros client IDs que também podem assinar eventos para este app
 - `GOOGLE_RISC_RECEIVER_URL`
-  URL HTTPS publica do receiver. Se omitida, o script tenta derivar a partir de `APP_URL`
+  URL HTTPS pública do receiver. Se omitida, o script tenta derivar a partir de `APP_URL`
 - `GOOGLE_RISC_SERVICE_ACCOUNT_JSON`
   JSON completo da service account com role `RISC Configuration Admin`
 - `GOOGLE_RISC_SERVICE_ACCOUNT_FILE`
   Alternativa ao JSON inline; aponta para um arquivo local com a mesma credencial
 
-Guarde a credencial da service account apenas no gerenciador de segredos do ambiente. Nao commite o JSON.
+Guarde a credencial da service account apenas no gerenciador de segredos do ambiente. Não commite o JSON.
 
-## Passo a passo de producao
+## Passo a passo de produção
 
 1. No projeto Google Cloud usado pelo OAuth do app, crie uma service account com a role `roles/riscconfigs.admin`.
 2. Habilite a RISC API no mesmo projeto do OAuth client.
 3. Confirme que o dominio do receiver esta em `Authorized domains` do app OAuth.
-4. Faça deploy desta versao do app para que a rota HTTPS exista publicamente.
+4. Faça deploy desta versão do app para que a rota HTTPS exista publicamente.
 5. Configure `GOOGLE_RISC_SERVICE_ACCOUNT_JSON` ou `GOOGLE_RISC_SERVICE_ACCOUNT_FILE`.
 6. Execute:
 
@@ -42,13 +42,13 @@ Guarde a credencial da service account apenas no gerenciador de segredos do ambi
 npm run google:risc -- configure
 ```
 
-Se precisar forcar a URL publica:
+Se precisar forçar a URL pública:
 
 ```bash
 npm run google:risc -- configure --receiver-url=https://seu-app.vercel.app/api/internal/google/cross-account-protection
 ```
 
-7. Dispare um token de verificacao:
+7. Dispare um token de verificação:
 
 ```bash
 npm run google:risc -- verify
@@ -61,9 +61,9 @@ npm run google:risc -- verify
 npm run google:risc -- status
 ```
 
-10. Verifique no painel do Google se o alerta de `Protecao entre contas` sumiu.
+10. Verifique no painel do Google se o alerta de `Proteção entre contas` sumiu.
 
-## Comandos uteis
+## Comandos úteis
 
 ```bash
 npm run google:risc -- status
@@ -73,13 +73,13 @@ npm run google:risc -- enable
 npm run google:risc -- disable
 ```
 
-## Observacoes operacionais
+## Observações operacionais
 
-- Este app nao armazena refresh tokens do Google, entao eventos `token-revoked` nao exigem limpeza adicional de credenciais persistidas.
-- A invalidacao de sessao local acontece na proxima leitura do JWT pelo Auth.js. Na pratica, a sessao deixa de ser aceita no proximo request do usuario.
-- O script nao limpa o alerta do painel sozinho; ele registra/testa o stream. A confirmacao final ainda deve ser feita no Google Cloud Console.
+- Este app não armazena refresh tokens do Google, então eventos `token-revoked` não exigem limpeza adicional de credenciais persistidas.
+- A invalidação de sessão local acontece na próxima leitura do JWT pelo Auth.js. Na prática, a sessão deixa de ser aceita no próximo request do usuário.
+- O script não limpa o alerta do painel sozinho; ele registra/testa o stream. A confirmação final ainda deve ser feita no Google Cloud Console.
 
-## Referencias oficiais
+## Referências oficiais
 
 - [Cross-Account Protection (RISC)](https://developers.google.com/identity/protocols/risc)
 - [Authorized domains no OAuth consent screen](https://support.google.com/cloud/answer/13804266)

--- a/src/app/(public)/indicacoes/page.tsx
+++ b/src/app/(public)/indicacoes/page.tsx
@@ -7,8 +7,8 @@ import { recommendationCategories } from "@/lib/recommendations";
 import type { ProductRecommendationRecord } from "@/lib/types";
 
 export const metadata: Metadata = {
-  title: "Indicacoes | Pipetz",
-  description: "Minha pagina publica com consoles, perifericos e acessorios que eu recomendo para a comunidade.",
+  title: "Indicações | Pipetz",
+  description: "Minha página pública com consoles, periféricos e acessórios que eu recomendo para a comunidade.",
 };
 
 function recommendationRel(linkKind: ProductRecommendationRecord["linkKind"]) {
@@ -60,8 +60,8 @@ function RecommendationCard({
           <div className="flex flex-wrap items-center justify-between gap-3 border-t-[2px] border-[var(--color-ink)] pt-4">
             <p className="max-w-xl text-sm font-bold leading-6 text-[var(--color-ink-soft)]">
               {item.linkKind === "affiliate"
-                ? "Link afiliado marcado de forma explicita antes do clique."
-                : "Link externo comum para abrir a pagina do produto."}
+                ? "Link afiliado marcado de forma explícita antes do clique."
+                : "Link externo comum para abrir a página do produto."}
             </p>
 
             <a
@@ -92,18 +92,18 @@ export default async function IndicacoesPage() {
           className="text-4xl uppercase leading-none sm:text-5xl"
           style={{ fontFamily: "var(--font-display)" }}
         >
-          Indicacoes
+          Indicações
         </h1>
         <p className="mt-4 max-w-3xl text-sm leading-7 text-[var(--color-ink-soft)] sm:text-base">
           Produtos que eu recomendo para setup, jogo e live. Se algum link virar afiliado,
-          isso aparece marcado no proprio item antes do clique.
+          isso aparece marcado no próprio item antes do clique.
         </p>
       </header>
 
       <section className="space-y-4">
         {productRecommendations.length === 0 ? (
           <div className="panel surface-section p-6 text-sm font-bold text-[var(--color-ink-soft)]">
-            Nenhuma recomendacao publicada ainda.
+            Nenhuma recomendação publicada ainda.
           </div>
         ) : null}
 

--- a/src/app/(public)/quotes/page.tsx
+++ b/src/app/(public)/quotes/page.tsx
@@ -44,7 +44,7 @@ export default async function QuotesPage() {
             </h1>
             <p className="mt-4 max-w-3xl text-sm leading-7 text-[var(--color-ink-soft)] sm:text-base">
               Aqui ficam as melhores perolas salvas pelo chat. Tudo em ordem de cadastro, com o
-              numero da quote e quem registrou.
+              número da quote e quem registrou.
             </p>
             <p className="mt-3 inline-flex items-center gap-2 border-[3px] border-[var(--color-ink)] bg-[var(--color-paper)] px-4 py-2 text-xs font-black uppercase tracking-[0.18em] text-[var(--color-ink)] shadow-[4px_4px_0_#000]">
               Mostrar no OBS custa {formatPipetz(50)} pipetz

--- a/src/app/api/admin/bets/route.ts
+++ b/src/app/api/admin/bets/route.ts
@@ -43,7 +43,7 @@ export async function POST(request: Request) {
     }
 
     if (error instanceof SyntaxError) {
-      return fail("Payload invalido.", 400);
+      return fail("Payload inválido.", 400);
     }
 
     const message = error instanceof Error ? error.message : "Falha ao criar aposta.";

--- a/src/app/api/admin/game-suggestions/[id]/route.ts
+++ b/src/app/api/admin/game-suggestions/[id]/route.ts
@@ -41,10 +41,10 @@ export async function POST(
     }
 
     if (error instanceof SyntaxError) {
-      return fail("Payload invalido.", 400);
+      return fail("Payload inválido.", 400);
     }
 
-    const message = error instanceof Error ? error.message : "Falha ao atualizar sugestao.";
+    const message = error instanceof Error ? error.message : "Falha ao atualizar sugestão.";
     return fail(message, 400);
   }
 }

--- a/src/app/api/admin/live-status/route.test.ts
+++ b/src/app/api/admin/live-status/route.test.ts
@@ -36,7 +36,7 @@ describe("admin live status route", () => {
 
   it("returns the schema guidance when the manual override cannot be persisted", async () => {
     setStreamerbotLivestreamManualOverrideMock.mockRejectedValue(
-      new Error("Schema dos contadores ainda nao foi aplicado. Rode npm run db:push."),
+      new Error("Schema dos contadores ainda não foi aplicado. Rode npm run db:push."),
     );
 
     const { POST } = await import("@/app/api/admin/live-status/route");
@@ -57,7 +57,7 @@ describe("admin live status route", () => {
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({
       ok: false,
-      error: "Schema dos contadores ainda nao foi aplicado. Rode npm run db:push.",
+      error: "Schema dos contadores ainda não foi aplicado. Rode npm run db:push.",
     });
   });
 });

--- a/src/app/api/admin/live-status/route.ts
+++ b/src/app/api/admin/live-status/route.ts
@@ -8,7 +8,7 @@ import {
 
 const liveStatusActionSchema = z.object({
   action: z.enum(["force_online", "force_offline", "clear_override"]),
-  confirmationText: z.string().trim().min(1, 'Digite a confirmacao.'),
+  confirmationText: z.string().trim().min(1, 'Digite a confirmação.'),
 });
 
 const confirmationKeywords = {
@@ -31,7 +31,7 @@ export async function POST(request: Request) {
     const json = await request.json();
     const parsed = liveStatusActionSchema.safeParse(json);
     if (!parsed.success) {
-      return fail(parsed.error.issues[0]?.message ?? "Payload invalido.", 400);
+      return fail(parsed.error.issues[0]?.message ?? "Payload inválido.", 400);
     }
 
     const expectedKeyword = confirmationKeywords[parsed.data.action];
@@ -57,7 +57,7 @@ export async function POST(request: Request) {
     return ok(status);
   } catch (error) {
     if (error instanceof SyntaxError) {
-      return fail("Payload invalido.", 400);
+      return fail("Payload inválido.", 400);
     }
 
     return fail(error instanceof Error ? error.message : "Falha ao atualizar o status da live.", 400);

--- a/src/app/api/admin/recommendations/[id]/route.ts
+++ b/src/app/api/admin/recommendations/[id]/route.ts
@@ -29,10 +29,10 @@ export async function PATCH(
     return ok(updated);
   } catch (error) {
     if (error instanceof SyntaxError) {
-      return fail("Payload invalido.", 400);
+      return fail("Payload inválido.", 400);
     }
 
-    const message = error instanceof Error ? error.message : "Falha ao atualizar recomendacao.";
+    const message = error instanceof Error ? error.message : "Falha ao atualizar recomendação.";
     return fail(message, message === "recommendation_not_found" ? 404 : 400);
   }
 }
@@ -55,7 +55,7 @@ export async function DELETE(
     const deleted = await deleteProductRecommendation(id);
     return ok(deleted);
   } catch (error) {
-    const message = error instanceof Error ? error.message : "Falha ao excluir recomendacao.";
+    const message = error instanceof Error ? error.message : "Falha ao excluir recomendação.";
     return fail(message, message === "recommendation_not_found" ? 404 : 400);
   }
 }

--- a/src/app/api/admin/recommendations/route.ts
+++ b/src/app/api/admin/recommendations/route.ts
@@ -43,10 +43,10 @@ export async function POST(request: Request) {
     }
 
     if (error instanceof SyntaxError) {
-      return fail("Payload invalido.", 400);
+      return fail("Payload inválido.", 400);
     }
 
-    const message = error instanceof Error ? error.message : "Falha ao criar recomendacao.";
+    const message = error instanceof Error ? error.message : "Falha ao criar recomendação.";
     return fail(message, 400);
   }
 }

--- a/src/app/api/admin/viewers/link/route.ts
+++ b/src/app/api/admin/viewers/link/route.ts
@@ -22,7 +22,7 @@ export async function POST(request: Request) {
   try {
     const payload = adminViewerLinkSchema.parse(await request.json());
     if (payload.confirmationText.toUpperCase() !== "VINCULAR") {
-      return fail('Digite "VINCULAR" para confirmar a operacao.', 400);
+      return fail('Digite "VINCULAR" para confirmar a operação.', 400);
     }
 
     const result = await adminLinkGoogleViewerToYoutubeViewer({
@@ -33,13 +33,13 @@ export async function POST(request: Request) {
     return ok(result);
   } catch (error) {
     if (error instanceof ZodError) {
-      return fail("Payload invalido.", 400);
+      return fail("Payload inválido.", 400);
     }
     if (error instanceof SyntaxError) {
-      return fail("Payload invalido.", 400);
+      return fail("Payload inválido.", 400);
     }
 
-    const message = error instanceof Error ? error.message : "Falha ao vincular usuarios.";
+    const message = error instanceof Error ? error.message : "Falha ao vincular usuários.";
     return fail(message, 400);
   }
 }

--- a/src/app/api/internal/streamerbot/bets/place/route.ts
+++ b/src/app/api/internal/streamerbot/bets/place/route.ts
@@ -12,21 +12,21 @@ function mapChatBetReply(message: string, viewerName?: string) {
 
   switch (message) {
     case "saldo_insuficiente":
-      return `${prefix}voce nao tem pipetz suficientes para essa aposta.`;
+      return `${prefix}você não tem pipetz suficientes para essa aposta.`;
     case "aposta_ja_registrada":
-      return `${prefix}voce ja apostou nessa rodada.`;
+      return `${prefix}você já apostou nessa rodada.`;
     case "bet_not_open":
-      return "Essa aposta nao esta aberta no momento.";
+      return "Essa aposta não está aberta no momento.";
     case "bet_closed":
       return "A janela de aposta ja fechou.";
     case "invalid_option":
-      return "Opcao invalida. Use o numero ou nome exibido na aposta.";
+      return "Opção inválida. Use o número ou nome exibido na aposta.";
     case "multiple_open_bets":
       return "Ha mais de uma aposta aberta. Configure lojaneon.activeBetId ou envie betId no comando do Streamer.bot.";
-    case "Aposta nao encontrada.":
+    case "Aposta não encontrada.":
       return "Nenhuma aposta aberta foi encontrada para esse comando.";
     default:
-      return "Nao consegui registrar a aposta agora.";
+      return "Não consegui registrar a aposta agora.";
   }
 }
 
@@ -51,7 +51,7 @@ export async function POST(request: Request) {
       {
         ok: false,
         error: "Invalid signature.",
-        replyMessage: "Assinatura invalida no comando de aposta.",
+        replyMessage: "Assinatura inválida no comando de aposta.",
       },
       { status: 401 },
     );

--- a/src/app/api/internal/streamerbot/counters/route.ts
+++ b/src/app/api/internal/streamerbot/counters/route.ts
@@ -13,7 +13,7 @@ function mapStreamerbotCounterReply(message: string, requestedBy?: string) {
     case "reset_confirmation_required":
       return `${prefix}reset bloqueado. Reenvie o comando com confirmReset=true para zerar esse contador.`;
     default:
-      return `${prefix}nao consegui processar esse contador agora.`;
+      return `${prefix}não consegui processar esse contador agora.`;
   }
 }
 
@@ -38,7 +38,7 @@ export async function POST(request: Request) {
       {
         ok: false,
         error: "Invalid signature.",
-        replyMessage: "Assinatura invalida no comando de contador.",
+        replyMessage: "Assinatura inválida no comando de contador.",
       },
       { status: 401 },
     );

--- a/src/app/api/internal/streamerbot/deaths/route.ts
+++ b/src/app/api/internal/streamerbot/deaths/route.ts
@@ -13,7 +13,7 @@ function mapDeathCounterReply(message: string, requestedBy?: string) {
     case "reset_confirmation_required":
       return `${prefix}reset bloqueado. Reenvie o comando com confirmReset=true para zerar o contador.`;
     default:
-      return `${prefix}nao consegui processar o contador de mortes agora.`;
+      return `${prefix}não consegui processar o contador de mortes agora.`;
   }
 }
 
@@ -38,7 +38,7 @@ export async function POST(request: Request) {
       {
         ok: false,
         error: "Invalid signature.",
-        replyMessage: "Assinatura invalida no comando de mortes.",
+        replyMessage: "Assinatura inválida no comando de mortes.",
       },
       { status: 401 },
     );

--- a/src/app/api/internal/streamerbot/link/route.ts
+++ b/src/app/api/internal/streamerbot/link/route.ts
@@ -8,7 +8,7 @@ function buildReplyMessage(input: { displayName?: string; mergedSyntheticViewer:
   const prefix = input.displayName ? `${input.displayName}, ` : "";
 
   if (input.mergedSyntheticViewer) {
-    return `${prefix}conta vinculada com sucesso. Mantive seu saldo e historico da loja neste canal.`;
+    return `${prefix}conta vinculada com sucesso. Mantive seu saldo e histórico da loja neste canal.`;
   }
 
   return `${prefix}conta vinculada com sucesso.`;

--- a/src/app/api/internal/streamerbot/points/route.ts
+++ b/src/app/api/internal/streamerbot/points/route.ts
@@ -12,11 +12,11 @@ function mapViewerBalanceReply(message: string, viewerName?: string) {
 
   switch (message) {
     case "viewer_external_id_required":
-      return "Nao consegui identificar seu canal do YouTube para consultar seus pipetz.";
+      return "Não consegui identificar seu canal do YouTube para consultar seus pipetz.";
     case "viewer_not_ready":
-      return `${prefix}ainda nao encontrei sua conta da live para consultar seus pipetz.`;
+      return `${prefix}ainda não encontrei sua conta da live para consultar seus pipetz.`;
     default:
-      return `${prefix}nao consegui consultar seus pipetz agora.`;
+      return `${prefix}não consegui consultar seus pipetz agora.`;
   }
 }
 
@@ -41,7 +41,7 @@ export async function POST(request: Request) {
       {
         ok: false,
         error: "Invalid signature.",
-        replyMessage: "Assinatura invalida no comando de saldo.",
+        replyMessage: "Assinatura inválida no comando de saldo.",
       },
       { status: 401 },
     );
@@ -51,7 +51,7 @@ export async function POST(request: Request) {
     const payload = streamerbotViewerBalanceCommandSchema.parse(JSON.parse(raw));
     const result = await getViewerBalanceFromChatCommand(payload);
     const viewerName = payload.youtubeDisplayName?.trim() || result.viewer.youtubeDisplayName;
-    const replyMessage = `${viewerName}, seu saldo atual e ${formatPipetz(result.balance.currentBalance)} pipetz.`;
+    const replyMessage = `${viewerName}, seu saldo atual é ${formatPipetz(result.balance.currentBalance)} pipetz.`;
 
     console.info("[streamerbot/points] Processed balance lookup.", {
       viewerId: result.viewer.id,

--- a/src/app/api/internal/streamerbot/quotes/route.ts
+++ b/src/app/api/internal/streamerbot/quotes/route.ts
@@ -20,32 +20,32 @@ function mapChatQuoteReply(input: {
   switch (input.message) {
     case "quote_not_found":
       return input.quoteId
-        ? `Quote #${input.quoteId} nao encontrada.`
-        : "Quote nao encontrada.";
+        ? `Quote #${input.quoteId} não encontrada.`
+        : "Quote não encontrada.";
     case "quote_list_empty":
       return "Nenhuma quote cadastrada ainda.";
     case "quote_text_required":
       return "Envie o texto da quote junto do comando.";
     case "quote_id_required":
-      return "Use !quoteobs <numero> para escolher uma quote ja existente.";
+      return "Use !quoteobs <número> para escolher uma quote já existente.";
     case "viewer_external_id_required":
-      return "Nao consegui identificar quem executou o comando.";
+      return "Não consegui identificar quem executou o comando.";
     case "livestream_not_live":
       return "Essa quote so pode ir para o OBS enquanto a live estiver acontecendo.";
     case "saldo_insuficiente":
-      return `${prefix}voce precisa de 50 pipetz para colocar a quote no OBS.`;
+      return `${prefix}você precisa de 50 pipetz para colocar a quote no OBS.`;
     case "quote_overlay_busy":
       return "Ja tem uma quote ocupando o overlay. Tenta de novo em alguns segundos.";
     default:
       if (input.action === "create") {
-        return "Nao consegui salvar a quote agora.";
+        return "Não consegui salvar a quote agora.";
       }
 
       if (input.action === "show") {
-        return "Nao consegui colocar a quote na tela agora.";
+        return "Não consegui colocar a quote na tela agora.";
       }
 
-      return "Nao consegui buscar a quote agora.";
+      return "Não consegui buscar a quote agora.";
   }
 }
 
@@ -88,7 +88,7 @@ export async function POST(request: Request) {
       {
         ok: false,
         error: "Invalid signature.",
-        replyMessage: "Assinatura invalida no comando de quotes.",
+        replyMessage: "Assinatura inválida no comando de quotes.",
       },
       { status: 401 },
     );

--- a/src/app/api/me/game-suggestions/[id]/boost/route.ts
+++ b/src/app/api/me/game-suggestions/[id]/boost/route.ts
@@ -49,7 +49,7 @@ export async function POST(
     }
 
     if (error instanceof SyntaxError) {
-      return fail("Payload invalido.", 400);
+      return fail("Payload inválido.", 400);
     }
 
     const message = error instanceof Error ? error.message : "Falha ao dar boost.";

--- a/src/app/api/me/game-suggestions/route.ts
+++ b/src/app/api/me/game-suggestions/route.ts
@@ -44,10 +44,10 @@ export async function POST(request: Request) {
     }
 
     if (error instanceof SyntaxError) {
-      return fail("Payload invalido.", 400);
+      return fail("Payload inválido.", 400);
     }
 
-    const message = error instanceof Error ? error.message : "Falha ao criar sugestao.";
+    const message = error instanceof Error ? error.message : "Falha ao criar sugestão.";
     return fail(message, 400);
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -60,18 +60,18 @@ function buildViewerLinkingIssueUrl(input: {
   const title = "[Linking] Conta logada sem viewer confirmado no chat";
   const body = [
     "## O que aconteceu",
-    "O login entrou no site, mas a conta ainda nao foi vinculada ao viewer do chat via codigo.",
+    "O login entrou no site, mas a conta ainda não foi vinculada ao viewer do chat via código.",
     "",
-    "## Diagnostico tecnico",
+    "## Diagnóstico técnico",
     `- hasActiveViewer: ${input.hasActiveViewer ? "yes" : "no"}`,
     `- isLinked: ${input.isLinked ? "yes" : "no"}`,
-    `- horario (UTC): ${new Date().toISOString()}`,
+    `- horário (UTC): ${new Date().toISOString()}`,
     "",
     "## O que eu esperava",
     "- Descreva qual canal deveria ser vinculado e o que apareceu no chat ao usar !link.",
     "",
-    "## Observacoes",
-    "- Nao inclua token, email privado, cookie nem segredo nesta issue.",
+    "## Observações",
+    "- Não inclua token, email privado, cookie nem segredo nesta issue.",
   ].join("\n");
 
   const url = new URL(env.NEXT_PUBLIC_GITHUB_ISSUES_URL ?? DEFAULT_GITHUB_ISSUES_URL);
@@ -88,11 +88,11 @@ function ViewerLinkingNotice({ issueUrl }: { issueUrl: string }) {
         Falta confirmar seu canal pelo chat.
       </p>
       <p className="mt-3 text-sm font-bold leading-6">
-        O login do site entrou, mas o viewer da live agora e vinculado por codigo no chat do
+        O login do site entrou, mas o viewer da live agora é vinculado por código no chat do
         YouTube.
       </p>
       <p className="mt-3 text-sm font-medium leading-6">
-        Abra sua area, gere um codigo curto e envie <span className="font-black">!link CODIGO</span>{" "}
+        Abra sua área, gere um código curto e envie <span className="font-black">!link CÓDIGO</span>{" "}
         no chat. Assim eu consigo unir sua conta do site ao viewer que chega pelo Streamer.bot sem
         depender da API do YouTube.
       </p>
@@ -101,7 +101,7 @@ function ViewerLinkingNotice({ issueUrl }: { issueUrl: string }) {
           href="/me"
           className="btn-brutal bg-[var(--color-paper)] px-4 py-2 text-xs text-[var(--color-ink)]"
         >
-          Abrir minha area
+          Abrir minha área
         </Link>
         <a
           href={issueUrl}
@@ -119,20 +119,20 @@ function ViewerLinkingNotice({ issueUrl }: { issueUrl: string }) {
 function AccountProtectionNotice({ status }: { status: AccountProtectionStatus }) {
   const title =
     status === "google_signin_blocked"
-      ? "Seu login Google foi pausado por seguranca."
-      : "Sua sessao foi encerrada por um alerta de seguranca.";
+      ? "Seu login Google foi pausado por segurança."
+      : "Sua sessão foi encerrada por um alerta de segurança.";
   const body =
     status === "google_signin_blocked"
-      ? "O Google enviou um sinal de risco para esta conta, entao eu bloqueei novas entradas com esse login ate a situacao ser normalizada."
-      : "Recebi um evento de protecao entre contas e encerrei sua sessao local. Para continuar, entre novamente depois de revisar a seguranca da sua conta Google.";
+      ? "O Google enviou um sinal de risco para esta conta, então eu bloqueei novas entradas com esse login até a situação ser normalizada."
+      : "Recebi um evento de proteção entre contas e encerrei sua sessão local. Para continuar, entre novamente depois de revisar a segurança da sua conta Google.";
   const nextStep =
     status === "google_signin_blocked"
-      ? "Se voce quiser testar com outra conta Google, use o seletor de conta. Se esta for a sua conta principal, revise a seguranca dela primeiro."
-      : "Se estiver tudo certo na sua conta Google, voce pode entrar novamente agora.";
+      ? "Se você quiser testar com outra conta Google, use o seletor de conta. Se esta for a sua conta principal, revise a segurança dela primeiro."
+      : "Se estiver tudo certo na sua conta Google, você pode entrar novamente agora.";
 
   return (
     <div className="card-poster mt-6 border-[3px] border-[var(--color-ink)] bg-[var(--color-blue)] p-4 text-[var(--color-ink)]">
-      <p className="mono text-[10px] uppercase tracking-[0.24em]">seguranca da conta</p>
+      <p className="mono text-[10px] uppercase tracking-[0.24em]">segurança da conta</p>
       <p className="mt-2 text-lg font-black uppercase leading-tight">{title}</p>
       <p className="mt-3 text-sm font-bold leading-6">{body}</p>
       <p className="mt-3 text-sm font-medium leading-6">{nextStep}</p>
@@ -246,7 +246,7 @@ function SpotlightOptionCard({
     >
       <CardHeader className="min-w-0 gap-0">
         <CardDescription className="mono text-[10px] uppercase tracking-[0.24em] text-[var(--color-ink-soft)]">
-          opcao 0{index + 1}
+          opção 0{index + 1}
         </CardDescription>
         <CardTitle className="mt-1 text-lg font-black uppercase leading-tight">{optionLabel}</CardTitle>
       </CardHeader>
@@ -324,7 +324,7 @@ function HeroPoster({
             <StickerBadge
               variant="heart"
               className="absolute right-4 top-6 h-[4.5rem] w-[4.5rem] rotate-[14deg] sm:right-6 sm:top-8 sm:h-20 sm:w-20"
-              label="coracao decorativo"
+              label="coração decorativo"
             />
             <div className="relative min-h-[340px] overflow-visible sm:min-h-[400px]">
               <div className="mx-auto w-[72%] max-w-[420px] pt-[4.75rem] sm:pt-[5.5rem]">
@@ -374,10 +374,10 @@ function FeatureShowcase({
             className="max-w-xl text-4xl uppercase leading-[0.9] sm:text-5xl"
             style={{ fontFamily: "var(--font-display)" }}
           >
-            Voce participa da minha live de verdade.
+            Você participa da minha live de verdade.
           </h2>
           <p className="mt-4 max-w-xl text-base leading-7 text-[var(--color-ink-soft)]">
-            Eu abro a live, voce junta pipetz, entra nas apostas e ainda solta resgates
+            Eu abro a live, você junta pipetz, entra nas apostas e ainda solta resgates
             que aparecem comigo ao vivo.
           </p>
 
@@ -390,14 +390,14 @@ function FeatureShowcase({
 
         <div className="landing-plane bg-[var(--color-sky)] p-6 sm:p-8">
           <p className="mono text-[11px] uppercase tracking-[0.28em] text-[var(--color-ink-soft)]">
-            termometro da live . comunidade agora
+            termômetro da live . comunidade agora
           </p>
 
           <h3
             className="mt-4 max-w-md text-3xl uppercase leading-[0.92] sm:text-4xl"
             style={{ fontFamily: "var(--font-display)" }}
           >
-            O que voces estao aprontando comigo agora.
+            O que vocês estão aprontando comigo agora.
           </h3>
 
           <div className="mt-6 grid gap-4 sm:grid-cols-2">
@@ -468,7 +468,7 @@ function RankingHeroCard({
         </Link>
         {typeof viewerRank === "number" && viewerRank > 0 ? (
           <span className="mono text-[11px] uppercase tracking-[0.24em] text-[var(--color-ink-soft)]">
-            voce esta em #{viewerRank}
+            você está em #{viewerRank}
           </span>
         ) : null}
       </div>
@@ -486,7 +486,7 @@ function LiveSpotlight({ activeBet, loggedIn = false }: SpotlightProps) {
         <div className="grid gap-6 lg:grid-cols-[1.05fr_0.95fr] lg:items-start">
           <div>
             <p className="mono text-[11px] uppercase tracking-[0.28em] text-[var(--color-ink-soft)]">
-              ao vivo . {activeBet.options.length} opcoes abertas
+              ao vivo . {activeBet.options.length} opções abertas
             </p>
 
             <h2
@@ -497,12 +497,12 @@ function LiveSpotlight({ activeBet, loggedIn = false }: SpotlightProps) {
             </h2>
 
             <p className="mt-4 max-w-xl text-base leading-7 text-[var(--color-ink-soft)]">
-              Quando eu abro uma aposta, voces escolhem um lado, entram no pool e tentam
+              Quando eu abro uma aposta, vocês escolhem um lado, entram no pool e tentam
               adivinhar o que vai acontecer comigo ao vivo.
             </p>
 
             <p className="mono mt-6 text-[11px] uppercase tracking-[0.24em] text-[var(--color-ink-soft)]">
-              pool {formatPipetz(activeBet.totalPool)} . voces palpitando ao vivo
+              pool {formatPipetz(activeBet.totalPool)} . vocês palpitando ao vivo
             </p>
 
             <div className="mt-6">
@@ -617,7 +617,7 @@ export default async function Home({ searchParams }: HomePageProps) {
       symbol: "⚡",
       eyebrow: "assistindo a live",
       title: "Ganhe assistindo",
-      body: "Enquanto voce assiste a minha live, seus pipetz vao acumulando para apostar, resgatar e entrar no ranking.",
+      body: "Enquanto você assiste à minha live, seus pipetz vão acumulando para apostar, resgatar e entrar no ranking.",
       bg: "bg-[var(--color-blue)]",
     },
     {
@@ -629,7 +629,7 @@ export default async function Home({ searchParams }: HomePageProps) {
     },
     {
       symbol: "↗",
-      eyebrow: "bagunca organizada",
+      eyebrow: "bagunça organizada",
       title: "Acione resgates",
       body: "Se quiser me trollar com carinho, os resgates viram efeitos e caos ao vivo na stream.",
       bg: "bg-[var(--color-pink)]",
@@ -638,7 +638,7 @@ export default async function Home({ searchParams }: HomePageProps) {
 
   const heroTitle: ReactNode = hasUsableSession ? (
     <>
-      Voce ja esta na minha live.{" "}
+      Você já está na minha live.{" "}
       <span className="inline-block border-[3px] border-[var(--color-ink)] bg-[var(--color-pink)] px-3 py-1 shadow-[4px_4px_0_#000]">
         Agora vem jogar comigo.
       </span>
@@ -654,11 +654,11 @@ export default async function Home({ searchParams }: HomePageProps) {
 
   const heroDescription = accountProtectionStatus
     ? accountProtectionStatus === "google_signin_blocked"
-      ? "Seu acesso com Google foi colocado em espera por um evento de seguranca. Eu mantive o painel publico disponivel enquanto voce revisa a conta."
-      : "Sua sessao local foi encerrada por seguranca. Assim que voce entrar de novo, o painel volta a mostrar seus dados normalmente."
+      ? "Seu acesso com Google foi colocado em espera por um evento de segurança. Eu mantive o painel público disponível enquanto você revisa a conta."
+      : "Sua sessão local foi encerrada por segurança. Assim que você entrar de novo, o painel volta a mostrar seus dados normalmente."
     : hasUsableSession
       ? dashboard
-        ? "Seu saldo, seu ranking e o que esta rolando comigo ao vivo ficam aqui para voce entrar na brincadeira sem se perder."
+        ? "Seu saldo, seu ranking e o que está rolando comigo ao vivo ficam aqui para você entrar na brincadeira sem se perder."
         : "Sua conta entrou, mas ainda falta sincronizar seus dados da live para eu te liberar tudo por aqui."
       : "Aqui o chat ganha pipetz, entra nas apostas e ativa resgates que aparecem durante a minha live.";
 
@@ -739,9 +739,9 @@ export default async function Home({ searchParams }: HomePageProps) {
             </div>
 
             <p className="mt-4 text-sm font-medium leading-6 text-[var(--color-ink-soft)]">
-              Ao usar o login Google, voce pode revisar nossa{" "}
+              Ao usar o login Google, você pode revisar nossa{" "}
               <Link href="/privacy" className="font-black underline decoration-[3px] underline-offset-4">
-                Politica de Privacidade
+                Política de Privacidade
               </Link>
               .
             </p>
@@ -782,7 +782,7 @@ export default async function Home({ searchParams }: HomePageProps) {
               href: "/ranking",
               label: "Ranking",
               value: viewerRank ? `#${viewerRank}` : "--",
-              sublabel: "Veja onde voce esta",
+              sublabel: "Veja onde você está",
               emoji: "TOP",
               bg: "bg-[var(--color-mint)]",
             },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -49,7 +49,7 @@ type FeatureCard = {
 };
 
 const DEFAULT_GITHUB_ISSUES_URL =
-  "https://github.com/ludmila-omlopes/ludylops-youtube-dashboard/issues/new";
+  "https://github.com/ludmila-omlopes/ludylops-live/issues/new";
 const LUDYLOPS_PROFILE_IMAGE =
   "/selfie2.png";
 

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 export const metadata: Metadata = {
-  title: "Politica de Privacidade | Pipetz",
+  title: "Política de Privacidade | Pipetz",
   description:
     "Como o Pipetz coleta, usa e protege dados de login Google e dados vinculados ao canal do YouTube.",
 };
@@ -19,55 +19,55 @@ const sections: PolicySection[] = [
   {
     title: "Resumo",
     body: [
-      "O Pipetz e um painel da comunidade da live da Ludylops. Esta politica explica quais dados podem ser coletados quando voce usa o login Google, participa das funcoes da live e vincula sua conta ao seu canal do YouTube.",
-      "Os dados sao usados para autenticar voce, associar sua conta ao viewer correto, mostrar saldo e ranking, registrar apostas, resgates e sugestoes, e manter o funcionamento do app.",
+      "O Pipetz é um painel da comunidade da live da Ludylops. Esta política explica quais dados podem ser coletados quando você usa o login Google, participa das funções da live e vincula sua conta ao seu canal do YouTube.",
+      "Os dados são usados para autenticar você, associar sua conta ao viewer correto, mostrar saldo e ranking, registrar apostas, resgates e sugestões, e manter o funcionamento do app.",
     ],
   },
   {
     title: "Dados que podemos coletar",
     body: [
-      "Dados basicos de login Google: nome, email, foto de perfil e identificador da conta Google.",
-      "Quando voce concede permissao de YouTube ao app: identificador do canal, nome exibido e handle do canal retornados pela API do Google.",
-      "Dados de uso dentro do Pipetz: viewer vinculado, saldo, historico de pontos, apostas, resgates, sugestoes de jogos, canais associados e informacoes necessarias para diagnosticar problemas de vinculacao.",
-      "Dados tecnicos de sessao e seguranca, como cookies de autenticacao e logs basicos necessarios para manter o app funcionando e investigar falhas ou abuso.",
+      "Dados básicos de login Google: nome, email, foto de perfil e identificador da conta Google.",
+      "Quando você concede permissão de YouTube ao app: identificador do canal, nome exibido e handle do canal retornados pela API do Google.",
+      "Dados de uso dentro do Pipetz: viewer vinculado, saldo, histórico de pontos, apostas, resgates, sugestões de jogos, canais associados e informações necessárias para diagnosticar problemas de vinculação.",
+      "Dados técnicos de sessão e segurança, como cookies de autenticação e logs básicos necessários para manter o app funcionando e investigar falhas ou abuso.",
     ],
   },
   {
     title: "Como usamos esses dados",
     body: [
-      "Para autenticar sua conta e manter sua sessao ativa no Pipetz.",
+      "Para autenticar sua conta e manter sua sessão ativa no Pipetz.",
       "Para tentar vincular sua conta Google ao canal correto do YouTube e ao viewer correspondente no chat da live.",
-      "Para operar as funcionalidades do app, incluindo painel do viewer, ranking, apostas, resgates, catalogo e sugestoes.",
-      "Para corrigir erros de vinculacao, evitar duplicidade de viewers e prestar suporte quando voce reporta um problema.",
+      "Para operar as funcionalidades do app, incluindo painel do viewer, ranking, apostas, resgates, catálogo e sugestões.",
+      "Para corrigir erros de vinculação, evitar duplicidade de viewers e prestar suporte quando você reporta um problema.",
     ],
   },
   {
     title: "Compartilhamento",
     body: [
-      "Seus dados nao sao vendidos.",
-      "Eles podem ser processados por provedores tecnicos usados para operar o app, como Google para autenticacao e consulta do canal do YouTube, e servicos de hospedagem, banco de dados e observabilidade usados pelo Pipetz.",
-      "Se voce clicar para abrir uma issue manualmente no GitHub, o conteudo que voce enviar seguira tambem as regras de privacidade do GitHub.",
+      "Seus dados não são vendidos.",
+      "Eles podem ser processados por provedores técnicos usados para operar o app, como Google para autenticação e consulta do canal do YouTube, e serviços de hospedagem, banco de dados e observabilidade usados pelo Pipetz.",
+      "Se você clicar para abrir uma issue manualmente no GitHub, o conteúdo que você enviar seguirá também as regras de privacidade do GitHub.",
     ],
   },
   {
-    title: "Retencao e seguranca",
+    title: "Retenção e segurança",
     body: [
-      "Mantemos os dados pelo tempo necessario para operar o Pipetz, preservar o historico das interacoes da live, resolver problemas de conta e cumprir obrigacoes tecnicas ou legais.",
-      "Buscamos limitar o acesso aos dados ao necessario para operar o app, mas nenhum sistema conectado a internet oferece garantia absoluta de seguranca.",
+      "Mantemos os dados pelo tempo necessário para operar o Pipetz, preservar o histórico das interações da live, resolver problemas de conta e cumprir obrigações técnicas ou legais.",
+      "Buscamos limitar o acesso aos dados ao necessário para operar o app, mas nenhum sistema conectado à internet oferece garantia absoluta de segurança.",
     ],
   },
   {
     title: "Seus controles",
     body: [
-      "Voce pode parar de usar o login Google a qualquer momento e pode revogar o acesso do app nas configuracoes da sua Conta Google.",
-      "Se quiser solicitar remocao de conta, desvinculacao ou tirar duvidas sobre estes dados, entre em contato pelo email de suporte informado abaixo.",
+      "Você pode parar de usar o login Google a qualquer momento e pode revogar o acesso do app nas configurações da sua Conta Google.",
+      "Se quiser solicitar remoção de conta, desvinculação ou tirar dúvidas sobre estes dados, entre em contato pelo email de suporte informado abaixo.",
     ],
   },
   {
     title: "Contato",
     body: [
       `Email de suporte: ${SUPPORT_EMAIL}`,
-      "Se esta politica mudar de forma relevante, a versao publicada nesta pagina sera atualizada.",
+      "Se esta política mudar de forma relevante, a versão publicada nesta página será atualizada.",
     ],
   },
 ];
@@ -78,22 +78,22 @@ export default function PrivacyPage() {
       <section className="panel surface-hero p-6 sm:p-8">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div>
-            <span className="retro-label accent-chip">documento publico</span>
+            <span className="retro-label accent-chip">documento público</span>
             <h1
               className="mt-4 text-4xl uppercase leading-[0.9] sm:text-5xl"
               style={{ fontFamily: "var(--font-display)" }}
             >
-              Politica de privacidade
+              Política de privacidade
             </h1>
             <p className="mt-4 max-w-2xl text-base leading-8 text-[var(--color-ink-soft)]">
-              Esta pagina explica como o Pipetz acessa, usa e protege dados de autenticacao Google
-              e de vinculacao com canal do YouTube.
+              Esta página explica como o Pipetz acessa, usa e protege dados de autenticação Google
+              e de vinculação com canal do YouTube.
             </p>
           </div>
 
           <div className="card-poster bg-[var(--color-paper)] p-4">
             <p className="mono text-[10px] uppercase tracking-[0.24em] text-[var(--color-ink-soft)]">
-              ultima atualizacao
+              última atualização
             </p>
             <p className="mt-2 text-lg font-black uppercase">{LAST_UPDATED}</p>
           </div>
@@ -112,7 +112,7 @@ export default function PrivacyPage() {
           }`}
         >
           <p className="mono text-[11px] uppercase tracking-[0.24em] text-[var(--color-ink-soft)]">
-            secao {String(index + 1).padStart(2, "0")}
+            seção {String(index + 1).padStart(2, "0")}
           </p>
           <h2
             className="mt-3 text-3xl uppercase leading-none sm:text-4xl"
@@ -130,7 +130,7 @@ export default function PrivacyPage() {
 
       <section className="panel bg-[var(--color-pink)] p-6 sm:p-8">
         <p className="mono text-[11px] uppercase tracking-[0.24em] text-[var(--color-accent-ink)]">
-          links uteis
+          links úteis
         </p>
         <div className="mt-4 flex flex-wrap gap-3">
           <Link href="/" className="btn-brutal bg-[var(--color-paper)] px-5 py-3 text-xs text-[var(--color-ink)]">

--- a/src/components/admin-bets-panel.tsx
+++ b/src/components/admin-bets-panel.tsx
@@ -33,15 +33,15 @@ function minLocalDateTimeInput() {
 function mapAdminBetError(message: string) {
   switch (message) {
     case "bet_not_open":
-      return "So e possivel travar apostas abertas.";
+      return "Só é possível travar apostas abertas.";
     case "bet_not_locked":
-      return "So e possivel resolver apostas travadas.";
+      return "Só é possível resolver apostas travadas.";
     case "bet_already_locked":
-      return "A aposta ja esta travada.";
+      return "A aposta já está travada.";
     case "bet_already_resolved":
-      return "A aposta ja foi resolvida.";
+      return "A aposta já foi resolvida.";
     case "bet_already_cancelled":
-      return "A aposta ja foi cancelada.";
+      return "A aposta já foi cancelada.";
     default:
       return message;
   }
@@ -51,7 +51,7 @@ export function AdminBetsPanel({ bets }: { bets: BetWithOptionsRecord[] }) {
   const router = useRouter();
   const [question, setQuestion] = useState("");
   const [closesAt, setClosesAt] = useState("");
-  const [optionsText, setOptionsText] = useState("Sim\nNao");
+  const [optionsText, setOptionsText] = useState("Sim\nNão");
   const [feedback, setFeedback] = useState<string | null>(null);
   const [resolveSelections, setResolveSelections] = useState<Record<string, string>>({});
   const [isPending, startTransition] = useTransition();
@@ -86,7 +86,7 @@ export function AdminBetsPanel({ bets }: { bets: BetWithOptionsRecord[] }) {
         throw new Error(trimmed);
       }
 
-      throw new Error("Falha na operacao.");
+      throw new Error("Falha na operação.");
     }
   }
 
@@ -120,7 +120,7 @@ export function AdminBetsPanel({ bets }: { bets: BetWithOptionsRecord[] }) {
         });
         setQuestion("");
         setClosesAt("");
-        setOptionsText("Sim\nNao");
+        setOptionsText("Sim\nNão");
         setFeedback("Aposta criada.");
         router.refresh();
       } catch (error) {
@@ -138,7 +138,7 @@ export function AdminBetsPanel({ bets }: { bets: BetWithOptionsRecord[] }) {
         router.refresh();
       } catch (error) {
         setFeedback(
-          error instanceof Error ? mapAdminBetError(error.message) : "Falha ao executar operacao.",
+          error instanceof Error ? mapAdminBetError(error.message) : "Falha ao executar operação.",
         );
       }
     });
@@ -201,24 +201,24 @@ export function AdminBetsPanel({ bets }: { bets: BetWithOptionsRecord[] }) {
                 className="px-3 py-2"
               />
               <span className="text-xs font-bold text-[var(--color-ink-soft)]">
-                Data e hora locais em que a janela de apostas fecha. Depois desse horario, ninguem mais consegue apostar.
+                Data e hora locais em que a janela de apostas fecha. Depois desse horário, ninguém mais consegue apostar.
               </span>
             </label>
 
             <label className="grid gap-2">
               <span className="text-sm font-black uppercase tracking-[0.14em] text-[var(--color-ink)]">
-                Opcoes
+                Opções
               </span>
               <Textarea
                 value={optionsText}
                 onChange={(e) => setOptionsText(e.target.value)}
                 rows={5}
                 maxLength={1550}
-                placeholder={"Sim\nNao"}
+                placeholder={"Sim\nNão"}
                 className="min-h-32 px-3 py-2 font-bold"
               />
               <span className="text-xs font-bold text-[var(--color-ink-soft)]">
-                Use uma opcao por linha. Minimo de 2 e maximo de 6 opcoes.
+                Use uma opção por linha. Mínimo de 2 e máximo de 6 opções.
               </span>
             </label>
 

--- a/src/components/admin-game-suggestions-panel.tsx
+++ b/src/components/admin-game-suggestions-panel.tsx
@@ -24,7 +24,7 @@ const statusBgMap: Record<GameSuggestionWithMeta["status"], string> = {
 function mapSuggestionError(message: string) {
   switch (message) {
     case "suggestion_not_found":
-      return "Sugestao nao encontrada.";
+      return "Sugestão não encontrada.";
     default:
       return message;
   }
@@ -52,7 +52,7 @@ export function AdminGameSuggestionsPanel({
 
       const payload = (await response.json()) as { ok: boolean; error?: string };
       if (!response.ok || !payload.ok) {
-        setFeedback(mapSuggestionError(payload.error ?? "Falha ao atualizar sugestao."));
+        setFeedback(mapSuggestionError(payload.error ?? "Falha ao atualizar sugestão."));
         return;
       }
 
@@ -73,7 +73,7 @@ export function AdminGameSuggestionsPanel({
             className="mt-2 text-3xl uppercase"
             style={{ fontFamily: "var(--font-display)" }}
           >
-            Fila de sugestoes
+            Fila de sugestões
           </h2>
         </div>
         {feedback ? (
@@ -86,7 +86,7 @@ export function AdminGameSuggestionsPanel({
         <div className="mt-6 grid gap-3">
         {suggestions.length === 0 ? (
           <div className="card-brutal-static p-4 text-sm font-bold text-[var(--color-ink-soft)]">
-            Nenhuma sugestao cadastrada.
+            Nenhuma sugestão cadastrada.
           </div>
         ) : null}
 

--- a/src/components/admin-recommendations-panel.tsx
+++ b/src/components/admin-recommendations-panel.tsx
@@ -15,11 +15,11 @@ import type { ProductRecommendationRecord } from "@/lib/types";
 function mapRecommendationError(message: string) {
   switch (message) {
     case "recommendation_slug_exists":
-      return "Ja existe uma recomendacao com esse slug.";
+      return "Já existe uma recomendação com esse slug.";
     case "recommendation_not_found":
-      return "Recomendacao nao encontrada.";
+      return "Recomendação não encontrada.";
     case "invalid_slug":
-      return "Nao consegui gerar um slug valido para esse produto.";
+      return "Não consegui gerar um slug válido para esse produto.";
     default:
       return message;
   }
@@ -102,7 +102,7 @@ export function AdminRecommendationsPanel({
 
     const payload = (await response.json()) as { ok?: boolean; error?: string };
     if (!response.ok || !payload.ok) {
-      throw new Error(payload.error ?? "Falha ao salvar recomendacao.");
+      throw new Error(payload.error ?? "Falha ao salvar recomendação.");
     }
   }
 
@@ -137,7 +137,7 @@ export function AdminRecommendationsPanel({
         router.refresh();
       } catch (error) {
         setFeedback(
-          error instanceof Error ? mapRecommendationError(error.message) : "Falha ao criar recomendacao.",
+          error instanceof Error ? mapRecommendationError(error.message) : "Falha ao criar recomendação.",
         );
       }
     });
@@ -156,7 +156,7 @@ export function AdminRecommendationsPanel({
         router.refresh();
       } catch (error) {
         setFeedback(
-          error instanceof Error ? mapRecommendationError(error.message) : "Falha ao atualizar recomendacao.",
+          error instanceof Error ? mapRecommendationError(error.message) : "Falha ao atualizar recomendação.",
         );
       }
     });
@@ -173,7 +173,7 @@ export function AdminRecommendationsPanel({
         router.refresh();
       } catch (error) {
         setFeedback(
-          error instanceof Error ? mapRecommendationError(error.message) : "Falha ao excluir recomendacao.",
+          error instanceof Error ? mapRecommendationError(error.message) : "Falha ao excluir recomendação.",
         );
       }
     });
@@ -184,7 +184,7 @@ export function AdminRecommendationsPanel({
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
           <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
-            Indicacoes
+            Indicações
           </p>
           <h2
             className="mt-2 text-3xl uppercase"
@@ -347,7 +347,7 @@ export function AdminRecommendationsPanel({
                 onChange={(event) => setIsActive(event.target.checked)}
                 className="h-4 w-4"
               />
-              Mostrar na pagina publica
+              Mostrar na página pública
             </label>
 
             <button
@@ -364,7 +364,7 @@ export function AdminRecommendationsPanel({
         <div className="grid gap-3">
           {recommendations.length === 0 ? (
             <div className="card-brutal-static p-4 text-sm font-bold text-[var(--color-ink-soft)]">
-              Nenhuma recomendacao cadastrada.
+              Nenhuma recomendação cadastrada.
             </div>
           ) : null}
 
@@ -417,7 +417,7 @@ export function AdminRecommendationsPanel({
                         {confirmingDeleteId === item.id ? (
                           <div className="flex flex-wrap items-center justify-end gap-2 rounded-[var(--radius)] border-[3px] border-[var(--color-ink)] bg-[var(--color-paper)] px-3 py-2">
                             <span className="text-[10px] font-black uppercase tracking-[0.14em]">
-                              Voce tem certeza?
+                              Você tem certeza?
                             </span>
                             <button
                               type="button"

--- a/src/components/admin-viewer-links-panel.tsx
+++ b/src/components/admin-viewer-links-panel.tsx
@@ -26,7 +26,7 @@ function getViewerStatus(entry: AdminViewerDirectoryRecord) {
 
   if (entry.googleAccountId && entry.isSyntheticYoutubeChannel) {
     return {
-      label: "Nao vinculado",
+      label: "Não vinculado",
       tone: "var(--color-lavender)",
       note: "Conta Google sem canal final",
     };
@@ -34,14 +34,14 @@ function getViewerStatus(entry: AdminViewerDirectoryRecord) {
 
   if (!entry.googleAccountId && !entry.isSyntheticYoutubeChannel) {
     return {
-      label: "Nao vinculado",
+      label: "Não vinculado",
       tone: "var(--color-sky)",
       note: "Canal do YouTube sem conta Google",
     };
   }
 
   return {
-    label: entry.isLinked ? "Vinculado" : "Nao vinculado",
+    label: entry.isLinked ? "Vinculado" : "Não vinculado",
     tone: "var(--color-paper)",
     note: "Sem dados suficientes",
   };
@@ -89,11 +89,11 @@ export function AdminViewerLinksPanel({
 
   function submitLink() {
     if (!googleViewerId || !youtubeViewerId) {
-      setFeedback("Escolha um usuario Google e um usuario do YouTube.");
+      setFeedback("Escolha um usuário Google e um usuário do YouTube.");
       return;
     }
     if (!isConfirmationValid) {
-      setFeedback('Digite "VINCULAR" para liberar a operacao.');
+      setFeedback('Digite "VINCULAR" para liberar a operação.');
       return;
     }
 
@@ -114,7 +114,7 @@ export function AdminViewerLinksPanel({
 
         const payload = (await response.json()) as { ok?: boolean; error?: string };
         if (!response.ok || !payload.ok) {
-          setFeedback(payload.error ?? "Falha ao vincular usuarios.");
+          setFeedback(payload.error ?? "Falha ao vincular usuários.");
           return;
         }
 
@@ -124,7 +124,7 @@ export function AdminViewerLinksPanel({
         setConfirmationText("");
         router.refresh();
       } catch (error) {
-        setFeedback(error instanceof Error ? error.message : "Falha ao vincular usuarios.");
+        setFeedback(error instanceof Error ? error.message : "Falha ao vincular usuários.");
       }
     });
   }
@@ -141,11 +141,11 @@ export function AdminViewerLinksPanel({
               className="mt-2 text-3xl uppercase"
               style={{ fontFamily: "var(--font-display)" }}
             >
-              Viculos Google + YouTube
+              Vínculos Google + YouTube
             </h2>
             <p className="mt-3 max-w-3xl text-sm leading-7 text-[var(--color-ink-soft)]">
-              Veja todos os usuarios, confira quem ja esta vinculado e use o fluxo abaixo para unir
-              com seguranca uma sessao Google ao canal certo do YouTube.
+              Veja todos os usuários, confira quem já está vinculado e use o fluxo abaixo para unir
+              com segurança uma sessão Google ao canal certo do YouTube.
             </p>
           </div>
           {feedback ? <div className="retro-label neutral-chip">{feedback}</div> : null}
@@ -164,13 +164,13 @@ export function AdminViewerLinksPanel({
                 </span>
                 <Select value={googleViewerId || null} onValueChange={(value) => setGoogleViewerId(value ?? "")}>
                   <SelectTrigger className="w-full">
-                    <SelectValue placeholder="Escolha a sessao Google">
+                    <SelectValue placeholder="Escolha a sessão Google">
                       {(value) =>
                         googleCandidates.find((entry) => entry.id === value)
                           ? buildGoogleCandidateLabel(
                               googleCandidates.find((entry) => entry.id === value)!,
                             )
-                          : "Escolha a sessao Google"
+                          : "Escolha a sessão Google"
                       }
                     </SelectValue>
                   </SelectTrigger>
@@ -183,7 +183,7 @@ export function AdminViewerLinksPanel({
                   </SelectContent>
                 </Select>
                 <span className="text-xs font-bold text-[var(--color-ink-soft)]">
-                  Mostro aqui apenas usuarios que ja tem conta Google, mas ainda nao foram ligados
+                  Mostro aqui apenas usuários que já têm conta Google, mas ainda não foram ligados
                   ao canal final do YouTube.
                 </span>
               </label>
@@ -219,14 +219,14 @@ export function AdminViewerLinksPanel({
 
               <div className="card-flat bg-[var(--color-paper)] p-4">
                 <p className="mono text-[10px] uppercase tracking-[0.2em] text-[var(--color-ink-soft)]">
-                  Revisao da operacao
+                  Revisão da operação
                 </p>
                 <div className="mt-3 grid gap-3 text-sm text-[var(--color-ink-soft)]">
                   <p>
                     <span className="font-black text-[var(--color-ink)]">Conta Google:</span>{" "}
                     {selectedGoogleViewer
                       ? buildGoogleCandidateLabel(selectedGoogleViewer)
-                      : "Escolha uma sessao Google"}
+                      : "Escolha uma sessão Google"}
                   </p>
                   <p>
                     <span className="font-black text-[var(--color-ink)]">Canal do YouTube:</span>{" "}
@@ -235,16 +235,16 @@ export function AdminViewerLinksPanel({
                       : "Escolha um canal do YouTube"}
                   </p>
                   <p>
-                    Essa acao transfere saldo, historico, sugestoes e a posse da conta Google para
-                    o canal do YouTube selecionado. Se houver conflito de apostas ou se o canal ja
-                    pertencer a outra conta Google, eu bloqueio a operacao.
+                    Essa ação transfere saldo, histórico, sugestões e a posse da conta Google para
+                    o canal do YouTube selecionado. Se houver conflito de apostas ou se o canal já
+                    pertencer a outra conta Google, eu bloqueio a operação.
                   </p>
                 </div>
               </div>
 
               <label className="grid gap-2">
                 <span className="text-sm font-black uppercase tracking-[0.14em] text-[var(--color-ink)]">
-                  Confirmacao
+                  Confirmação
                 </span>
                 <Input
                   value={confirmationText}
@@ -253,7 +253,7 @@ export function AdminViewerLinksPanel({
                   className="px-3 py-2"
                 />
                 <span className="text-xs font-bold text-[var(--color-ink-soft)]">
-                  Essa confirmacao existe para evitar vinculos acidentais.
+                  Essa confirmação existe para evitar vínculos acidentais.
                 </span>
               </label>
 
@@ -264,7 +264,7 @@ export function AdminViewerLinksPanel({
                 size="sm"
                 className="w-full sm:w-fit"
               >
-                {isPending ? "Vinculando..." : "Vincular usuarios"}
+                {isPending ? "Vinculando..." : "Vincular usuários"}
               </Button>
             </div>
           </div>
@@ -277,7 +277,7 @@ export function AdminViewerLinksPanel({
               <p className="mt-2 text-3xl font-black" style={{ fontFamily: "var(--font-display)" }}>
                 {entries.length}
               </p>
-              <p className="mt-2 text-sm text-[var(--color-ink-soft)]">usuarios no diretorio</p>
+              <p className="mt-2 text-sm text-[var(--color-ink-soft)]">usuários no diretório</p>
             </div>
             <div className="card-brutal-static bg-[var(--color-mint)] p-5">
               <p className="mono text-[10px] uppercase tracking-[0.22em] text-[var(--color-ink-soft)]">
@@ -336,7 +336,7 @@ export function AdminViewerLinksPanel({
                           ? "viewer ativo da conta"
                           : "viewer secundario da conta"
                         : entry.isSyntheticYoutubeChannel
-                          ? "sessao sem conta vinculada"
+                          ? "sessão sem conta vinculada"
                           : "canal sem conta Google"}
                     </p>
                   </div>

--- a/src/components/app-chrome.tsx
+++ b/src/components/app-chrome.tsx
@@ -51,7 +51,7 @@ export function AppChrome({
   }, [isObsView]);
 
   const navLinks = [
-    { href: "/indicacoes", label: "Indicacoes" },
+    { href: "/indicacoes", label: "Indicações" },
     { href: "/apostas", label: "Apostas" },
     { href: "/contadores", label: "Contadores" },
     { href: "/jogos", label: "Jogos" },
@@ -140,7 +140,7 @@ export function AppChrome({
             <div className="mb-4">
               <LivestreamIndicator isLive={isLive} />
             </div>
-            <nav className="flex flex-col gap-1.5" aria-label="Navegacao principal">
+            <nav className="flex flex-col gap-1.5" aria-label="Navegação principal">
               {allLinks.map((link) => (
                 <Link
                   key={link.href}
@@ -185,7 +185,7 @@ export function AppChrome({
             href="/privacy"
             className="w-fit font-black uppercase tracking-[0.08em] text-[var(--color-ink)] underline decoration-[3px] underline-offset-4"
           >
-            Politica de Privacidade
+            Política de Privacidade
           </Link>
           <p className="flex items-center gap-2 text-[var(--color-ink)]">
             <span>Feito com carinho por ludylops</span>

--- a/src/components/auth-buttons.tsx
+++ b/src/components/auth-buttons.tsx
@@ -72,7 +72,7 @@ export function AuthButtons() {
             variant="neutral"
             size="sm"
           >
-            Limpar sessao
+            Limpar sessão
           </Button>
         ) : null}
       </div>

--- a/src/components/bet-card.tsx
+++ b/src/components/bet-card.tsx
@@ -29,15 +29,15 @@ function mapError(message: string) {
     case "saldo_insuficiente":
       return "Saldo insuficiente.";
     case "aposta_ja_registrada":
-      return "Voce ja apostou nesta rodada.";
+      return "Você já apostou nesta rodada.";
     case "bet_not_open":
-      return "A aposta nao esta aberta.";
+      return "A aposta não está aberta.";
     case "bet_closed":
       return "A janela de aposta ja fechou.";
     case "invalid_option":
-      return "Opcao invalida.";
+      return "Opção inválida.";
     case "invalid_amount":
-      return "Valor invalido.";
+      return "Valor inválido.";
     default:
       return message;
   }
@@ -109,7 +109,7 @@ export function BetCard({
   const hasViewerBet = Boolean(bet.viewerPosition);
   const selectedOption = bet.viewerPosition?.optionId ?? draftSelectedOption;
   const selectedOptionLabel =
-    bet.options.find((option) => option.id === selectedOption)?.label ?? "opcao selecionada";
+    bet.options.find((option) => option.id === selectedOption)?.label ?? "opção selecionada";
   const accent = accentColors[index % accentColors.length];
 
   function handlePlace() {
@@ -274,7 +274,7 @@ export function BetCard({
 
       {isOpen ? (
         <p className="mono mt-3 text-[11px] uppercase tracking-[0.14em] text-[var(--color-ink-soft)]">
-          chat: !bet &lt;opcao&gt; &lt;valor&gt; ex.: !bet 1 100
+          chat: !bet &lt;opção&gt; &lt;valor&gt; ex.: !bet 1 100
         </p>
       ) : null}
 
@@ -283,11 +283,11 @@ export function BetCard({
           <p className="font-bold uppercase">Sua posicao</p>
           <p className="mt-1">
             {formatPipetz(bet.viewerPosition.amount)} em{" "}
-            {bet.options.find((option) => option.id === bet.viewerPosition?.optionId)?.label ?? "opcao"}
+            {bet.options.find((option) => option.id === bet.viewerPosition?.optionId)?.label ?? "opção"}
           </p>
           {isOpen && canBet ? (
             <p className="mt-1 text-[var(--color-ink-soft)]">
-              Voce pode adicionar mais pipetz nessa mesma opcao ate a janela fechar.
+              Você pode adicionar mais pipetz nessa mesma opção até a janela fechar.
             </p>
           ) : null}
           {bet.viewerPosition.payoutAmount !== null ? (
@@ -327,7 +327,7 @@ export function BetCard({
 
       {!loggedIn ? (
         <p className="mt-3 text-xs font-bold uppercase tracking-[0.16em] text-[var(--color-ink-soft)]">
-          faca login para apostar
+          faça login para apostar
         </p>
       ) : null}
       {loggedIn && !canBet && !bet.viewerPosition ? (

--- a/src/components/counter-board.tsx
+++ b/src/components/counter-board.tsx
@@ -9,13 +9,13 @@ function scopeHeading(scopeKey: string, scopeLabel: string | null) {
 function actionLabel(action: string | null) {
   switch (action) {
     case "increment":
-      return "ultima acao: incremento";
+      return "última ação: incremento";
     case "decrement":
-      return "ultima acao: decremento";
+      return "última ação: decremento";
     case "reset":
-      return "ultima acao: reset";
+      return "última ação: reset";
     default:
-      return "sem historico recente";
+      return "sem histórico recente";
   }
 }
 
@@ -58,15 +58,15 @@ function CounterCard({ counter }: { counter: StreamerbotCounterSummaryRecord }) 
           <p>
             {counter.lastAction
               ? `atualizado em ${formatDateTime(counter.updatedAt)}`
-              : "ainda sem atualizacao vinda do chat"}
+              : "ainda sem atualização vinda do chat"}
           </p>
           <p>
             {counter.lastResetAt
               ? `ultimo reset em ${formatDateTime(counter.lastResetAt)}`
-              : "ainda nao foi resetado"}
+              : "ainda não foi resetado"}
           </p>
           <p>chave tecnica: {counter.key}</p>
-          <p>origem: {counter.source ?? "manual / nao informado"}</p>
+          <p>origem: {counter.source ?? "manual / não informado"}</p>
         </div>
       </CardContent>
     </Card>

--- a/src/components/game-suggest-form.tsx
+++ b/src/components/game-suggest-form.tsx
@@ -13,11 +13,11 @@ import { formatPipetz } from "@/lib/utils";
 function mapSuggestionError(message: string) {
   switch (message) {
     case "saldo_insuficiente":
-      return `Voce precisa de ${formatPipetz(GAME_SUGGESTION_CREATION_COST)} para criar uma sugestao.`;
+      return `Você precisa de ${formatPipetz(GAME_SUGGESTION_CREATION_COST)} para criar uma sugestão.`;
     case "suggestion_already_exists":
-      return "Esse jogo ja esta na lista aberta.";
+      return "Esse jogo já está na lista aberta.";
     case "invalid_name":
-      return "Escreva um nome valido para o jogo.";
+      return "Escreva um nome válido para o jogo.";
     default:
       return message;
   }
@@ -56,12 +56,12 @@ export function GameSuggestForm({
     }
 
     if (!canSuggest) {
-      setFeedback(loggedIn ? "Sua conta ainda nao esta pronta para sugerir." : "Faca login para sugerir.");
+      setFeedback(loggedIn ? "Sua conta ainda não está pronta para sugerir." : "Faça login para sugerir.");
       return;
     }
 
     if (hasInsufficientBalance) {
-      setFeedback(`Faltam ${formatPipetz(missingBalance)} para criar uma sugestao.`);
+      setFeedback(`Faltam ${formatPipetz(missingBalance)} para criar uma sugestão.`);
       return;
     }
 
@@ -80,13 +80,13 @@ export function GameSuggestForm({
 
       const payload = (await response.json()) as { ok: boolean; error?: string };
       if (!response.ok || !payload.ok) {
-        setFeedback(mapSuggestionError(payload.error ?? "Falha ao enviar sugestao."));
+        setFeedback(mapSuggestionError(payload.error ?? "Falha ao enviar sugestão."));
         return;
       }
 
       setName("");
       setDescription("");
-      setFeedback(`Sugestao enviada. ${formatPipetz(GAME_SUGGESTION_CREATION_COST)} debitados.`);
+      setFeedback(`Sugestão enviada. ${formatPipetz(GAME_SUGGESTION_CREATION_COST)} debitados.`);
       router.refresh();
     });
   }
@@ -108,10 +108,10 @@ export function GameSuggestForm({
               Sugira um jogo
             </h3>
             <p className="mt-2 text-sm text-[var(--color-ink-soft)]">
-              Se tiver algo que voce quer muito me ver jogando, manda aqui.
+              Se tiver algo que você quer muito me ver jogando, manda aqui.
             </p>
             <p className="mt-2 text-xs font-bold uppercase tracking-[0.12em] text-[var(--color-ink-soft)]">
-              cada nova sugestao custa {formatPipetz(GAME_SUGGESTION_CREATION_COST)}. boost continua separado.
+              cada nova sugestão custa {formatPipetz(GAME_SUGGESTION_CREATION_COST)}. boost continua separado.
             </p>
           </div>
           <div className="flex flex-wrap items-center justify-end gap-2">
@@ -152,19 +152,19 @@ export function GameSuggestForm({
           >
             {isPending
               ? "Enviando..."
-              : `Enviar sugestao por ${formatPipetz(GAME_SUGGESTION_CREATION_COST)}`}
+              : `Enviar sugestão por ${formatPipetz(GAME_SUGGESTION_CREATION_COST)}`}
           </Button>
         </div>
 
         {!loggedIn ? (
           <p className="mt-3 text-xs font-bold uppercase tracking-[0.12em] text-[var(--color-ink-soft)]">
-            faca login para sugerir e dar boost
+            faça login para sugerir e dar boost
           </p>
         ) : null}
 
         {loggedIn && hasInsufficientBalance ? (
           <p className="mt-3 text-xs font-bold uppercase tracking-[0.12em] text-[var(--color-ink-soft)]">
-            faltam {formatPipetz(missingBalance)} para liberar uma nova sugestao
+            faltam {formatPipetz(missingBalance)} para liberar uma nova sugestão
           </p>
         ) : null}
 

--- a/src/components/game-suggestion-card.tsx
+++ b/src/components/game-suggestion-card.tsx
@@ -10,7 +10,7 @@ import { formatPipetz } from "@/lib/utils";
 const statusLabels: Record<GameSuggestionWithMeta["status"], string> = {
   open: "Aberta",
   accepted: "Aceita",
-  played: "Ja joguei",
+  played: "Já joguei",
   rejected: "Fechada",
 };
 
@@ -35,9 +35,9 @@ function mapSuggestionError(message: string) {
     case "saldo_insuficiente":
       return "Saldo insuficiente.";
     case "suggestion_not_found":
-      return "Sugestao nao encontrada.";
+      return "Sugestão não encontrada.";
     case "suggestion_not_open":
-      return "So da para dar boost em sugestoes abertas.";
+      return "Só dá para dar boost em sugestões abertas.";
     case "invalid_amount":
       return "Digite um valor inteiro positivo.";
     default:
@@ -72,7 +72,7 @@ export function GameSuggestionCard({
     }
 
     if (!canBoost) {
-      setFeedback(loggedIn ? "Sua conta ainda nao esta pronta para dar boost." : "Faca login para dar boost.");
+      setFeedback(loggedIn ? "Sua conta ainda não está pronta para dar boost." : "Faça login para dar boost.");
       return;
     }
 
@@ -184,7 +184,7 @@ export function GameSuggestionCard({
 
       {!loggedIn ? (
         <p className="mt-3 text-xs font-bold uppercase tracking-[0.12em] text-[var(--color-ink-soft)]">
-          faca login para sugerir e dar boost
+          faça login para sugerir e dar boost
         </p>
       ) : null}
 

--- a/src/components/live-status-panel.tsx
+++ b/src/components/live-status-panel.tsx
@@ -23,21 +23,21 @@ const actionConfig: Record<
 > = {
   force_online: {
     keyword: "ONLINE",
-    label: "Forcar online",
-    pendingLabel: "Forcando online...",
-    successMessage: "Live forcada para online.",
+    label: "Forçar online",
+    pendingLabel: "Forçando online...",
+    successMessage: "Live forçada para online.",
     variant: "success",
   },
   force_offline: {
     keyword: "OFFLINE",
-    label: "Forcar offline",
-    pendingLabel: "Forcando offline...",
-    successMessage: "Live forcada para offline.",
+    label: "Forçar offline",
+    pendingLabel: "Forçando offline...",
+    successMessage: "Live forçada para offline.",
     variant: "danger",
   },
   clear_override: {
     keyword: "AUTO",
-    label: "Voltar ao automatico",
+    label: "Voltar ao automático",
     pendingLabel: "Limpando override...",
     successMessage: "Override manual removido.",
     variant: "neutral",
@@ -163,14 +163,14 @@ export function LiveStatusPanel({
               {status.isLive ? "Live online" : "Live offline"}
             </div>
             <div className="retro-label neutral-chip">
-              {status.source === "manual" ? "Modo manual" : "Modo automatico"}
+              {status.source === "manual" ? "Modo manual" : "Modo automático"}
             </div>
           </div>
         </div>
         <div className="mt-6 grid gap-4 sm:grid-cols-2">
           <div className="card-brutal-static surface-card p-4">
             <p className="mono text-xs uppercase tracking-[0.28em] text-[var(--color-ink-soft)]">
-              Ultimo heartbeat
+              Último heartbeat
             </p>
             <p className="mt-2 text-lg font-bold">{formatDateTime(current?.lastSeenAt)}</p>
           </div>
@@ -188,7 +188,7 @@ export function LiveStatusPanel({
           </p>
           <p className="mt-2 text-sm leading-7 text-[var(--color-ink-soft)]">
             Esse override muda o estado efetivo usado pelos fluxos que dependem da live estar online,
-            mesmo se a deteccao automatica estiver atrasada ou indisponivel.
+            mesmo se a detecção automática estiver atrasada ou indisponível.
           </p>
 
           {status.manualOverride ? (
@@ -210,7 +210,7 @@ export function LiveStatusPanel({
               variant="success"
               size="sm"
             >
-              Forcar online
+              Forçar online
             </Button>
             <Button
               type="button"
@@ -219,7 +219,7 @@ export function LiveStatusPanel({
               variant="danger"
               size="sm"
             >
-              Forcar offline
+              Forçar offline
             </Button>
             <Button
               type="button"
@@ -228,7 +228,7 @@ export function LiveStatusPanel({
               variant="neutral"
               size="sm"
             >
-              Voltar ao automatico
+              Voltar ao automático
             </Button>
           </div>
 

--- a/src/components/quote-overlay-trigger.tsx
+++ b/src/components/quote-overlay-trigger.tsx
@@ -15,15 +15,15 @@ function mapError(message: string) {
     case "saldo_insuficiente":
       return "Saldo insuficiente.";
     case "livestream_not_live":
-      return "Esse overlay so pode ser usado durante a live.";
+      return "Esse overlay só pode ser usado durante a live.";
     case "quote_overlay_busy":
-      return "Ja tem uma quote ocupando o overlay.";
+      return "Já tem uma quote ocupando o overlay.";
     case "quote_not_found":
-      return "Quote nao encontrada.";
+      return "Quote não encontrada.";
     case "quote_id_required":
-      return "Escolha uma quote valida.";
+      return "Escolha uma quote válida.";
     default:
-      return "Nao consegui mostrar a quote no OBS agora.";
+      return "Não consegui mostrar a quote no OBS agora.";
   }
 }
 
@@ -76,7 +76,7 @@ export function QuoteOverlayTrigger({
   if (!loggedIn) {
     return (
       <p className="text-xs font-bold uppercase tracking-[0.16em] text-[var(--color-ink-soft)]">
-        faca login para chamar no OBS
+        faça login para chamar no OBS
       </p>
     );
   }

--- a/src/components/redemption-grid.tsx
+++ b/src/components/redemption-grid.tsx
@@ -41,7 +41,7 @@ export function RedemptionGrid({
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div>
           <p className="mono text-xs uppercase tracking-[0.32em] text-[var(--color-ink-soft)]">
-            Resgates disponiveis
+            Resgates disponíveis
           </p>
           <h2 className="mt-2 text-3xl font-bold uppercase" style={{ fontFamily: "var(--font-display)" }}>
             {expanded ? "Todos os resgates" : "Resgates em destaque"}
@@ -109,7 +109,7 @@ export function RedemptionGrid({
                     }`}
                   >
                     {canAfford
-                      ? "Da pra resgatar!"
+                      ? "Dá pra resgatar!"
                       : `Faltam ${formatPipetz(item.cost - viewerBalance!)} pipetz`}
                   </div>
                 ) : null}

--- a/src/components/viewer-link-card.tsx
+++ b/src/components/viewer-link-card.tsx
@@ -76,12 +76,12 @@ export function ViewerLinkCard({ isLinked }: { isLinked: boolean }) {
       };
 
       if (!response.ok || !payload.ok || !payload.data?.link) {
-        setFeedback(payload.error ?? "Nao foi possivel gerar o codigo.");
+        setFeedback(payload.error ?? "Não foi possível gerar o código.");
         return;
       }
 
       setLink(payload.data.link);
-      setFeedback("Codigo atualizado.");
+      setFeedback("Código atualizado.");
     });
   }
 
@@ -93,18 +93,18 @@ export function ViewerLinkCard({ isLinked }: { isLinked: boolean }) {
             Vinculo da live
           </p>
           <h2 className="mt-3 text-3xl uppercase" style={{ fontFamily: "var(--font-display)" }}>
-            {isLinked ? "Seu canal ja esta vinculado." : "Conecte sua conta do chat."}
+            {isLinked ? "Seu canal já está vinculado." : "Conecte sua conta do chat."}
           </h2>
           <p className="mt-4 max-w-3xl text-sm leading-7 text-[var(--color-ink-soft)] sm:text-base">
-            O login entra no site, mas o viewer da live agora e confirmado pelo chat do YouTube.
-            Gere um codigo curto e envie <span className="font-black">!link CODIGO</span> no chat
-            para provar que essa conta tambem e sua.
+            O login entra no site, mas o viewer da live agora é confirmado pelo chat do YouTube.
+            Gere um código curto e envie <span className="font-black">!link CÓDIGO</span> no chat
+            para provar que essa conta também é sua.
           </p>
 
           <div className="mt-6 grid gap-4 lg:grid-cols-[1fr_auto] lg:items-center">
             <div className="card-flat bg-[var(--color-sky)] p-5">
               <p className="mono text-[10px] uppercase tracking-[0.24em] text-[var(--color-ink-soft)]">
-                Codigo atual
+                Código atual
               </p>
               <p className="mt-3 text-4xl font-black tracking-[0.16em]" style={{ fontFamily: "var(--font-display)" }}>
                 {isLoading ? "......" : link?.linkCode ?? "------"}
@@ -112,13 +112,13 @@ export function ViewerLinkCard({ isLinked }: { isLinked: boolean }) {
               <p className="mt-3 text-sm leading-6 text-[var(--color-ink-soft)]">
                 {link
                   ? `Expira em ${formatExpiry(link.expiresAt)}.`
-                  : "Gere um codigo novo para fazer o vinculo pelo chat."}
+                  : "Gere um código novo para fazer o vínculo pelo chat."}
               </p>
             </div>
 
             <div className="flex flex-col gap-3">
               <Button type="button" onClick={generateCode} disabled={isPending} className="justify-center">
-                {isPending ? "Gerando..." : link ? "Gerar novo codigo" : "Gerar codigo"}
+                {isPending ? "Gerando..." : link ? "Gerar novo código" : "Gerar código"}
               </Button>
               {feedback ? (
                 <p className="text-sm font-bold text-[var(--color-ink-soft)]" aria-live="polite">
@@ -130,10 +130,10 @@ export function ViewerLinkCard({ isLinked }: { isLinked: boolean }) {
 
           <div className="mt-6 grid gap-3 text-sm text-[var(--color-ink-soft)] sm:grid-cols-3">
             <div className="card-flat bg-[var(--color-mint)] p-4">
-              1. Entre no site com o login que voce preferir.
+              1. Entre no site com o login que você preferir.
             </div>
             <div className="card-flat bg-[var(--color-yellow)] p-4">
-              2. Gere o codigo e mande <span className="font-black">!link CODIGO</span> no chat.
+              2. Gere o código e mande <span className="font-black">!link CÓDIGO</span> no chat.
             </div>
             <div className="card-flat bg-[var(--color-pink)] p-4">
               3. O bot vincula seu viewer e seu saldo passa a seguir esse canal.


### PR DESCRIPTION
## Resumo
- corrige acentuação em textos visíveis ao usuário nas páginas públicas, área logada e painéis admin
- ajusta mensagens retornadas por rotas usadas pela web e pelo Streamer.bot para manter a convenção em português BR
- revisa a documentação em português no README e no guia de Cross-Account Protection

## Por que isso mudou
A issue #63 pediu uma auditoria ampla de acentuação e UTF-8 porque já havia sinais anteriores de mojibake e cópia inconsistente em português. Este PR padroniza a escrita para português BR acentuado e elimina ocorrências restantes nas áreas auditadas.

## Impacto
- páginas principais deixam de exibir termos sem acento ou com caracteres incorretos
- mensagens de feedback no app, admin e integrações de chat ficam mais legíveis e consistentes
- documentação em português fica alinhada com a mesma convenção textual

## Validação
- `npm.cmd run lint`
- `npm.cmd run test` (falhou em uma suíte já existente de `src/lib/db/repository.test.ts`, com `TypeError: rows.map is not a function` em `listStreamerbotCounters`, sem relação com as mudanças textuais deste PR)

Closes #63