### PR TITLE
Add admin active game config for death counters

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,5 +1,6 @@
 import { AdminObsOverlaysPanel } from "@/components/admin-obs-overlays-panel";
 import { AdminBetsPanel } from "@/components/admin-bets-panel";
+import { DeathCounterGamePanel } from "@/components/death-counter-game-panel";
 import { AdminGameSuggestionsPanel } from "@/components/admin-game-suggestions-panel";
 import { AdminRecommendationsPanel } from "@/components/admin-recommendations-panel";
 import { AdminViewerLinksPanel } from "@/components/admin-viewer-links-panel";
@@ -18,6 +19,7 @@ import {
   listAdminRedemptions,
 } from "@/lib/db/repository";
 import { getStreamerbotLivestreamStatus } from "@/lib/streamerbot/live-status";
+import { getActiveDeathCounterGame } from "@/lib/streamerbot/death-counter-game";
 import { formatDateTime, formatPipetz } from "@/lib/utils";
 
 const statusColorMap: Record<string, string> = {
@@ -30,11 +32,12 @@ const statusColorMap: Record<string, string> = {
 
 export default async function AdminPage() {
   await requireAdminSession();
-  const [catalog, leaderboard, bridge, liveStatus, redemptions, bets, suggestions, recommendations, viewers] = await Promise.all([
+  const [catalog, leaderboard, bridge, liveStatus, activeDeathCounterGame, redemptions, bets, suggestions, recommendations, viewers] = await Promise.all([
     getCatalog(),
     getLeaderboard(),
     getBridgeStatus(),
     getStreamerbotLivestreamStatus(),
+    getActiveDeathCounterGame(),
     listAdminRedemptions(),
     listAdminBets(),
     listAdminGameSuggestions(),
@@ -60,7 +63,10 @@ export default async function AdminPage() {
 
       <section className="landing-plane landing-divider bg-[var(--color-paper-pink)] py-8 sm:py-10">
         <div className="mx-auto grid w-full max-w-[1500px] gap-6 px-4 sm:px-6 lg:grid-cols-[0.95fr_1.05fr] lg:px-10">
-          <LiveStatusPanel bridge={bridge} initialStatus={liveStatus} />
+          <div className="space-y-6">
+            <LiveStatusPanel bridge={bridge} initialStatus={liveStatus} />
+            <DeathCounterGamePanel initialGame={activeDeathCounterGame} />
+          </div>
           <div className="panel surface-section p-6">
             <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
               Fila recente

--- a/src/app/api/admin/death-counter-game/route.test.ts
+++ b/src/app/api/admin/death-counter-game/route.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const requireAdminApiSessionMock = vi.hoisted(() => vi.fn());
+const isTrustedAppMutationRequestMock = vi.hoisted(() => vi.fn());
+const setActiveDeathCounterGameMock = vi.hoisted(() => vi.fn());
+const clearActiveDeathCounterGameMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/api", () => ({
+  fail: (message: string, status = 400) =>
+    Response.json({ ok: false, error: message }, { status }),
+  ok: (data: unknown, init?: ResponseInit) =>
+    Response.json({ ok: true, data }, init),
+  isTrustedAppMutationRequest: isTrustedAppMutationRequestMock,
+  requireAdminApiSession: requireAdminApiSessionMock,
+}));
+
+vi.mock("@/lib/streamerbot/death-counter-game", () => ({
+  setActiveDeathCounterGame: setActiveDeathCounterGameMock,
+  clearActiveDeathCounterGame: clearActiveDeathCounterGameMock,
+}));
+
+describe("admin death counter game route", () => {
+  beforeEach(() => {
+    isTrustedAppMutationRequestMock.mockReset();
+    requireAdminApiSessionMock.mockReset();
+    setActiveDeathCounterGameMock.mockReset();
+    clearActiveDeathCounterGameMock.mockReset();
+
+    isTrustedAppMutationRequestMock.mockReturnValue(true);
+    requireAdminApiSessionMock.mockResolvedValue({
+      user: {
+        email: "admin@example.com",
+      },
+    });
+  });
+
+  it("returns the schema guidance when the active game cannot be persisted", async () => {
+    setActiveDeathCounterGameMock.mockRejectedValue(
+      new Error("Schema dos contadores ainda nao foi aplicado. Rode npm run db:push."),
+    );
+
+    const { POST } = await import("@/app/api/admin/death-counter-game/route");
+    const response = await POST(
+      new Request("https://example.test/api/admin/death-counter-game", {
+        method: "POST",
+        headers: {
+          origin: "https://example.test",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          action: "set",
+          gameName: "Silksong",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: "Schema dos contadores ainda nao foi aplicado. Rode npm run db:push.",
+    });
+  });
+});

--- a/src/app/api/admin/death-counter-game/route.ts
+++ b/src/app/api/admin/death-counter-game/route.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+import { fail, isTrustedAppMutationRequest, ok, requireAdminApiSession } from "@/lib/api";
+import {
+  clearActiveDeathCounterGame,
+  setActiveDeathCounterGame,
+} from "@/lib/streamerbot/death-counter-game";
+
+const deathCounterGameActionSchema = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("set"),
+    gameName: z.string().trim().min(1, "Digite o nome do jogo."),
+  }),
+  z.object({
+    action: z.literal("clear"),
+  }),
+]);
+
+export async function POST(request: Request) {
+  if (!isTrustedAppMutationRequest(request)) {
+    return fail("Forbidden", 403);
+  }
+
+  const session = await requireAdminApiSession();
+  if (!session) {
+    return fail("Forbidden", 403);
+  }
+
+  try {
+    const json = await request.json();
+    const parsed = deathCounterGameActionSchema.safeParse(json);
+    if (!parsed.success) {
+      return fail(parsed.error.issues[0]?.message ?? "Payload invalido.", 400);
+    }
+
+    const updatedBy = session.user?.email?.toLowerCase() ?? null;
+    const data =
+      parsed.data.action === "set"
+        ? await setActiveDeathCounterGame({
+            gameName: parsed.data.gameName,
+            updatedBy,
+          })
+        : await clearActiveDeathCounterGame();
+
+    return ok(data);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return fail("Payload invalido.", 400);
+    }
+
+    return fail(error instanceof Error ? error.message : "Falha ao atualizar o jogo ativo.", 400);
+  }
+}

--- a/src/app/api/internal/streamerbot/deaths/route.ts
+++ b/src/app/api/internal/streamerbot/deaths/route.ts
@@ -50,8 +50,8 @@ export async function POST(request: Request) {
 
     console.info("[streamerbot/deaths] Processed command.", {
       action: payload.action,
-      scopeType: payload.scopeType,
-      scopeKey: payload.scopeKey ?? "global",
+      scopeType: result.counter.scopeType,
+      scopeKey: result.counter.scopeKey ?? "global",
       amount: payload.amount,
       requestedBy: payload.requestedBy,
       count: result.count,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -109,7 +109,7 @@ function ViewerLinkingNotice({ issueUrl }: { issueUrl: string }) {
           rel="noreferrer"
           className="btn-brutal bg-[var(--color-paper)] px-4 py-2 text-xs text-[var(--color-ink)]"
         >
-          Abrir issue no GitHub ->
+          Abrir issue no GitHub {"->"}
         </a>
       </div>
     </div>
@@ -464,7 +464,7 @@ function RankingHeroCard({
 
       <div className="mt-6 flex flex-wrap items-center gap-3">
         <Link href="/ranking" className="btn-brutal ink-button px-5 py-3 text-xs">
-          Ver ranking ->
+          Ver ranking {"->"}
         </Link>
         {typeof viewerRank === "number" && viewerRank > 0 ? (
           <span className="mono text-[11px] uppercase tracking-[0.24em] text-[var(--color-ink-soft)]">
@@ -722,17 +722,17 @@ export default async function Home({ searchParams }: HomePageProps) {
               {hasUsableSession ? (
                 <>
                   <Link href="/apostas" className="btn-brutal accent-button px-6 py-3 text-sm">
-                    Ir para apostas ->
+                    Ir para apostas {"->"}
                   </Link>
                   <Link href="/ranking" className="btn-brutal ink-button px-6 py-3 text-sm">
-                    Ver ranking ->
+                    Ver ranking {"->"}
                   </Link>
                 </>
               ) : (
                 <>
                   <AuthButtons />
                   <Link href="/ranking" className="btn-brutal accent-button px-6 py-3 text-sm">
-                    Ver ranking ->
+                    Ver ranking {"->"}
                   </Link>
                 </>
               )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -109,7 +109,7 @@ function ViewerLinkingNotice({ issueUrl }: { issueUrl: string }) {
           rel="noreferrer"
           className="btn-brutal bg-[var(--color-paper)] px-4 py-2 text-xs text-[var(--color-ink)]"
         >
-          Abrir issue no GitHub ÃƒÂ¢Ã¢â‚¬Â Ã¢â‚¬â„¢
+          Abrir issue no GitHub ->
         </a>
       </div>
     </div>
@@ -415,7 +415,7 @@ function FeatureShowcase({
               href={loggedIn ? "/apostas" : "/jogos"}
               className="btn-brutal accent-button px-5 py-3 text-xs"
             >
-              {loggedIn ? "Entrar em apostas â†—" : "Explorar a comunidade â†—"}
+              {loggedIn ? "Entrar em apostas ->" : "Explorar a comunidade ->"}
             </Link>
           </div>
         </div>
@@ -464,7 +464,7 @@ function RankingHeroCard({
 
       <div className="mt-6 flex flex-wrap items-center gap-3">
         <Link href="/ranking" className="btn-brutal ink-button px-5 py-3 text-xs">
-          Ver ranking completo â†’
+          Ver ranking ->
         </Link>
         {typeof viewerRank === "number" && viewerRank > 0 ? (
           <span className="mono text-[11px] uppercase tracking-[0.24em] text-[var(--color-ink-soft)]">
@@ -507,7 +507,7 @@ function LiveSpotlight({ activeBet, loggedIn = false }: SpotlightProps) {
 
             <div className="mt-6">
               <Link href="/apostas" className="btn-brutal accent-button px-5 py-3 text-xs">
-                {loggedIn ? "Ir para apostas â†—" : "Ver apostas da live â†—"}
+                {loggedIn ? "Ir para apostas ->" : "Ver apostas da live ->"}
               </Link>
             </div>
           </div>
@@ -614,21 +614,21 @@ export default async function Home({ searchParams }: HomePageProps) {
 
   const features: FeatureCard[] = [
     {
-      symbol: "âš¡",
+      symbol: "++",
       eyebrow: "assistindo a live",
       title: "Ganhe assistindo",
       body: "Enquanto voce assiste a minha live, seus pipetz vao acumulando para apostar, resgatar e entrar no ranking.",
       bg: "bg-[var(--color-blue)]",
     },
     {
-      symbol: "â–£",
+      symbol: "$$",
       eyebrow: "palpite do chat",
       title: "Aposte ao vivo",
       body: "Quando eu abrir uma aposta, escolhe seu lado e vem ver se o chat me conhece mesmo.",
       bg: "bg-[var(--color-purple)]",
     },
     {
-      symbol: "â†—",
+      symbol: "->",
       eyebrow: "bagunca organizada",
       title: "Acione resgates",
       body: "Se quiser me trollar com carinho, os resgates viram efeitos e caos ao vivo na stream.",
@@ -647,7 +647,7 @@ export default async function Home({ searchParams }: HomePageProps) {
     <>
       Oi, eu sou a ludylops.{" "}
       <span className="inline-block border-[3px] border-[var(--color-ink)] bg-[var(--color-pink)] px-3 py-1 shadow-[4px_4px_0_#000]">
-        Bem-vindos Ã  minha live.
+        Bem-vindos a minha live.
       </span>
     </>
   );
@@ -722,17 +722,17 @@ export default async function Home({ searchParams }: HomePageProps) {
               {hasUsableSession ? (
                 <>
                   <Link href="/apostas" className="btn-brutal accent-button px-6 py-3 text-sm">
-                    Ir para apostas â†—
+                    Ir para apostas ->
                   </Link>
                   <Link href="/ranking" className="btn-brutal ink-button px-6 py-3 text-sm">
-                    Ver ranking â†’
+                    Ver ranking ->
                   </Link>
                 </>
               ) : (
                 <>
                   <AuthButtons />
                   <Link href="/ranking" className="btn-brutal accent-button px-6 py-3 text-sm">
-                    Ver ranking â†’
+                    Ver ranking ->
                   </Link>
                 </>
               )}

--- a/src/components/counter-board.tsx
+++ b/src/components/counter-board.tsx
@@ -1,22 +1,9 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import type { StreamerbotCounterSummaryRecord } from "@/lib/types";
-import { formatDateTime, formatPipetz } from "@/lib/utils";
+import { formatPipetz } from "@/lib/utils";
 
 function scopeHeading(scopeKey: string, scopeLabel: string | null) {
   return scopeLabel ?? scopeKey.replace(/[_-]+/g, " ");
-}
-
-function actionLabel(action: string | null) {
-  switch (action) {
-    case "increment":
-      return "ultima acao: incremento";
-    case "decrement":
-      return "ultima acao: decremento";
-    case "reset":
-      return "ultima acao: reset";
-    default:
-      return "sem historico recente";
-  }
 }
 
 function CounterCard({ counter }: { counter: StreamerbotCounterSummaryRecord }) {
@@ -24,10 +11,6 @@ function CounterCard({ counter }: { counter: StreamerbotCounterSummaryRecord }) 
     counter.scopeType === "global"
       ? "escopo global"
       : `jogo: ${scopeHeading(counter.scopeKey, counter.scopeLabel)}`;
-  const amountNote =
-    counter.lastAction === "increment" || counter.lastAction === "decrement"
-      ? ` . ajuste ${counter.lastAmount ?? 0}`
-      : "";
 
   return (
     <Card variant="poster" className="h-full bg-[var(--color-paper)] p-5">
@@ -51,22 +34,6 @@ function CounterCard({ counter }: { counter: StreamerbotCounterSummaryRecord }) 
           >
             {formatPipetz(counter.value)}
           </span>
-        </div>
-
-        <div className="mt-5 space-y-2 text-sm leading-6 text-[var(--color-ink-soft)]">
-          <p>{actionLabel(counter.lastAction)}{amountNote}</p>
-          <p>
-            {counter.lastAction
-              ? `atualizado em ${formatDateTime(counter.updatedAt)}`
-              : "ainda sem atualizacao vinda do chat"}
-          </p>
-          <p>
-            {counter.lastResetAt
-              ? `ultimo reset em ${formatDateTime(counter.lastResetAt)}`
-              : "ainda nao foi resetado"}
-          </p>
-          <p>chave tecnica: {counter.key}</p>
-          <p>origem: {counter.source ?? "manual / nao informado"}</p>
         </div>
       </CardContent>
     </Card>

--- a/src/components/death-counter-game-panel.tsx
+++ b/src/components/death-counter-game-panel.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { ActiveDeathCounterGameRecord } from "@/lib/types";
+import { formatDateTime } from "@/lib/utils";
+
+export function DeathCounterGamePanel({
+  initialGame,
+}: {
+  initialGame: ActiveDeathCounterGameRecord | null;
+}) {
+  const router = useRouter();
+  const [activeGame, setActiveGame] = useState(initialGame);
+  const [gameName, setGameName] = useState(initialGame?.scopeLabel ?? "");
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function saveGame() {
+    const nextName = gameName.trim();
+    if (!nextName) {
+      setFeedback("Digite o nome do jogo atual.");
+      return;
+    }
+
+    setFeedback(null);
+    startTransition(async () => {
+      try {
+        const response = await fetch("/api/admin/death-counter-game", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            action: "set",
+            gameName: nextName,
+          }),
+        });
+
+        const payload = (await response.json()) as {
+          ok?: boolean;
+          error?: string;
+          data?: ActiveDeathCounterGameRecord | null;
+        };
+
+        if (!response.ok || !payload.ok || !payload.data) {
+          setFeedback(payload.error ?? "Falha ao salvar o jogo ativo.");
+          return;
+        }
+
+        setActiveGame(payload.data);
+        setGameName(payload.data.scopeLabel);
+        setFeedback("Jogo ativo atualizado.");
+        router.refresh();
+      } catch (error) {
+        setFeedback(error instanceof Error ? error.message : "Falha ao salvar o jogo ativo.");
+      }
+    });
+  }
+
+  function clearGame() {
+    setFeedback(null);
+    startTransition(async () => {
+      try {
+        const response = await fetch("/api/admin/death-counter-game", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            action: "clear",
+          }),
+        });
+
+        const payload = (await response.json()) as {
+          ok?: boolean;
+          error?: string;
+          data?: ActiveDeathCounterGameRecord | null;
+        };
+
+        if (!response.ok || !payload.ok) {
+          setFeedback(payload.error ?? "Falha ao limpar o jogo ativo.");
+          return;
+        }
+
+        setActiveGame(null);
+        setGameName("");
+        setFeedback("Jogo ativo removido. O contador voltou ao escopo global.");
+        router.refresh();
+      } catch (error) {
+        setFeedback(error instanceof Error ? error.message : "Falha ao limpar o jogo ativo.");
+      }
+    });
+  }
+
+  return (
+    <div className="panel surface-section p-6">
+      <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
+        Contador de mortes
+      </p>
+      <h2
+        className="mt-2 text-2xl font-bold uppercase"
+        style={{ fontFamily: "var(--font-display)" }}
+      >
+        Jogo ativo
+      </h2>
+      <p className="mt-3 text-sm leading-7 text-[var(--color-ink-soft)]">
+        Os comandos simples do chat, como <span className="font-black text-[var(--color-ink)]">!death+</span>, <span className="font-black text-[var(--color-ink)]">!death-</span> e <span className="font-black text-[var(--color-ink)]">!deaths</span>, vao usar esse jogo quando nenhum escopo for enviado pelo Streamer.bot.
+      </p>
+
+      <div className="mt-5 card-brutal-static surface-card p-4">
+        <p className="mono text-[10px] uppercase tracking-[0.28em] text-[var(--color-ink-soft)]">
+          Estado atual
+        </p>
+        {activeGame ? (
+          <>
+            <p className="mt-2 text-xl font-black uppercase">{activeGame.scopeLabel}</p>
+            <p className="mt-2 text-sm text-[var(--color-ink-soft)]">
+              chave: <span className="font-black text-[var(--color-ink)]">{activeGame.scopeKey}</span>
+            </p>
+            <p className="mt-2 text-sm text-[var(--color-ink-soft)]">
+              atualizado em {formatDateTime(activeGame.updatedAt)}
+              {activeGame.updatedBy ? ` por ${activeGame.updatedBy}` : ""}
+            </p>
+          </>
+        ) : (
+          <p className="mt-2 text-sm font-bold text-[var(--color-ink-soft)]">
+            Nenhum jogo ativo configurado. O contador segue no modo global.
+          </p>
+        )}
+      </div>
+
+      <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-end">
+        <div className="w-full">
+          <label className="mono text-[10px] uppercase tracking-[0.28em] text-[var(--color-ink-soft)]">
+            Nome do jogo
+          </label>
+          <Input
+            value={gameName}
+            onChange={(event) => setGameName(event.target.value)}
+            placeholder="Ex.: Silksong"
+            className="mt-2"
+          />
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button type="button" onClick={saveGame} disabled={isPending} variant="success" size="sm">
+            {isPending ? "Salvando..." : "Salvar jogo"}
+          </Button>
+          <Button
+            type="button"
+            onClick={clearGame}
+            disabled={isPending || !activeGame}
+            variant="neutral"
+            size="sm"
+          >
+            Limpar
+          </Button>
+        </div>
+      </div>
+
+      {feedback ? <div className="retro-label neutral-chip mt-4">{feedback}</div> : null}
+    </div>
+  );
+}

--- a/src/lib/db/repository.test.ts
+++ b/src/lib/db/repository.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getDbMock = vi.hoisted(() => vi.fn());
 const isStreamerbotLivestreamActiveMock = vi.hoisted(() => vi.fn());
+const getActiveDeathCounterGameMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/db/client", () => ({
   getDb: getDbMock,
@@ -38,6 +39,10 @@ vi.mock("@/lib/streamerbot/live-status", () => ({
 
     return true;
   },
+}));
+
+vi.mock("@/lib/streamerbot/death-counter-game", () => ({
+  getActiveDeathCounterGame: getActiveDeathCounterGameMock,
 }));
 
 import { demoBetRecords, demoQuotes } from "@/lib/demo-data";
@@ -85,6 +90,7 @@ import {
   listQuotes,
   registerGoogleRiscDelivery,
   runQuoteCommandFromChat,
+  runDeathCounterCommand,
   runStreamerbotCounterCommand,
   resolveBet,
   setActiveViewerForGoogleAccount,
@@ -627,13 +633,13 @@ function createStreamerbotCounterDb({
       return {
         from(table: unknown) {
           if (table === streamerbotCounters) {
-            return {
+            return Object.assign(rows, {
               where() {
                 return {
                   limit: async () => rows,
                 };
               },
-            };
+            });
           }
 
           throw new Error("Unexpected table in streamerbot counter tx stub.");
@@ -703,6 +709,8 @@ describe("listBets", () => {
   beforeEach(() => {
     getDbMock.mockReset();
     delete (globalThis as typeof globalThis & { __lojaDemoStore?: unknown }).__lojaDemoStore;
+    getActiveDeathCounterGameMock.mockReset();
+    getActiveDeathCounterGameMock.mockResolvedValue(null);
   });
 
   it("falls back to demo bets when the bets table query is unavailable", async () => {
@@ -1365,6 +1373,8 @@ describe("showQuoteOverlayForViewer", () => {
 describe("runStreamerbotCounterCommand", () => {
   beforeEach(() => {
     getDbMock.mockReset();
+    getActiveDeathCounterGameMock.mockReset();
+    getActiveDeathCounterGameMock.mockResolvedValue(null);
     delete (globalThis as typeof globalThis & { __lojaDemoStore?: unknown }).__lojaDemoStore;
   });
 
@@ -1504,13 +1514,6 @@ describe("runStreamerbotCounterCommand", () => {
       value: counter.value,
     }))).toEqual([
       {
-        key: "death_count",
-        label: "mortes",
-        scopeType: "global",
-        scopeKey: "global",
-        value: 0,
-      },
-      {
         key: "win_count",
         label: "vitorias",
         scopeType: "global",
@@ -1638,19 +1641,6 @@ describe("runStreamerbotCounterCommand", () => {
 
     expect(counters).toEqual([
       {
-        key: "death_count",
-        label: "mortes",
-        scopeType: "global",
-        scopeKey: "global",
-        scopeLabel: null,
-        value: 0,
-        lastResetAt: null,
-        updatedAt: new Date(0).toISOString(),
-        lastAction: null,
-        lastAmount: null,
-        source: null,
-      },
-      {
         key: "win_count",
         label: "vitorias",
         scopeType: "game",
@@ -1661,6 +1651,57 @@ describe("runStreamerbotCounterCommand", () => {
         updatedAt: "2026-04-07T11:00:00.000Z",
         lastAction: "increment",
         lastAmount: 2,
+        source: "streamerbot_chat",
+      },
+    ]);
+  });
+
+  it("hides technical counters from the public counter listing", async () => {
+    const { db } = createStreamerbotCounterDb({
+      counterRows: [
+        {
+          key: "livestream_override",
+          value: 1,
+          lastResetAt: null,
+          updatedAt: new Date("2026-04-07T11:00:00.000Z"),
+          metadata: {
+            updatedBy: "admin",
+          },
+        },
+        {
+          key: "death_count",
+          value: 154,
+          lastResetAt: null,
+          updatedAt: new Date("2026-04-07T11:05:00.000Z"),
+          metadata: {
+            counterKey: "death_count",
+            counterLabel: "mortes",
+            scopeType: "game",
+            scopeKey: "silksong",
+            scopeLabel: "Silksong",
+            lastAction: "increment",
+            lastAmount: 1,
+            source: "streamerbot_chat",
+          },
+        },
+      ],
+    });
+    getDbMock.mockReturnValue(db);
+
+    const counters = await listStreamerbotCounters();
+
+    expect(counters).toEqual([
+      {
+        key: "death_count",
+        label: "mortes",
+        scopeType: "game",
+        scopeKey: "silksong",
+        scopeLabel: "Silksong",
+        value: 154,
+        lastResetAt: null,
+        updatedAt: "2026-04-07T11:05:00.000Z",
+        lastAction: "increment",
+        lastAmount: 1,
         source: "streamerbot_chat",
       },
     ]);
@@ -1711,6 +1752,65 @@ describe("runStreamerbotCounterCommand", () => {
       },
     });
     expect(rows[0]?.lastResetAt?.toISOString()).toBe("2026-04-07T12:00:00.000Z");
+  });
+
+  it("routes death commands to the configured active game when no game scope is provided", async () => {
+    const { db, rows } = createStreamerbotCounterDb();
+    getDbMock.mockReturnValue(db);
+    getActiveDeathCounterGameMock.mockResolvedValue({
+      scopeType: "game",
+      scopeKey: "silksong",
+      scopeLabel: "Silksong",
+      updatedAt: "2026-04-07T10:00:00.000Z",
+      updatedBy: "admin@example.com",
+    });
+
+    const result = await runDeathCounterCommand({
+      action: "increment",
+      amount: 3,
+      requestedBy: "Mod",
+    });
+
+    expect(result).toMatchObject({
+      mode: "database",
+      action: "increment",
+      count: 3,
+      replyMessage: "Mod, contador de mortes em Silksong: 3 (+3).",
+    });
+    expect(rows[0]).toMatchObject({
+      key: "game::silksong::death_count",
+      value: 3,
+      metadata: {
+        counterKey: "death_count",
+        counterLabel: "mortes",
+        scopeType: "game",
+        scopeKey: "silksong",
+        scopeLabel: "Silksong",
+      },
+    });
+  });
+
+  it("preserves an explicit game scope even when an active game is configured", async () => {
+    const { db, rows } = createStreamerbotCounterDb();
+    getDbMock.mockReturnValue(db);
+    getActiveDeathCounterGameMock.mockResolvedValue({
+      scopeType: "game",
+      scopeKey: "silksong",
+      scopeLabel: "Silksong",
+      updatedAt: "2026-04-07T10:00:00.000Z",
+      updatedBy: "admin@example.com",
+    });
+
+    const result = await runDeathCounterCommand({
+      action: "increment",
+      scopeType: "game",
+      scopeKey: "hades_2",
+      scopeLabel: "Hades 2",
+      amount: 1,
+    });
+
+    expect(result.replyMessage).toBe("contador de mortes em Hades 2: 1.");
+    expect(rows[0]?.key).toBe("game::hades_2::death_count");
   });
 });
 

--- a/src/lib/db/repository.test.ts
+++ b/src/lib/db/repository.test.ts
@@ -1669,6 +1669,18 @@ describe("runStreamerbotCounterCommand", () => {
           },
         },
         {
+          key: "death_counter_active_game",
+          value: 1,
+          lastResetAt: null,
+          updatedAt: new Date("2026-04-07T11:02:00.000Z"),
+          metadata: {
+            scopeType: "game",
+            scopeKey: "silksong",
+            scopeLabel: "Silksong",
+            updatedBy: "admin@example.com",
+          },
+        },
+        {
           key: "death_count",
           value: 154,
           lastResetAt: null,

--- a/src/lib/db/repository.ts
+++ b/src/lib/db/repository.ts
@@ -55,6 +55,7 @@ import {
   eventRequiresActiveLivestream,
   requireActiveLivestream,
 } from "@/lib/streamerbot/live-status";
+import { getActiveDeathCounterGame } from "@/lib/streamerbot/death-counter-game";
 import { normalizeYoutubeHandle } from "@/lib/youtube/identity";
 import { evaluateRedeemability } from "@/lib/redemptions/service";
 import {
@@ -399,36 +400,12 @@ function buildStreamerbotCounterSummary(counter: StreamerbotCounterRecord): Stre
   };
 }
 
-function ensureDefaultCounterSummaries(
+function sanitizePublicCounterSummaries(
   counters: StreamerbotCounterSummaryRecord[],
 ): StreamerbotCounterSummaryRecord[] {
-  const hasDefaultDeaths = counters.some(
-    (counter) =>
-      counter.key === DEFAULT_DEATH_COUNTER_KEY &&
-      counter.scopeType === GLOBAL_COUNTER_SCOPE_TYPE &&
-      counter.scopeKey === GLOBAL_COUNTER_SCOPE_KEY,
-  );
-
-  const source = hasDefaultDeaths
-    ? counters
-    : [
-        {
-          key: DEFAULT_DEATH_COUNTER_KEY,
-          label: DEFAULT_DEATH_COUNTER_LABEL,
-          scopeType: GLOBAL_COUNTER_SCOPE_TYPE as StreamerbotCounterSummaryRecord["scopeType"],
-          scopeKey: GLOBAL_COUNTER_SCOPE_KEY,
-          scopeLabel: null,
-          value: 0,
-          lastResetAt: null,
-          updatedAt: new Date(0).toISOString(),
-          lastAction: null,
-          lastAmount: null,
-          source: null,
-        },
-        ...counters,
-      ];
-
-  return [...source].sort((left, right) => {
+  return counters
+    .filter((counter) => counter.key !== "livestream_override")
+    .sort((left, right) => {
     if (left.scopeType !== right.scopeType) {
       return left.scopeType === GLOBAL_COUNTER_SCOPE_TYPE ? -1 : 1;
     }
@@ -1936,7 +1913,7 @@ function isMissingCounterSchemaError(error: unknown) {
 
 function listDemoStreamerbotCounters() {
   const store = getDemoStore();
-  return ensureDefaultCounterSummaries(store.streamerbotCounters.map(buildStreamerbotCounterSummary));
+  return sanitizePublicCounterSummaries(store.streamerbotCounters.map(buildStreamerbotCounterSummary));
 }
 
 async function withGoogleAccountById(googleAccountId: string) {
@@ -3274,12 +3251,12 @@ export async function listStreamerbotCounters() {
     rows = await db.select().from(streamerbotCounters);
   } catch (error) {
     if (isMissingCounterSchemaError(error)) {
-      return ensureDefaultCounterSummaries([]);
+      return [];
     }
     throw error;
   }
 
-  return ensureDefaultCounterSummaries(rows.map(serializeStreamerbotCounter).map(buildStreamerbotCounterSummary));
+  return sanitizePublicCounterSummaries(rows.map(serializeStreamerbotCounter).map(buildStreamerbotCounterSummary));
 }
 
 export async function listProductRecommendations(options?: {
@@ -4527,8 +4504,14 @@ export async function runDeathCounterCommand(input: {
   confirmReset?: boolean;
   resetReason?: string | null;
 }) {
+  const hasExplicitGameScope = input.scopeType === "game" && Boolean(input.scopeKey?.trim());
+  const activeGame = hasExplicitGameScope ? null : await getActiveDeathCounterGame();
+
   return runStreamerbotCounterCommand({
     ...input,
+    scopeType: hasExplicitGameScope ? input.scopeType : activeGame?.scopeType ?? input.scopeType,
+    scopeKey: hasExplicitGameScope ? input.scopeKey : activeGame?.scopeKey ?? input.scopeKey,
+    scopeLabel: hasExplicitGameScope ? input.scopeLabel : activeGame?.scopeLabel ?? input.scopeLabel,
     counterKey: DEFAULT_DEATH_COUNTER_KEY,
     counterLabel: DEFAULT_DEATH_COUNTER_LABEL,
   });

--- a/src/lib/db/repository.ts
+++ b/src/lib/db/repository.ts
@@ -403,8 +403,10 @@ function buildStreamerbotCounterSummary(counter: StreamerbotCounterRecord): Stre
 function sanitizePublicCounterSummaries(
   counters: StreamerbotCounterSummaryRecord[],
 ): StreamerbotCounterSummaryRecord[] {
+  const hiddenCounterKeys = new Set(["livestream_override", "death_counter_active_game"]);
+
   return counters
-    .filter((counter) => counter.key !== "livestream_override")
+    .filter((counter) => !hiddenCounterKeys.has(counter.key))
     .sort((left, right) => {
     if (left.scopeType !== right.scopeType) {
       return left.scopeType === GLOBAL_COUNTER_SCOPE_TYPE ? -1 : 1;

--- a/src/lib/streamerbot/death-counter-game.test.ts
+++ b/src/lib/streamerbot/death-counter-game.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getDbMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/db/client", () => ({
+  getDb: getDbMock,
+}));
+
+describe("active death counter game config", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    getDbMock.mockReset();
+    getDbMock.mockReturnValue(null);
+    delete (globalThis as typeof globalThis & {
+      __lojaActiveDeathCounterGame?: unknown;
+    }).__lojaActiveDeathCounterGame;
+  });
+
+  it("stores and clears the active game in demo mode", async () => {
+    const module = await import("@/lib/streamerbot/death-counter-game");
+
+    const saved = await module.setActiveDeathCounterGame({
+      gameName: "Hollow Knight: Silksong",
+      updatedBy: "admin@example.com",
+    });
+
+    expect(saved).toMatchObject({
+      scopeType: "game",
+      scopeKey: "hollow-knight-silksong",
+      scopeLabel: "Hollow Knight: Silksong",
+      updatedBy: "admin@example.com",
+    });
+
+    await expect(module.getActiveDeathCounterGame()).resolves.toMatchObject({
+      scopeKey: "hollow-knight-silksong",
+      scopeLabel: "Hollow Knight: Silksong",
+    });
+
+    await expect(module.clearActiveDeathCounterGame()).resolves.toBeNull();
+    await expect(module.getActiveDeathCounterGame()).resolves.toBeNull();
+  });
+
+  it("reads the active game from streamerbot_counters in database mode", async () => {
+    getDbMock.mockReturnValue({
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            limit: async () => [
+              {
+                updatedAt: new Date("2026-04-21T20:00:00.000Z"),
+                metadata: {
+                  scopeType: "game",
+                  scopeKey: "silksong",
+                  scopeLabel: "Silksong",
+                  updatedBy: "admin@example.com",
+                },
+              },
+            ],
+          }),
+        }),
+      }),
+    });
+
+    const module = await import("@/lib/streamerbot/death-counter-game");
+
+    await expect(module.getActiveDeathCounterGame()).resolves.toEqual({
+      scopeType: "game",
+      scopeKey: "silksong",
+      scopeLabel: "Silksong",
+      updatedAt: "2026-04-21T20:00:00.000Z",
+      updatedBy: "admin@example.com",
+    });
+  });
+});

--- a/src/lib/streamerbot/death-counter-game.ts
+++ b/src/lib/streamerbot/death-counter-game.ts
@@ -1,0 +1,227 @@
+import { eq } from "drizzle-orm";
+
+import { getDb } from "@/lib/db/client";
+import { streamerbotCounters } from "@/lib/db/schema";
+import type { ActiveDeathCounterGameRecord } from "@/lib/types";
+import { slugify } from "@/lib/utils";
+
+const ACTIVE_DEATH_COUNTER_GAME_KEY = "death_counter_active_game";
+
+declare global {
+  var __lojaActiveDeathCounterGame: ActiveDeathCounterGameRecord | null | undefined;
+}
+
+function getDemoActiveDeathCounterGame() {
+  return globalThis.__lojaActiveDeathCounterGame ?? null;
+}
+
+function setDemoActiveDeathCounterGame(config: ActiveDeathCounterGameRecord | null) {
+  globalThis.__lojaActiveDeathCounterGame = config;
+}
+
+function isMissingCounterSchemaError(error: unknown) {
+  const tableNames = ['"streamerbot_counters"', "streamerbot_counters"];
+  const queue: unknown[] = [error];
+  const visited = new Set<unknown>();
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current || visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+
+    const message =
+      current instanceof Error ? current.message : typeof current === "string" ? current : "";
+    const normalized = message.toLowerCase();
+    const mentionsTable = tableNames.some((tableName) => normalized.includes(tableName));
+
+    if (
+      mentionsTable &&
+      (normalized.includes("does not exist") ||
+        normalized.includes("relation") ||
+        normalized.includes("table") ||
+        normalized.includes("failed query"))
+    ) {
+      return true;
+    }
+
+    if (typeof current === "object" && current && "cause" in current) {
+      queue.push((current as { cause?: unknown }).cause);
+    }
+  }
+
+  return false;
+}
+
+function parseActiveDeathCounterGameRow(
+  row:
+    | {
+        updatedAt: Date;
+        metadata: Record<string, unknown>;
+      }
+    | {
+        updatedAt: string;
+        metadata: Record<string, unknown>;
+      },
+): ActiveDeathCounterGameRecord | null {
+  if (row.metadata.scopeType !== "game") {
+    return null;
+  }
+
+  const scopeKey =
+    typeof row.metadata.scopeKey === "string" ? row.metadata.scopeKey.trim().toLowerCase() : "";
+  const scopeLabel =
+    typeof row.metadata.scopeLabel === "string" ? row.metadata.scopeLabel.trim() : "";
+
+  if (!scopeKey || !scopeLabel) {
+    return null;
+  }
+
+  const metadataUpdatedAt = row.metadata.updatedAt;
+  const updatedAt =
+    typeof metadataUpdatedAt === "string"
+      ? metadataUpdatedAt
+      : typeof row.updatedAt === "string"
+        ? row.updatedAt
+        : row.updatedAt.toISOString();
+
+  return {
+    scopeType: "game",
+    scopeKey,
+    scopeLabel,
+    updatedAt,
+    updatedBy:
+      typeof row.metadata.updatedBy === "string" ? row.metadata.updatedBy : null,
+  };
+}
+
+function normalizeGameName(gameName: string) {
+  const scopeLabel = gameName.trim();
+  const scopeKey = slugify(scopeLabel);
+
+  if (!scopeLabel || !scopeKey) {
+    throw new Error("Nome do jogo invalido.");
+  }
+
+  return { scopeKey, scopeLabel };
+}
+
+export async function getActiveDeathCounterGame(): Promise<ActiveDeathCounterGameRecord | null> {
+  const db = getDb();
+  if (!db) {
+    return getDemoActiveDeathCounterGame();
+  }
+
+  let row:
+    | {
+        updatedAt: Date;
+        metadata: unknown;
+      }
+    | undefined;
+
+  try {
+    [row] = await db
+      .select({
+        updatedAt: streamerbotCounters.updatedAt,
+        metadata: streamerbotCounters.metadata,
+      })
+      .from(streamerbotCounters)
+      .where(eq(streamerbotCounters.key, ACTIVE_DEATH_COUNTER_GAME_KEY))
+      .limit(1);
+  } catch (error) {
+    if (isMissingCounterSchemaError(error)) {
+      return null;
+    }
+    throw error;
+  }
+
+  if (!row) {
+    return null;
+  }
+
+  return parseActiveDeathCounterGameRow({
+    updatedAt: row.updatedAt,
+    metadata: row.metadata as Record<string, unknown>,
+  });
+}
+
+export async function setActiveDeathCounterGame(input: {
+  gameName: string;
+  updatedBy?: string | null;
+}) {
+  const config = normalizeGameName(input.gameName);
+  const nextConfig: ActiveDeathCounterGameRecord = {
+    scopeType: "game",
+    scopeKey: config.scopeKey,
+    scopeLabel: config.scopeLabel,
+    updatedAt: new Date().toISOString(),
+    updatedBy: input.updatedBy ?? null,
+  };
+  const db = getDb();
+
+  if (!db) {
+    setDemoActiveDeathCounterGame(nextConfig);
+    return nextConfig;
+  }
+
+  try {
+    await db
+      .insert(streamerbotCounters)
+      .values({
+        key: ACTIVE_DEATH_COUNTER_GAME_KEY,
+        value: 1,
+        lastResetAt: null,
+        updatedAt: new Date(nextConfig.updatedAt),
+        metadata: {
+          scopeType: nextConfig.scopeType,
+          scopeKey: nextConfig.scopeKey,
+          scopeLabel: nextConfig.scopeLabel,
+          updatedAt: nextConfig.updatedAt,
+          updatedBy: nextConfig.updatedBy,
+        },
+      })
+      .onConflictDoUpdate({
+        target: streamerbotCounters.key,
+        set: {
+          value: 1,
+          updatedAt: new Date(nextConfig.updatedAt),
+          metadata: {
+            scopeType: nextConfig.scopeType,
+            scopeKey: nextConfig.scopeKey,
+            scopeLabel: nextConfig.scopeLabel,
+            updatedAt: nextConfig.updatedAt,
+            updatedBy: nextConfig.updatedBy,
+          },
+        },
+      });
+  } catch (error) {
+    if (isMissingCounterSchemaError(error)) {
+      throw new Error("Schema dos contadores ainda nao foi aplicado. Rode npm run db:push.");
+    }
+    throw error;
+  }
+
+  return nextConfig;
+}
+
+export async function clearActiveDeathCounterGame() {
+  const db = getDb();
+  if (!db) {
+    setDemoActiveDeathCounterGame(null);
+    return null;
+  }
+
+  try {
+    await db
+      .delete(streamerbotCounters)
+      .where(eq(streamerbotCounters.key, ACTIVE_DEATH_COUNTER_GAME_KEY));
+  } catch (error) {
+    if (isMissingCounterSchemaError(error)) {
+      throw new Error("Schema dos contadores ainda nao foi aplicado. Rode npm run db:push.");
+    }
+    throw error;
+  }
+
+  return null;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -264,6 +264,14 @@ export interface LivestreamManualOverrideRecord {
   updatedBy: string | null;
 }
 
+export interface ActiveDeathCounterGameRecord {
+  scopeType: "game";
+  scopeKey: string;
+  scopeLabel: string;
+  updatedAt: string;
+  updatedBy: string | null;
+}
+
 export interface LivestreamStatusRecord {
   isLive: boolean;
   source: "automatic" | "manual";


### PR DESCRIPTION
## Summary
- add an admin control to set or clear the active game used by chat death-counter commands
- route `!death+`, `!death-`, and `!deaths` to the configured active game in the backend when no explicit scope is provided
- remove the synthetic public death-counter fallback, hide `livestream_override` from the public counter board, and simplify the counter cards

## Testing
- `npm.cmd run test -- src/lib/db/repository.test.ts src/lib/streamerbot/death-counter-game.test.ts src/app/api/admin/death-counter-game/route.test.ts`

Closes #67