### PR TITLE
feat: polish dark mode and public pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,13 @@
-<!-- BEGIN:nextjs-agent-rules -->
+﻿<!-- BEGIN:nextjs-agent-rules -->
 # This is NOT the Next.js you know
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
 <!-- END:nextjs-agent-rules -->
+
+## Encoding Safety
+
+- Avoid round-tripping UTF-8 source files through PowerShell `Get-Content` / `Set-Content`, especially for `.ts`, `.tsx`, `.md`, and Portuguese copy with accents. On this machine that can turn `você` into `vocÃª` and `à` into `Ã `.
+- Prefer `apply_patch` for manual edits. For scripted rewrites, use .NET file APIs with explicit UTF-8 read/write settings instead of `Get-Content` / `Set-Content`.
 
 # GitHub PR Linking
 

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ Assinatura:
 - HMAC SHA-256 de `timestamp.body`
 - Secret: `STREAMERBOT_SHARED_SECRET`
 
-Payload recomendado para `!pontos`, `!saldo` ou `!pipetz`:
+Payload recomendado para `!pontos`, `!saldo`, `!pipetz` ou `!points`:
 
 ```json
 {
@@ -434,7 +434,7 @@ Notas:
 2. Crie um comando do YouTube com regex:
 
 ```regex
-^!(?:pontos|saldo|pipetz)$
+^!(?:pontos|saldo|pipetz|points)$
 ```
 
 3. Na action desse comando, adicione `Core > C# > Execute C# Code`.

--- a/src/app/(public)/apostas/page.tsx
+++ b/src/app/(public)/apostas/page.tsx
@@ -1,4 +1,4 @@
-import { auth } from "@/auth";
+﻿import { auth } from "@/auth";
 import { BetList } from "@/components/bet-list";
 import { getViewerDashboard, listBets } from "@/lib/db/repository";
 
@@ -14,16 +14,13 @@ export default async function ApostasPage() {
   const canBet = Boolean(activeViewerId && dashboard?.viewer.isLinked);
 
   return (
-    <div className="flex w-full flex-col pb-20 pt-8">
+    <div className="flex w-full flex-col pb-20">
       <section className="landing-plane surface-hero relative overflow-hidden py-8 sm:py-10">
         <div className="bg-dots-light pointer-events-none absolute inset-0 opacity-20" />
-        <div className="relative mx-auto flex w-full max-w-[1500px] items-start justify-between gap-4 px-4 sm:px-6 lg:px-10">
+        <div className="relative mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
           <div>
-            <p className="mono text-xs font-bold uppercase tracking-[0.32em] text-[var(--color-ink-soft)]">
-              🎲 Apostas
-            </p>
             <h1
-              className="mt-3 text-4xl uppercase sm:text-6xl lg:text-7xl"
+              className="text-4xl uppercase sm:text-6xl lg:text-7xl"
               style={{ fontFamily: "var(--font-display)" }}
             >
               Aposte pipetz nos desafios da live.
@@ -31,9 +28,6 @@ export default async function ApostasPage() {
             <p className="mt-4 max-w-3xl text-sm leading-7 text-[var(--color-ink-soft)] sm:text-base">
               Escolha um lado, coloque seus pipetz e torça. Se acertar, leva uma parte do pool!
             </p>
-          </div>
-          <div className="sticker sticker-tilt-right hidden accent-chip-strong px-4 py-2 text-sm sm:inline-flex">
-            🔥 Ao vivo
           </div>
         </div>
       </section>
@@ -64,3 +58,4 @@ export default async function ApostasPage() {
     </div>
   );
 }
+

--- a/src/app/(public)/contadores/page.tsx
+++ b/src/app/(public)/contadores/page.tsx
@@ -3,68 +3,21 @@ import { listStreamerbotCounters } from "@/lib/db/repository";
 
 export default async function ContadoresPage() {
   const counters = await listStreamerbotCounters();
-  const gameScopeCount = new Set(
-    counters.filter((counter) => counter.scopeType === "game").map((counter) => counter.scopeKey),
-  ).size;
 
   return (
-    <div className="flex w-full flex-col pb-20 pt-8">
+    <div className="flex w-full flex-col pb-20">
       <section className="landing-plane surface-hero relative overflow-hidden py-8 sm:py-10">
         <div className="bg-dots-light pointer-events-none absolute inset-0 opacity-15" />
-        <div className="relative mx-auto flex w-full max-w-[1500px] items-start justify-between gap-4 px-4 sm:px-6 lg:px-10">
+        <div className="relative mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
           <div>
-            <p className="mono text-xs font-bold uppercase tracking-[0.32em] text-[var(--color-ink-soft)]">
-              stream state
-            </p>
             <h1
-              className="mt-3 text-4xl uppercase sm:text-6xl lg:text-7xl"
+              className="text-4xl uppercase sm:text-6xl lg:text-7xl"
               style={{ fontFamily: "var(--font-display)" }}
             >
               Contadores da live.
             </h1>
             <p className="mt-4 max-w-3xl text-sm leading-7 text-[var(--color-ink-soft)] sm:text-base">
               Aqui ficam os totais globais e os contadores por jogo que o chat e o Streamer.bot estao mexendo ao vivo.
-            </p>
-          </div>
-          <div className="sticker hidden accent-chip-strong px-4 py-2 text-sm sm:inline-flex">
-            {counters.length} contadores
-          </div>
-        </div>
-      </section>
-
-      <section className="landing-plane landing-divider bg-[var(--color-sky)] py-8 sm:py-10">
-        <div className="mx-auto grid w-full max-w-[1500px] gap-4 px-4 sm:px-6 lg:grid-cols-3 lg:px-10">
-          <div className="card-poster bg-[var(--color-yellow)] p-5">
-            <p className="mono text-[10px] uppercase tracking-[0.28em] text-[var(--color-ink-soft)]">
-              total monitorado
-            </p>
-            <p
-              className="mt-3 text-4xl uppercase leading-none"
-              style={{ fontFamily: "var(--font-display)" }}
-            >
-              {counters.length}
-            </p>
-          </div>
-          <div className="card-poster bg-[var(--color-blue)] p-5">
-            <p className="mono text-[10px] uppercase tracking-[0.28em] text-[var(--color-ink-soft)]">
-              escopos globais
-            </p>
-            <p
-              className="mt-3 text-4xl uppercase leading-none"
-              style={{ fontFamily: "var(--font-display)" }}
-            >
-              {counters.filter((counter) => counter.scopeType === "global").length}
-            </p>
-          </div>
-          <div className="card-poster bg-[var(--color-pink)] p-5">
-            <p className="mono text-[10px] uppercase tracking-[0.28em] text-[var(--color-ink-soft)]">
-              jogos com contador
-            </p>
-            <p
-              className="mt-3 text-4xl uppercase leading-none"
-              style={{ fontFamily: "var(--font-display)" }}
-            >
-              {gameScopeCount}
             </p>
           </div>
         </div>

--- a/src/app/(public)/jogos/page.tsx
+++ b/src/app/(public)/jogos/page.tsx
@@ -15,10 +15,10 @@ export default async function JogosPage() {
   const canInteract = Boolean(activeViewerId);
 
   return (
-    <div className="flex w-full flex-col pb-20 pt-8">
+    <div className="flex w-full flex-col pb-20">
       <section className="landing-plane surface-hero relative overflow-hidden py-8 sm:py-10">
         <div className="bg-dots-light pointer-events-none absolute inset-0 opacity-20" />
-        <div className="relative mx-auto flex w-full max-w-[1500px] items-start justify-between gap-4 px-4 sm:px-6 lg:px-10">
+        <div className="relative mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
           <div>
             <p className="mono text-xs font-bold uppercase tracking-[0.32em] text-[var(--color-ink-soft)]">
               Sugestoes de jogos
@@ -32,9 +32,6 @@ export default async function JogosPage() {
             <p className="mt-4 max-w-3xl text-sm leading-7 text-[var(--color-ink-soft)] sm:text-base">
               Sugere um jogo e, se quiser empurrar sua ideia, gasta pipetz pra dar boost nela.
             </p>
-          </div>
-          <div className="sticker hidden accent-chip-strong px-4 py-2 text-sm sm:inline-flex">
-            boost real
           </div>
         </div>
       </section>

--- a/src/app/(public)/quotes/page.tsx
+++ b/src/app/(public)/quotes/page.tsx
@@ -1,4 +1,4 @@
-import { auth } from "@/auth";
+﻿import { auth } from "@/auth";
 import { QuoteOverlayTrigger } from "@/components/quote-overlay-trigger";
 import {
   Card,
@@ -9,7 +9,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { getViewerDashboard, listQuotes } from "@/lib/db/repository";
-import { formatDateTime, formatPipetz } from "@/lib/utils";
+import { cn, formatDateTime, formatPipetz } from "@/lib/utils";
 
 const quoteCardBackgrounds = [
   "bg-[var(--color-paper)]",
@@ -17,6 +17,12 @@ const quoteCardBackgrounds = [
   "bg-[var(--color-blue)]",
   "bg-[var(--color-mint)]",
 ];
+
+function usesPastelQuoteBackground(bgClass: string) {
+  return ["--color-blue", "--color-pink", "--color-purple", "--color-yellow", "--color-mint"].some((token) =>
+    bgClass.includes(token),
+  );
+}
 
 export default async function QuotesPage() {
   const session = await auth();
@@ -28,10 +34,10 @@ export default async function QuotesPage() {
   const canShowOnOverlay = Boolean(activeViewerId);
 
   return (
-    <div className="flex w-full flex-col pb-20 pt-8">
+    <div className="flex w-full flex-col pb-20">
       <section className="landing-plane surface-hero relative overflow-hidden py-8 sm:py-10">
         <div className="bg-dots-light pointer-events-none absolute inset-0 opacity-20" />
-        <div className="relative mx-auto flex w-full max-w-[1500px] items-start justify-between gap-4 px-4 sm:px-6 lg:px-10">
+        <div className="relative mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
           <div>
             <p className="mono text-xs font-bold uppercase tracking-[0.32em] text-[var(--color-ink-soft)]">
               Quotes da live
@@ -46,12 +52,9 @@ export default async function QuotesPage() {
               Aqui ficam as melhores perolas salvas pelo chat. Tudo em ordem de cadastro, com o
               número da quote e quem registrou.
             </p>
-            <p className="mt-3 inline-flex items-center gap-2 border-[3px] border-[var(--color-ink)] bg-[var(--color-paper)] px-4 py-2 text-xs font-black uppercase tracking-[0.18em] text-[var(--color-ink)] shadow-[4px_4px_0_#000]">
+            <p className="mt-3 inline-flex items-center gap-2 border-[3px] border-[var(--color-ink)] bg-[var(--color-paper)] px-4 py-2 text-xs font-black uppercase tracking-[0.18em] text-[var(--color-ink)] shadow-[4px_4px_0_var(--shadow-color)]">
               Mostrar no OBS custa {formatPipetz(50)} pipetz
             </p>
-          </div>
-          <div className="sticker hidden accent-chip-strong px-4 py-2 text-sm sm:inline-flex">
-            {quotes.length} quotes
           </div>
         </div>
       </section>
@@ -60,49 +63,69 @@ export default async function QuotesPage() {
         <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
           <div className="grid gap-4">
             {quotes.length > 0 ? (
-              quotes.map((quote, index) => (
-                <Card
-                  key={quote.id}
-                  variant="poster"
-                  className={`gap-4 p-5 ${quoteCardBackgrounds[index % quoteCardBackgrounds.length]}`}
-                >
-                  <CardHeader>
-                    <div>
-                      <CardDescription className="mono text-[10px] uppercase tracking-[0.28em] text-[var(--color-ink-soft)]">
-                        Quote registrada
-                      </CardDescription>
-                      <CardTitle
-                        className="mt-2 text-3xl uppercase leading-none"
-                        style={{ fontFamily: "var(--font-display)" }}
+              quotes.map((quote, index) => {
+                const bgClass = quoteCardBackgrounds[index % quoteCardBackgrounds.length];
+                const usesPastelInk = usesPastelQuoteBackground(bgClass);
+
+                return (
+                  <Card
+                    key={quote.id}
+                    variant="poster"
+                    className={cn("gap-4 p-5", bgClass, usesPastelInk && "text-[var(--color-accent-ink)]")}
+                  >
+                    <CardHeader>
+                      <div>
+                        <CardDescription
+                          className={cn(
+                            "mono text-[10px] uppercase tracking-[0.28em]",
+                            usesPastelInk ? "text-[var(--color-accent-ink-soft)]" : "text-[var(--color-ink-soft)]",
+                          )}
+                        >
+                          Quote registrada
+                        </CardDescription>
+                        <CardTitle
+                          className="mt-2 text-3xl uppercase leading-none"
+                          style={{ fontFamily: "var(--font-display)" }}
+                        >
+                          #{quote.quoteNumber}
+                        </CardTitle>
+                      </div>
+                    </CardHeader>
+
+                    <CardContent>
+                      <blockquote
+                        className={cn(
+                          "text-lg font-black leading-8 sm:text-xl",
+                          usesPastelInk ? "text-[var(--color-accent-ink)]" : "text-[var(--color-ink)]",
+                        )}
                       >
-                        #{quote.quoteNumber}
-                      </CardTitle>
-                    </div>
-                  </CardHeader>
+                        <span aria-hidden="true">&ldquo;</span>
+                        {quote.body}
+                        <span aria-hidden="true">&rdquo;</span>
+                      </blockquote>
+                    </CardContent>
 
-                  <CardContent>
-                    <blockquote className="text-lg font-black leading-8 text-[var(--color-ink)] sm:text-xl">
-                      <span aria-hidden="true">&ldquo;</span>
-                      {quote.body}
-                      <span aria-hidden="true">&rdquo;</span>
-                    </blockquote>
-                  </CardContent>
-
-                  <CardFooter className="flex flex-wrap items-end justify-between gap-4 text-sm font-bold text-[var(--color-ink-soft)]">
-                    <div className="flex flex-col gap-1">
-                      <span>{quote.createdByDisplayName}</span>
-                      {quote.createdByYoutubeHandle ? ` • ${quote.createdByYoutubeHandle}` : ""}
-                      <span>{formatDateTime(quote.createdAt)}</span>
-                    </div>
-                    <QuoteOverlayTrigger
-                      quoteId={quote.quoteNumber}
-                      loggedIn={Boolean(session?.user)}
-                      canShow={canShowOnOverlay}
-                      viewerBalance={dashboard?.balance.currentBalance}
-                    />
-                  </CardFooter>
-                </Card>
-              ))
+                    <CardFooter
+                      className={cn(
+                        "flex flex-wrap items-end justify-between gap-4 text-sm font-bold",
+                        usesPastelInk ? "text-[var(--color-accent-ink-soft)]" : "text-[var(--color-ink-soft)]",
+                      )}
+                    >
+                      <div className="flex flex-col gap-1">
+                        <span>{quote.createdByDisplayName}</span>
+                        {quote.createdByYoutubeHandle ? ` • ${quote.createdByYoutubeHandle}` : ""}
+                        <span>{formatDateTime(quote.createdAt)}</span>
+                      </div>
+                      <QuoteOverlayTrigger
+                        quoteId={quote.quoteNumber}
+                        loggedIn={Boolean(session?.user)}
+                        canShow={canShowOnOverlay}
+                        viewerBalance={dashboard?.balance.currentBalance}
+                      />
+                    </CardFooter>
+                  </Card>
+                );
+              })
             ) : (
               <Card variant="poster" className="bg-[var(--color-paper)] p-6">
                 <CardHeader>
@@ -129,3 +152,4 @@ export default async function QuotesPage() {
     </div>
   );
 }
+

--- a/src/app/(public)/ranking/page.tsx
+++ b/src/app/(public)/ranking/page.tsx
@@ -5,10 +5,10 @@ export default async function RankingPage() {
   const leaderboard = await getLeaderboard();
 
   return (
-    <div className="flex w-full flex-col pb-20 pt-8">
+    <div className="flex w-full flex-col pb-20">
       <section className="landing-plane surface-hero relative overflow-hidden py-8 sm:py-10">
         <div className="bg-dots-light pointer-events-none absolute inset-0 opacity-15" />
-        <div className="relative mx-auto flex w-full max-w-[1500px] items-start justify-between gap-4 px-4 sm:px-6 lg:px-10">
+        <div className="relative mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
           <div>
             <p className="mono text-xs font-bold uppercase tracking-[0.32em]">
               🏆 Ranking de pipetz
@@ -19,9 +19,6 @@ export default async function RankingPage() {
             >
               Quem ta mandando na live.
             </h1>
-          </div>
-          <div className="sticker hidden accent-chip-strong px-4 py-2 text-sm sm:inline-flex">
-            {leaderboard.length} viewers
           </div>
         </div>
       </section>

--- a/src/app/(viewer)/me/page.tsx
+++ b/src/app/(viewer)/me/page.tsx
@@ -5,15 +5,6 @@ import { RedemptionGrid } from "@/components/redemption-grid";
 import { ViewerLinkCard } from "@/components/viewer-link-card";
 import { getCatalog, getViewerDashboard } from "@/lib/db/repository";
 import { requireSession } from "@/lib/auth/session";
-import { formatDateTime, formatPipetz } from "@/lib/utils";
-
-const statusColorMap: Record<string, string> = {
-  queued: "var(--color-lavender)",
-  claimed: "var(--color-sky)",
-  completed: "var(--color-mint)",
-  failed: "var(--color-rose)",
-  cancelled: "var(--color-periwinkle)",
-};
 
 export default async function MePage() {
   const session = await requireSession();
@@ -27,78 +18,14 @@ export default async function MePage() {
   }
 
   return (
-    <div className="flex w-full flex-col pb-20 pt-8">
+    <div className="flex w-full flex-col pb-20">
       {/* Balance hero */}
       <PipetzBalanceCard
         displayName={dashboard.viewer.youtubeDisplayName}
         currentBalance={dashboard.balance.currentBalance}
-        lifetimeEarned={dashboard.balance.lifetimeEarned}
-        lifetimeSpent={dashboard.balance.lifetimeSpent}
       />
 
       <ViewerLinkCard isLinked={dashboard.viewer.isLinked} />
-
-      {/* Stats + Redemption timeline */}
-      <section className="landing-plane landing-divider bg-[var(--color-sky)] py-8 sm:py-10">
-        <div className="mx-auto grid w-full max-w-[1500px] gap-6 px-4 sm:px-6 lg:grid-cols-[0.9fr_1.1fr] lg:px-10">
-          <div className="grid gap-4 self-start sm:grid-cols-2">
-            <div className="card-brutal surface-card p-5">
-              <p className="mono text-[10px] uppercase tracking-[0.28em] text-[var(--color-ink-soft)]">
-                Pipetz ganhos
-              </p>
-              <p className="mt-2 text-3xl font-bold" style={{ fontFamily: "var(--font-display)" }}>
-                {formatPipetz(dashboard.balance.lifetimeEarned)}
-              </p>
-            </div>
-            <div className="card-brutal surface-card-alt p-5">
-              <p className="mono text-[10px] uppercase tracking-[0.28em] text-[var(--color-ink-soft)]">
-                Pipetz gastos
-              </p>
-              <p className="mt-2 text-3xl font-bold" style={{ fontFamily: "var(--font-display)" }}>
-                {formatPipetz(dashboard.balance.lifetimeSpent)}
-              </p>
-            </div>
-          </div>
-
-          <div className="landing-plane surface-section p-6 sm:p-8">
-            <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
-              Seus resgates
-            </p>
-            <div className="mt-5 grid gap-3">
-              {dashboard.redemptions.length ? (
-                dashboard.redemptions.map((entry) => {
-                  const item = catalog.find((catalogItem) => catalogItem.id === entry.catalogItemId);
-                  const statusBg = statusColorMap[entry.status] ?? "var(--color-paper)";
-                  return (
-                    <div key={entry.id} className="card-brutal p-4">
-                      <div className="flex flex-wrap items-center justify-between gap-3">
-                        <h2 className="text-lg font-bold" style={{ fontFamily: "var(--font-display)" }}>
-                          {item?.name ?? "Item removido"}
-                        </h2>
-                        <span
-                          className="badge-brutal px-2 py-1 text-[10px] text-[var(--color-ink)]"
-                          style={{ backgroundColor: statusBg }}
-                        >
-                          {entry.status}
-                        </span>
-                      </div>
-                      <p className="mt-2 text-sm text-[var(--color-ink-soft)]">
-                        {formatPipetz(entry.costAtPurchase)} pipetz &bull; {formatDateTime(entry.queuedAt)}
-                      </p>
-                    </div>
-                  );
-                })
-              ) : (
-                <div className="card-brutal surface-card p-5 text-center">
-                  <p className="text-sm font-bold text-[var(--color-ink-soft)]">
-                    Nenhum resgate ainda. Gaste seus pipetz nos resgates!
-                  </p>
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
-      </section>
 
       <RedemptionGrid
         items={catalog}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -46,7 +46,7 @@ export default async function AdminPage() {
   ]);
 
   return (
-    <div className="flex w-full flex-col pb-20 pt-8">
+    <div className="flex w-full flex-col pb-20">
       <section className="landing-plane surface-hero py-8 sm:py-10">
         <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
           <p className="mono text-xs font-bold uppercase tracking-[0.32em] text-[var(--color-ink-soft)]">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,7 +16,7 @@
   --color-yellow: #40a9ff;
   --color-lavender: #f0e8f8;
   --color-sky: #d8efff;
-  --color-mint: #95ff82;
+  --color-mint: #00beae;
   --color-periwinkle: #e8dcfb;
   --color-rose: #ffd7ef;
   --color-lilac: #f5effd;
@@ -59,6 +59,7 @@
   --shadow-hover: 2px 2px 0 var(--shadow-color);
 
   --color-accent-ink: #000000;
+  --color-accent-ink-soft: #1d1822;
   --color-on-yellow: #000000;
 
   --shadow-purple: 4px 4px 0 var(--shadow-color);
@@ -102,49 +103,50 @@
 }
 
 html[data-theme="dark"] {
-  --color-ink: #ffffff;
-  --color-paper: #241237;
-  --color-purple: #c7a2e9;
-  --color-purple-mid: #c7a2e9;
-  --color-purple-bold: #e3c8ff;
-  --color-pink: #ff79c6;
-  --color-pink-hot: #ff79c6;
-  --color-blue: #40a9ff;
-  --color-yellow: #40a9ff;
-  --color-lavender: #2e1745;
-  --color-sky: #17344c;
-  --color-mint: #21422a;
-  --color-periwinkle: #36224f;
-  --color-rose: #4b1e42;
-  --color-lilac: #241237;
-  --color-muted: #ffffff;
-  --color-cream: #140c1d;
-  --color-paper-warm: #30184a;
-  --color-paper-pink: #4a1d44;
-  --color-ink-soft: #f3e9ff;
-  --color-surface-strong: #241237;
+  --color-ink: #f8f8f8;
+  --color-paper: #090909;
+  --color-purple: #b998ff;
+  --color-purple-mid: #d0b6ff;
+  --color-purple-bold: #eadcff;
+  --color-pink: #ff78bf;
+  --color-pink-hot: #ff5fa8;
+  --color-blue: #54c7ff;
+  --color-yellow: #ffd44d;
+  --color-lavender: #151515;
+  --color-sky: #101d25;
+  --color-mint: #00beae;
+  --color-periwinkle: #1a1630;
+  --color-rose: #26141c;
+  --color-lilac: #111111;
+  --color-muted: #f8f8f8;
+  --color-cream: #020202;
+  --color-paper-warm: #141414;
+  --color-paper-pink: #1a0f17;
+  --color-ink-soft: #d7d7d7;
+  --color-surface-strong: #111111;
 
-  --bg-page: #140c1d;
-  --surface-hero: #30184a;
-  --surface-section: #241237;
-  --surface-card: #241237;
-  --surface-card-alt: #30184a;
-  --surface-card-accent: #17344c;
-  --color-header-surface: #241237;
+  --bg-page: #000000;
+  --surface-hero: #0c0c0c;
+  --surface-section: #080808;
+  --surface-card: #111111;
+  --surface-card-alt: #1a1a1a;
+  --surface-card-accent: #101d25;
+  --color-header-surface: rgba(0, 0, 0, 0.94);
   --color-ticker-bg: #000000;
-  --color-window-bar: #c7a2e9;
+  --color-window-bar: #131313;
   --color-backdrop: rgba(0, 0, 0, 0.65);
-  --color-grid-line: rgba(255, 255, 255, 0.08);
-  --color-halftone-dot: rgba(255, 121, 198, 0.24);
+  --color-grid-line: rgba(255, 255, 255, 0.12);
+  --color-halftone-dot: rgba(84, 199, 255, 0.2);
   --color-dot: #ffffff;
   --color-dot-soft: #ffffff;
-  --color-podium-gold: #40a9ff;
-  --color-podium-silver: #c7a2e9;
-  --color-podium-bronze: #ff79c6;
+  --color-podium-gold: #ffd44d;
+  --color-podium-silver: #b998ff;
+  --color-podium-bronze: #ff78bf;
   --color-on-yellow: #000000;
+  --color-accent-ink-soft: #161616;
 
-  --shadow-color: #000000;
-  --shadow-soft-color: #000000;
+  --shadow-color: #ffffff;
+  --shadow-soft-color: rgba(255, 255, 255, 0.88);
 
   --background: var(--bg-page);
   --foreground: var(--color-ink);
@@ -254,17 +256,33 @@ button {
 }
 
 .panel {
-  background: var(--color-paper);
   border: var(--border-strong);
-  box-shadow: var(--shadow);
+  box-shadow: none;
   border-radius: var(--radius);
+  transition: box-shadow var(--snap), filter var(--snap);
+}
+
+.panel:not([class*="bg-"]):not([class*="surface-"]) {
+  background: var(--color-paper);
+}
+
+.panel:hover {
+  box-shadow: var(--shadow);
 }
 
 .panel-soft {
-  background: var(--color-paper);
   border: var(--border-strong);
-  box-shadow: var(--shadow-sm);
+  box-shadow: none;
   border-radius: var(--radius);
+  transition: box-shadow var(--snap), filter var(--snap);
+}
+
+.panel-soft:not([class*="bg-"]):not([class*="surface-"]) {
+  background: var(--color-paper);
+}
+
+.panel-soft:hover {
+  box-shadow: var(--shadow-sm);
 }
 
 .btn-brutal {
@@ -298,26 +316,31 @@ button {
 
 .card-brutal {
   border: var(--border-strong);
-  box-shadow: var(--shadow);
+  box-shadow: none;
   border-radius: var(--radius);
+  transition: box-shadow var(--snap), filter var(--snap);
+}
+
+.card-brutal:not([class*="bg-"]):not([class*="surface-"]) {
   background: var(--color-paper);
-  transition: transform var(--snap), box-shadow var(--snap);
 }
 
 .card-brutal:hover {
-  transform: translate(3px, 3px);
-  box-shadow: var(--shadow-hover);
+  box-shadow: var(--shadow);
 }
 
 .card-brutal-static {
   border: var(--border-strong);
-  box-shadow: var(--shadow);
+  box-shadow: none;
   border-radius: var(--radius);
+  transition: box-shadow var(--snap), filter var(--snap);
+}
+
+.card-brutal-static:not([class*="bg-"]):not([class*="surface-"]) {
   background: var(--color-paper);
 }
 
 .card-brutal-static:hover {
-  transform: none;
   box-shadow: var(--shadow);
 }
 
@@ -328,15 +351,17 @@ button {
 
 .card-poster {
   border: var(--border-strong);
-  box-shadow: var(--shadow);
+  box-shadow: none;
   border-radius: var(--radius);
+  transition: box-shadow var(--snap), filter var(--snap);
+}
+
+.card-poster:not([class*="bg-"]):not([class*="surface-"]) {
   background: var(--color-paper);
-  transition: transform var(--snap), box-shadow var(--snap), filter var(--snap);
 }
 
 .card-poster:hover {
-  transform: translate(3px, 3px);
-  box-shadow: var(--shadow-hover);
+  box-shadow: var(--shadow);
   filter: saturate(1.02);
 }
 
@@ -348,11 +373,16 @@ button {
 .card-flat {
   border: var(--border-strong);
   border-radius: var(--radius);
+  box-shadow: none;
+  transition: background-color var(--snap), box-shadow var(--snap), filter var(--snap);
+}
+
+.card-flat:not([class*="bg-"]):not([class*="surface-"]) {
   background: var(--color-paper);
-  transition: background-color var(--snap);
 }
 
 .card-flat:hover {
+  box-shadow: var(--shadow);
   filter: brightness(0.96);
 }
 
@@ -361,17 +391,40 @@ button {
   outline-offset: 2px;
 }
 
+/* Secondary badges and micro-panels inside an already framed card stay flat. */
+.micro-flat {
+  box-shadow: none !important;
+}
+
+.micro-flat:hover {
+  box-shadow: none !important;
+  filter: none;
+  transform: none;
+}
+
 .panel-inset {
-  background: var(--color-paper);
   border: var(--border-strong);
   border-radius: var(--radius);
   border-left-width: 6px;
 }
 
-.panel-flat {
+.panel-inset:not([class*="bg-"]):not([class*="surface-"]) {
   background: var(--color-paper);
+}
+
+.panel-flat {
   border: var(--border-strong);
   border-radius: var(--radius);
+  box-shadow: none;
+  transition: box-shadow var(--snap), filter var(--snap);
+}
+
+.panel-flat:not([class*="bg-"]):not([class*="surface-"]) {
+  background: var(--color-paper);
+}
+
+.panel-flat:hover {
+  box-shadow: var(--shadow);
 }
 
 .landing-plane {
@@ -382,7 +435,7 @@ button {
 }
 
 .landing-divider {
-  border-top: 6px solid var(--color-ink);
+  border-top: 1px solid var(--color-ink);
 }
 
 .surface-hero {
@@ -550,6 +603,21 @@ button {
   background: var(--color-purple);
   color: var(--color-accent-ink);
   box-shadow: var(--shadow);
+}
+
+/* Pastel action surfaces should keep dark ink in both light and dark themes. */
+.pastel-action {
+  color: var(--color-accent-ink);
+}
+
+.btn-brutal[class*="bg-[var(--color-blue)]"],
+.btn-brutal[class*="bg-[var(--color-purple)]"],
+.btn-brutal[class*="bg-[var(--color-pink)]"],
+.btn-brutal[class*="bg-[var(--color-yellow)]"],
+.btn-brutal[class*="bg-[var(--color-sky)]"],
+.btn-brutal[class*="bg-[var(--color-lavender)]"],
+.btn-brutal[class*="bg-[var(--color-mint)]"] {
+  color: var(--color-accent-ink);
 }
 
 .marquee-strip {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
 import { Archivo_Black, IBM_Plex_Mono, DM_Sans, Geist } from "next/font/google";
 import Script from "next/script";
 
@@ -8,6 +9,7 @@ import { Providers } from "@/components/providers";
 import "./globals.css";
 import { adminEmails } from "@/lib/env";
 import { isStreamerbotLivestreamActive } from "@/lib/streamerbot/live-status";
+import { isThemeMode, themeCookieKey, themeStorageKey } from "@/lib/theme";
 import { cn } from "@/lib/utils";
 
 const geist = Geist({subsets:['latin'],variable:'--font-sans'});
@@ -37,9 +39,14 @@ export const metadata: Metadata = {
 
 const themeScript = `
 (() => {
-  const storageKey = "pipetz-theme";
+  const storageKey = "${themeStorageKey}";
+  const cookieKey = "${themeCookieKey}";
   const root = document.documentElement;
-  const storedTheme = window.localStorage.getItem(storageKey);
+  const cookieMatch = document.cookie
+    .split("; ")
+    .find((entry) => entry.startsWith(cookieKey + "="));
+  const cookieTheme = cookieMatch ? decodeURIComponent(cookieMatch.split("=").slice(1).join("=")) : null;
+  const storedTheme = window.localStorage.getItem(storageKey) ?? cookieTheme;
   const theme =
     storedTheme === "dark" || storedTheme === "light"
       ? storedTheme
@@ -57,6 +64,9 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const cookieStore = await cookies();
+  const cookieTheme = cookieStore.get(themeCookieKey)?.value;
+  const initialTheme = isThemeMode(cookieTheme) ? cookieTheme : null;
   const [session, isLive] = await Promise.all([
     auth(),
     isStreamerbotLivestreamActive(),
@@ -67,14 +77,21 @@ export default async function RootLayout({
     <html
       lang="pt-BR"
       suppressHydrationWarning
+      data-theme={initialTheme ?? undefined}
       className={cn("h-full", "antialiased", display.variable, body.variable, mono.variable, "font-sans", geist.variable)}
+      style={initialTheme ? { colorScheme: initialTheme } : undefined}
     >
       <body className="min-h-full text-[var(--color-ink)]" style={{ fontFamily: "var(--font-body), var(--font-display), sans-serif" }}>
         <Script id="pipetz-theme" strategy="beforeInteractive">
           {themeScript}
         </Script>
         <Providers>
-          <AppChrome session={session} isAdmin={isAdmin} isLive={isLive}>
+          <AppChrome
+            session={session}
+            isAdmin={isAdmin}
+            isLive={isLive}
+            initialTheme={initialTheme}
+          >
             {children}
           </AppChrome>
         </Providers>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+﻿import type { ReactNode } from "react";
 import Link from "next/link";
 import Image from "next/image";
 
@@ -52,6 +52,12 @@ const DEFAULT_GITHUB_ISSUES_URL =
   "https://github.com/ludmila-omlopes/ludylops-live/issues/new";
 const LUDYLOPS_PROFILE_IMAGE =
   "/selfie2.png";
+
+function usesPastelSurface(bgClass: string) {
+  return ["--color-blue", "--color-purple", "--color-pink", "--color-yellow", "--color-mint"].some((token) =>
+    bgClass.includes(token),
+  );
+}
 
 function buildViewerLinkingIssueUrl(input: {
   isLinked: boolean;
@@ -131,7 +137,7 @@ function AccountProtectionNotice({ status }: { status: AccountProtectionStatus }
       : "Se estiver tudo certo na sua conta Google, você pode entrar novamente agora.";
 
   return (
-    <div className="card-poster mt-6 border-[3px] border-[var(--color-ink)] bg-[var(--color-blue)] p-4 text-[var(--color-ink)]">
+    <div className="card-poster mt-6 border-[3px] border-[var(--color-ink)] bg-[var(--color-blue)] p-4 text-[var(--color-accent-ink)]">
       <p className="mono text-[10px] uppercase tracking-[0.24em]">segurança da conta</p>
       <p className="mt-2 text-lg font-black uppercase leading-tight">{title}</p>
       <p className="mt-3 text-sm font-bold leading-6">{body}</p>
@@ -142,10 +148,20 @@ function AccountProtectionNotice({ status }: { status: AccountProtectionStatus }
 }
 
 function MetricCard({ metric, className }: { metric: HomeMetric; className?: string }) {
+  const usesPastelInk = usesPastelSurface(metric.bg);
+
   return (
-    <Card variant="poster" className={cn("p-4", metric.bg, className)}>
+    <Card
+      variant="poster"
+      className={cn("p-4", metric.bg, usesPastelInk && "text-[var(--color-accent-ink)]", className)}
+    >
       <CardHeader className="gap-0">
-        <CardDescription className="mono text-[10px] uppercase tracking-[0.24em] text-[var(--color-ink-soft)]">
+        <CardDescription
+          className={cn(
+            "mono text-[10px] uppercase tracking-[0.24em]",
+            usesPastelInk ? "text-[var(--color-accent-ink-soft)]" : "text-[var(--color-ink-soft)]",
+          )}
+        >
           {metric.label}
         </CardDescription>
         <CardTitle
@@ -156,22 +172,43 @@ function MetricCard({ metric, className }: { metric: HomeMetric; className?: str
         </CardTitle>
       </CardHeader>
       <CardContent className="mt-2">
-        <p className="text-sm font-bold leading-6 text-[var(--color-ink-soft)]">{metric.note}</p>
+        <p
+          className={cn(
+            "text-sm font-bold leading-6",
+            usesPastelInk ? "text-[var(--color-accent-ink-soft)]" : "text-[var(--color-ink-soft)]",
+          )}
+        >
+          {metric.note}
+        </p>
       </CardContent>
     </Card>
   );
 }
 
 function FeatureStoryCard({ feature }: { feature: FeatureCard }) {
+  const usesPastelInk = usesPastelSurface(feature.bg);
+
   return (
-    <Card variant="poster" className={`flex-row gap-4 p-4 sm:p-5 ${feature.bg}`}>
+    <Card
+      variant="poster"
+      className={cn(
+        "flex-row gap-4 p-4 sm:p-5",
+        feature.bg,
+        usesPastelInk && "text-[var(--color-accent-ink)]",
+      )}
+    >
       <CardContent className="flex h-14 w-14 shrink-0 items-center justify-center">
-        <div className="card-brutal flex h-14 w-14 items-center justify-center bg-[var(--color-paper)] text-xl font-black">
+        <div className="card-brutal micro-flat flex h-14 w-14 items-center justify-center bg-[var(--color-paper)] text-xl font-black text-[var(--color-ink)]">
           {feature.symbol}
         </div>
       </CardContent>
       <CardHeader className="gap-0">
-        <CardDescription className="mono text-[10px] uppercase tracking-[0.28em] text-[var(--color-ink-soft)]">
+        <CardDescription
+          className={cn(
+            "mono text-[10px] uppercase tracking-[0.28em]",
+            usesPastelInk ? "text-[var(--color-accent-ink-soft)]" : "text-[var(--color-ink-soft)]",
+          )}
+        >
           {feature.eyebrow}
         </CardDescription>
         <CardTitle
@@ -181,7 +218,14 @@ function FeatureStoryCard({ feature }: { feature: FeatureCard }) {
           {feature.title}
         </CardTitle>
         <CardContent className="mt-3">
-          <p className="text-sm leading-6 text-[var(--color-ink-soft)]">{feature.body}</p>
+          <p
+            className={cn(
+              "text-sm leading-6",
+              usesPastelInk ? "text-[var(--color-accent-ink-soft)]" : "text-[var(--color-ink-soft)]",
+            )}
+          >
+            {feature.body}
+          </p>
         </CardContent>
       </CardHeader>
     </Card>
@@ -199,14 +243,28 @@ function RankingLeaderCard({
   viewerName: string;
   balance: number;
 }) {
+  const usesPastelInk = usesPastelSurface(bgClass);
+
   return (
-    <Card variant="poster" className={`flex-row items-center justify-between gap-3 px-4 py-4 ${bgClass}`}>
+    <Card
+      variant="poster"
+      className={cn(
+        "flex-row items-center justify-between gap-3 px-4 py-4",
+        bgClass,
+        usesPastelInk && "text-[var(--color-accent-ink)]",
+      )}
+    >
       <CardContent className="flex min-w-0 items-center gap-3">
-        <div className="card-brutal flex min-w-[52px] items-center justify-center bg-[var(--color-paper)] px-3 py-2 text-sm font-black">
+        <div className="card-brutal micro-flat flex min-w-[52px] items-center justify-center bg-[var(--color-paper)] px-3 py-2 text-sm font-black text-[var(--color-ink)]">
           #{index + 1}
         </div>
         <CardHeader className="min-w-0 gap-0">
-          <CardDescription className="mono text-[10px] uppercase tracking-[0.24em] text-[var(--color-ink-soft)]">
+          <CardDescription
+            className={cn(
+              "mono text-[10px] uppercase tracking-[0.24em]",
+              usesPastelInk ? "text-[var(--color-accent-ink-soft)]" : "text-[var(--color-ink-soft)]",
+            )}
+          >
             viewer
           </CardDescription>
           <CardTitle className="truncate text-base font-black uppercase tracking-[0.04em]">
@@ -215,7 +273,12 @@ function RankingLeaderCard({
         </CardHeader>
       </CardContent>
       <CardFooter className="shrink-0">
-        <span className="mono text-xs font-black uppercase tracking-[0.18em] text-[var(--color-ink)]">
+        <span
+          className={cn(
+            "mono text-xs font-black uppercase tracking-[0.18em]",
+            usesPastelInk ? "text-[var(--color-accent-ink)]" : "text-[var(--color-ink)]",
+          )}
+        >
           {formatPipetz(balance)}
         </span>
       </CardFooter>
@@ -238,20 +301,36 @@ function SpotlightOptionCard({
     "bg-[var(--color-pink)]",
     "bg-[var(--color-paper)]",
   ];
+  const bgClass = colors[index % colors.length];
+  const usesPastelInk = usesPastelSurface(bgClass);
 
   return (
     <Card
       variant="poster"
-      className={`flex-row items-center justify-between gap-3 px-4 py-4 ${colors[index % colors.length]}`}
+      className={cn(
+        "flex-row items-center justify-between gap-3 px-4 py-4",
+        bgClass,
+        usesPastelInk && "text-[var(--color-accent-ink)]",
+      )}
     >
       <CardHeader className="min-w-0 gap-0">
-        <CardDescription className="mono text-[10px] uppercase tracking-[0.24em] text-[var(--color-ink-soft)]">
+        <CardDescription
+          className={cn(
+            "mono text-[10px] uppercase tracking-[0.24em]",
+            usesPastelInk ? "text-[var(--color-accent-ink-soft)]" : "text-[var(--color-ink-soft)]",
+          )}
+        >
           opção 0{index + 1}
         </CardDescription>
         <CardTitle className="mt-1 text-lg font-black uppercase leading-tight">{optionLabel}</CardTitle>
       </CardHeader>
       <CardFooter className="shrink-0">
-        <span className="mono text-xs font-black uppercase tracking-[0.18em] text-[var(--color-ink)]">
+        <span
+          className={cn(
+            "mono text-xs font-black uppercase tracking-[0.18em]",
+            usesPastelInk ? "text-[var(--color-accent-ink)]" : "text-[var(--color-ink)]",
+          )}
+        >
           {formatPipetz(poolAmount)}
         </span>
       </CardFooter>
@@ -290,11 +369,8 @@ function HeroPoster({
         {loggedIn ? (
           <>
             <div>
-              <p className="mono text-[11px] uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
-                painel da live . pontos . apostas . resgates
-              </p>
               <h2
-                className="mt-3 text-4xl uppercase leading-[0.88] sm:text-5xl"
+                className="text-4xl uppercase leading-[0.88] sm:text-5xl"
                 style={{ fontFamily: "var(--font-display)" }}
               >
                 {heading}
@@ -328,7 +404,7 @@ function HeroPoster({
             />
             <div className="relative min-h-[340px] overflow-visible sm:min-h-[400px]">
               <div className="mx-auto w-[72%] max-w-[420px] pt-[4.75rem] sm:pt-[5.5rem]">
-                <div className="relative aspect-video border-[4px] border-[var(--color-ink)] bg-[var(--color-purple)] shadow-[7px_7px_0_#000]">
+                <div className="relative aspect-video border-[4px] border-[var(--color-ink)] bg-[var(--color-purple)] shadow-[7px_7px_0_var(--shadow-color)]">
                   <div className="absolute bottom-0 left-1/2 z-10 w-[118%] -translate-x-1/2 sm:w-[122%]">
                   <Image
                     src={LUDYLOPS_PROFILE_IMAGE}
@@ -342,7 +418,7 @@ function HeroPoster({
                 </div>
               </div>
 
-              <div className="absolute bottom-3 right-3 z-20 flex h-20 w-20 items-center justify-center rounded-full border-[4px] border-[var(--color-ink)] bg-[var(--color-pink-hot)] shadow-[5px_5px_0_#000] sm:bottom-5 sm:right-5 sm:h-24 sm:w-24">
+              <div className="absolute bottom-3 right-3 z-20 flex h-20 w-20 items-center justify-center rounded-full border-[4px] border-[var(--color-ink)] bg-[var(--color-pink-hot)] shadow-[5px_5px_0_var(--shadow-color)] sm:bottom-5 sm:right-5 sm:h-24 sm:w-24">
                 <div className="flex rotate-[20deg] h-11 w-11 items-center justify-center rounded-full bg-[var(--color-yellow)] text-xl font-black text-[var(--color-accent-ink)]">
                 =D
                 </div>
@@ -357,27 +433,21 @@ function HeroPoster({
 
 function FeatureShowcase({
   features,
-  metrics,
-  loggedIn = false,
 }: {
   features: FeatureCard[];
-  metrics: HomeMetric[];
-  loggedIn?: boolean;
 }) {
-  const metricRotations = ["rotate-[1deg]", "rotate-[-1deg]", "rotate-[1.5deg]", "rotate-[-1.5deg]"];
-
   return (
     <section className="landing-plane landing-divider bg-[var(--color-paper-pink)] py-8 sm:py-10">
-      <div className="mx-auto grid w-full max-w-[1520px] gap-8 px-4 sm:px-6 lg:grid-cols-[1.05fr_0.95fr] lg:px-10">
+      <div className="mx-auto w-full max-w-[1520px] px-4 sm:px-6 lg:px-10">
         <div>
           <h2
             className="max-w-xl text-4xl uppercase leading-[0.9] sm:text-5xl"
             style={{ fontFamily: "var(--font-display)" }}
           >
-            Você participa da minha live de verdade.
+            Voce participa da minha live de verdade.
           </h2>
           <p className="mt-4 max-w-xl text-base leading-7 text-[var(--color-ink-soft)]">
-            Eu abro a live, você junta pipetz, entra nas apostas e ainda solta resgates
+            Eu abro a live, voce junta pipetz, entra nas apostas e ainda solta resgates
             que aparecem comigo ao vivo.
           </p>
 
@@ -387,37 +457,47 @@ function FeatureShowcase({
             ))}
           </div>
         </div>
+      </div>
+    </section>
+  );
+}
 
-        <div className="landing-plane bg-[var(--color-sky)] p-6 sm:p-8">
-          <p className="mono text-[11px] uppercase tracking-[0.28em] text-[var(--color-ink-soft)]">
-            termômetro da live . comunidade agora
-          </p>
+function LiveThermometerSection({
+  metrics,
+  loggedIn = false,
+}: {
+  metrics: HomeMetric[];
+  loggedIn?: boolean;
+}) {
+  const metricRotations = ["rotate-[1deg]", "rotate-[-1deg]", "rotate-[1.5deg]", "rotate-[-1.5deg]"];
 
-          <h3
-            className="mt-4 max-w-md text-3xl uppercase leading-[0.92] sm:text-4xl"
-            style={{ fontFamily: "var(--font-display)" }}
+  return (
+    <section className="landing-plane landing-divider bg-[var(--color-sky)] py-8 sm:py-10">
+      <div className="mx-auto w-full max-w-[1520px] px-4 sm:px-6 lg:px-10">
+        <h2
+          className="max-w-md text-3xl uppercase leading-[0.92] sm:text-4xl"
+          style={{ fontFamily: "var(--font-display)" }}
+        >
+          O que voces estao aprontando comigo agora.
+        </h2>
+
+        <div className="mt-6 grid gap-4 sm:grid-cols-2">
+          {metrics.map((metric, index) => (
+            <MetricCard
+              key={metric.label}
+              metric={metric}
+              className={metricRotations[index % metricRotations.length]}
+            />
+          ))}
+        </div>
+
+        <div className="mt-6">
+          <Link
+            href={loggedIn ? "/apostas" : "/jogos"}
+            className="btn-brutal accent-button px-5 py-3 text-xs"
           >
-            O que vocês estão aprontando comigo agora.
-          </h3>
-
-          <div className="mt-6 grid gap-4 sm:grid-cols-2">
-            {metrics.map((metric, index) => (
-              <MetricCard
-                key={metric.label}
-                metric={metric}
-                className={metricRotations[index % metricRotations.length]}
-              />
-            ))}
-          </div>
-
-          <div className="mt-6">
-            <Link
-              href={loggedIn ? "/apostas" : "/jogos"}
-              className="btn-brutal accent-button px-5 py-3 text-xs"
-            >
-              {loggedIn ? "Entrar em apostas ->" : "Explorar a comunidade ->"}
-            </Link>
-          </div>
+            {loggedIn ? "Entrar em apostas ->" : "Explorar a comunidade ->"}
+          </Link>
         </div>
       </div>
     </section>
@@ -436,10 +516,8 @@ function RankingHeroCard({
 
   return (
     <aside className="p-6 sm:p-7">
-      <p className="mono text-[11px] uppercase tracking-[0.24em] text-[var(--color-ink-soft)]">top da live</p>
-
       <h2
-        className="mt-4 max-w-[10ch] text-4xl uppercase leading-[0.88] sm:text-5xl"
+        className="max-w-[10ch] text-4xl uppercase leading-[0.88] sm:text-5xl"
         style={{ fontFamily: "var(--font-display)" }}
       >
         Liderando agora
@@ -639,14 +717,14 @@ export default async function Home({ searchParams }: HomePageProps) {
   const heroTitle: ReactNode = hasUsableSession ? (
     <>
       Você já está na minha live.{" "}
-      <span className="inline-block border-[3px] border-[var(--color-ink)] bg-[var(--color-pink)] px-3 py-1 shadow-[4px_4px_0_#000]">
+      <span className="micro-flat inline-block border-[3px] border-[var(--color-ink)] bg-[var(--color-pink)] px-3 py-1 text-[var(--color-accent-ink)] shadow-[4px_4px_0_var(--shadow-color)]">
         Agora vem jogar comigo.
       </span>
     </>
   ) : (
     <>
       Oi, eu sou a ludylops.{" "}
-      <span className="inline-block border-[3px] border-[var(--color-ink)] bg-[var(--color-pink)] px-3 py-1 shadow-[4px_4px_0_#000]">
+      <span className="micro-flat inline-block border-[3px] border-[var(--color-ink)] bg-[var(--color-pink)] px-3 py-1 text-[var(--color-accent-ink)] shadow-[4px_4px_0_var(--shadow-color)]">
         Bem-vindos à minha live.
       </span>
     </>
@@ -694,10 +772,7 @@ export default async function Home({ searchParams }: HomePageProps) {
 
         <div className="relative mx-auto grid w-full max-w-[1520px] gap-8 px-4 sm:px-6 lg:grid-cols-[1.02fr_0.98fr] lg:items-center lg:px-10">
           <div className="max-w-3xl">
-            <p className="mono text-[11px] uppercase tracking-[0.36em] text-[var(--color-ink-soft)]">
-              pontos . apostas . resgates . comunidade ao vivo
-            </p>
-            <div className="mt-4">
+            <div>
               <LivestreamIndicator isLive={isLive} />
             </div>
 
@@ -757,7 +832,9 @@ export default async function Home({ searchParams }: HomePageProps) {
         </div>
       </section>
 
-      <FeatureShowcase features={features} metrics={metrics} loggedIn={hasUsableSession} />
+      <FeatureShowcase features={features} />
+
+      <LiveThermometerSection metrics={metrics} loggedIn={hasUsableSession} />
 
       {false ? (
         <QuickNavGrid
@@ -790,7 +867,7 @@ export default async function Home({ searchParams }: HomePageProps) {
         />
       ) : null}
 
-      <section className="landing-plane landing-divider bg-[var(--color-sky)] py-8 sm:py-10">
+      <section className="landing-plane landing-divider bg-[var(--color-paper-pink)] py-8 sm:py-10">
         <div className="mx-auto w-full max-w-[1520px] px-4 sm:px-6 lg:px-10">
           <RankingHeroCard leaderboard={leaderboard} viewerRank={viewerRank} />
         </div>
@@ -807,3 +884,4 @@ export default async function Home({ searchParams }: HomePageProps) {
     </div>
   );
 }
+

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+﻿import type { Metadata } from "next";
 import Link from "next/link";
 
 export const metadata: Metadata = {
@@ -74,7 +74,7 @@ const sections: PolicySection[] = [
 
 export default function PrivacyPage() {
   return (
-    <div className="mx-auto flex w-full max-w-[980px] flex-col gap-6 px-4 pb-20 pt-8 sm:px-6 lg:px-8">
+    <div className="mx-auto flex w-full max-w-[980px] flex-col gap-6 px-4 pb-20 sm:px-6 lg:px-8">
       <section className="panel surface-hero p-6 sm:p-8">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div>
@@ -107,11 +107,11 @@ export default function PrivacyPage() {
             index % 3 === 0
               ? "bg-[var(--color-paper)]"
               : index % 3 === 1
-                ? "bg-[var(--color-blue)]"
-                : "bg-[var(--color-mint)]"
+                ? "bg-[var(--color-blue)] text-[var(--color-accent-ink)]"
+                : "bg-[var(--color-mint)] text-[var(--color-accent-ink)]"
           }`}
         >
-          <p className="mono text-[11px] uppercase tracking-[0.24em] text-[var(--color-ink-soft)]">
+          <p className={`mono text-[11px] uppercase tracking-[0.24em] ${ index % 3 === 0 ? "text-[var(--color-ink-soft)]" : "text-[var(--color-accent-ink-soft)]" }`}>
             seção {String(index + 1).padStart(2, "0")}
           </p>
           <h2
@@ -120,7 +120,7 @@ export default function PrivacyPage() {
           >
             {section.title}
           </h2>
-          <div className="mt-5 space-y-4 text-sm font-medium leading-7 text-[var(--color-ink-soft)] sm:text-base">
+          <div className={`mt-5 space-y-4 text-sm font-medium leading-7 sm:text-base ${ index % 3 === 0 ? "text-[var(--color-ink-soft)]" : "text-[var(--color-accent-ink-soft)]" }`}>
             {section.body.map((paragraph) => (
               <p key={paragraph}>{paragraph}</p>
             ))}
@@ -147,3 +147,4 @@ export default function PrivacyPage() {
     </div>
   );
 }
+

--- a/src/components/admin-bets-panel.tsx
+++ b/src/components/admin-bets-panel.tsx
@@ -145,11 +145,11 @@ export function AdminBetsPanel({ bets }: { bets: BetWithOptionsRecord[] }) {
   }
 
   return (
-    <section className="landing-plane landing-divider bg-[var(--color-mint)] py-8 sm:py-10">
+    <section className="landing-plane landing-divider bg-[var(--color-mint)] py-8 text-[var(--color-accent-ink)] sm:py-10">
       <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
         <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
-          <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink)]/50">
+          <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-accent-ink-soft)]">
             Apostas
           </p>
           <h2

--- a/src/components/admin-obs-overlays-panel.tsx
+++ b/src/components/admin-obs-overlays-panel.tsx
@@ -44,10 +44,10 @@ export function AdminObsOverlaysPanel() {
               <Card
                 key={overlay.id}
                 variant="poster"
-                className={`gap-4 p-5 ${index % 2 === 0 ? "bg-[var(--color-blue)]" : "bg-[var(--color-mint)]"}`}
+                className={`gap-4 p-5 text-[var(--color-accent-ink)] ${index % 2 === 0 ? "bg-[var(--color-blue)]" : "bg-[var(--color-mint)]"}`}
               >
                 <CardHeader className="gap-2">
-                  <CardDescription className="mono text-[10px] uppercase tracking-[0.28em] text-[var(--color-ink-soft)]">
+                  <CardDescription className="mono text-[10px] uppercase tracking-[0.28em] text-[var(--color-accent-ink-soft)]">
                     browser source
                   </CardDescription>
                   <CardTitle
@@ -59,7 +59,7 @@ export function AdminObsOverlaysPanel() {
                 </CardHeader>
 
                 <CardContent className="grid gap-4">
-                  <p className="text-sm leading-7 text-[var(--color-ink-soft)] sm:text-base">
+                  <p className="text-sm leading-7 text-[var(--color-accent-ink-soft)] sm:text-base">
                     {overlay.description}
                   </p>
 

--- a/src/components/admin-viewer-links-panel.tsx
+++ b/src/components/admin-viewer-links-panel.tsx
@@ -48,15 +48,29 @@ function getViewerStatus(entry: AdminViewerDirectoryRecord) {
 }
 
 function buildGoogleCandidateLabel(entry: AdminViewerDirectoryRecord) {
-  const parts = [entry.googleAccountEmail, entry.youtubeDisplayName];
+  const parts = [maskEmail(entry.googleAccountEmail), entry.youtubeDisplayName];
   if (entry.email && entry.email !== entry.googleAccountEmail) {
-    parts.push(entry.email);
+    parts.push(maskEmail(entry.email));
   }
   return parts.filter(Boolean).join(" . ");
 }
 
 function buildYoutubeCandidateLabel(entry: AdminViewerDirectoryRecord) {
-  return [entry.youtubeDisplayName, entry.youtubeHandle, entry.email].filter(Boolean).join(" . ");
+  return [entry.youtubeDisplayName, entry.youtubeHandle, maskEmail(entry.email)].filter(Boolean).join(" . ");
+}
+
+function maskEmail(email: string | null | undefined) {
+  if (!email) {
+    return null;
+  }
+
+  const [localPart, domain] = email.split("@");
+  if (!localPart || !domain) {
+    return email;
+  }
+
+  const visibleLocal = localPart.length <= 3 ? localPart.slice(0, 1) : localPart.slice(0, 3);
+  return `${visibleLocal}...@${domain}`;
 }
 
 export function AdminViewerLinksPanel({
@@ -279,14 +293,14 @@ export function AdminViewerLinksPanel({
               </p>
               <p className="mt-2 text-sm text-[var(--color-ink-soft)]">usuários no diretório</p>
             </div>
-            <div className="card-brutal-static bg-[var(--color-mint)] p-5">
-              <p className="mono text-[10px] uppercase tracking-[0.22em] text-[var(--color-ink-soft)]">
+            <div className="card-brutal-static bg-[var(--color-mint)] p-5 text-[var(--color-accent-ink)]">
+              <p className="mono text-[10px] uppercase tracking-[0.22em] text-[var(--color-accent-ink-soft)]">
                 Vinculados
               </p>
               <p className="mt-2 text-3xl font-black" style={{ fontFamily: "var(--font-display)" }}>
                 {totalLinked}
               </p>
-              <p className="mt-2 text-sm text-[var(--color-ink-soft)]">Google + YouTube unidos</p>
+              <p className="mt-2 text-sm text-[var(--color-accent-ink-soft)]">Google + YouTube unidos</p>
             </div>
             <div className="card-brutal-static bg-[var(--color-sky)] p-5">
               <p className="mono text-[10px] uppercase tracking-[0.22em] text-[var(--color-ink-soft)]">
@@ -300,7 +314,7 @@ export function AdminViewerLinksPanel({
           </div>
         </div>
 
-        <div className="mt-6 overflow-hidden rounded-[var(--radius)] border-[3px] border-[var(--color-ink)] shadow-[4px_4px_0_#000]">
+        <div className="mt-6 overflow-hidden rounded-[var(--radius)] border-[3px] border-[var(--color-ink)] shadow-[4px_4px_0_var(--shadow-color)]">
           <div className="grid grid-cols-[minmax(0,1.3fr)_minmax(0,1fr)_120px_120px] gap-3 border-b-[3px] border-[var(--color-ink)] bg-[var(--color-blue)] px-4 py-3 text-xs font-bold uppercase tracking-[0.18em]">
             <span>Usuario</span>
             <span>Conta Google</span>
@@ -328,7 +342,7 @@ export function AdminViewerLinksPanel({
 
                   <div className="min-w-0">
                     <p className="truncate font-bold">
-                      {entry.googleAccountEmail ?? entry.email ?? "Sem conta Google"}
+                      {maskEmail(entry.googleAccountEmail) ?? maskEmail(entry.email) ?? "Sem conta Google"}
                     </p>
                     <p className="mt-0.5 text-xs text-[var(--color-ink-soft)]">
                       {entry.googleAccountId

--- a/src/components/app-chrome.tsx
+++ b/src/components/app-chrome.tsx
@@ -8,16 +8,19 @@ import { useEffect, useState } from "react";
 import { AuthButtons } from "@/components/auth-buttons";
 import { LivestreamIndicator } from "@/components/livestream-indicator";
 import { hasUsableAppSession } from "@/lib/auth/session-state";
+import type { ThemeMode } from "@/lib/theme";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
 
 export function AppChrome({
   children,
+  initialTheme = null,
   isAdmin = false,
   isLive = false,
   session,
 }: {
   children: React.ReactNode;
+  initialTheme?: ThemeMode | null;
   isAdmin?: boolean;
   isLive?: boolean;
   session: Session | null;
@@ -82,7 +85,7 @@ export function AppChrome({
         <div className="mx-auto flex w-full max-w-[1500px] items-center gap-4 px-4 py-3 sm:px-6 lg:px-10">
           <div className="shrink-0">
             <Link href="/" className="group flex items-center gap-3">
-              <div className="flex h-12 w-12 items-center justify-center rounded-[var(--radius)] border-[3px] border-[var(--color-ink)] bg-[var(--color-pink)] text-lg font-bold text-[var(--color-accent-ink)] shadow-[4px_4px_0_#000] transition-transform group-hover:rotate-[-4deg]">
+              <div className="flex h-12 w-12 items-center justify-center rounded-[var(--radius)] border-[3px] border-[var(--color-ink)] bg-[var(--color-pink)] text-lg font-bold text-[var(--color-accent-ink)] shadow-[4px_4px_0_var(--shadow-color)] transition-transform group-hover:rotate-[-4deg]">
                 Pz
               </div>
               <p
@@ -102,7 +105,7 @@ export function AppChrome({
                   href={link.href}
                   className={`rounded-[var(--radius)] border px-3.5 py-1.5 text-xs font-extrabold uppercase tracking-[0.1em] transition-colors duration-[var(--snap)] ${
                     pathname === link.href
-                      ? "border-[2px] border-[var(--color-ink)] bg-[var(--color-purple)] text-[var(--color-ink)] shadow-[4px_4px_0_#000]"
+                      ? "pastel-action border-[2px] border-[var(--color-ink)] bg-[var(--color-purple)] text-[var(--color-accent-ink)] shadow-[4px_4px_0_var(--shadow-color)]"
                       : "border-transparent text-[var(--color-ink-soft)] hover:border-[var(--color-ink)] hover:bg-[var(--color-paper)] hover:text-[var(--color-ink)]"
                   }`}
                 >
@@ -116,7 +119,7 @@ export function AppChrome({
             <div className="hidden md:block">
               <LivestreamIndicator isLive={isLive} compact />
             </div>
-            <ThemeToggle />
+            <ThemeToggle initialTheme={initialTheme} />
             <div className="hidden md:block">
               <AuthButtons />
             </div>
@@ -148,7 +151,7 @@ export function AppChrome({
                   onClick={() => setMobileOpen(false)}
                   className={`rounded-[var(--radius)] border px-4 py-3 text-sm font-extrabold uppercase tracking-[0.1em] transition-colors duration-[var(--snap)] ${
                     pathname === link.href
-                      ? "border-[2px] border-[var(--color-ink)] bg-[var(--color-purple)] text-[var(--color-ink)] shadow-[4px_4px_0_#000]"
+                      ? "pastel-action border-[2px] border-[var(--color-ink)] bg-[var(--color-purple)] text-[var(--color-accent-ink)] shadow-[4px_4px_0_var(--shadow-color)]"
                       : "border-[2px] border-transparent text-[var(--color-ink-soft)] hover:border-[var(--color-ink)] hover:bg-[var(--color-paper)] hover:text-[var(--color-ink)] active:border-[var(--color-ink)] active:bg-[var(--color-paper)] active:text-[var(--color-ink)]"
                   }`}
                 >

--- a/src/components/bet-card.tsx
+++ b/src/components/bet-card.tsx
@@ -8,22 +8,6 @@ import { Input } from "@/components/ui/input";
 import type { BetWithOptionsRecord } from "@/lib/types";
 import { formatPipetz } from "@/lib/utils";
 
-function timeLeft(closesAt: string, nowMs: number): string {
-  const diff = new Date(closesAt).getTime() - nowMs;
-  if (diff <= 0) return "Encerrada";
-  const hours = Math.floor(diff / (1000 * 60 * 60));
-  const mins = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
-  if (hours > 0) return `${hours}h ${mins}min restantes`;
-  return `${mins}min restantes`;
-}
-
-function statusLabel(bet: BetWithOptionsRecord, nowMs: number) {
-  if (bet.status === "resolved") return "Resolvida";
-  if (bet.status === "cancelled") return "Cancelada";
-  if (bet.status === "locked") return "Travada";
-  return timeLeft(bet.closesAt, nowMs);
-}
-
 function mapError(message: string) {
   switch (message) {
     case "saldo_insuficiente":
@@ -42,15 +26,6 @@ function mapError(message: string) {
       return message;
   }
 }
-
-const accentColors = [
-  "var(--color-purple-mid)",
-  "var(--color-blue)",
-  "var(--color-pink-hot)",
-  "var(--color-mint)",
-  "var(--color-yellow)",
-  "var(--color-periwinkle)",
-];
 
 const optionBgs = [
   "surface-card",
@@ -72,13 +47,11 @@ const barColors = [
 
 export function BetCard({
   bet,
-  index = 0,
   viewerBalance,
   loggedIn = false,
   canBet = false,
 }: {
   bet: BetWithOptionsRecord;
-  index?: number;
   viewerBalance?: number | null;
   loggedIn?: boolean;
   canBet?: boolean;
@@ -110,8 +83,6 @@ export function BetCard({
   const selectedOption = bet.viewerPosition?.optionId ?? draftSelectedOption;
   const selectedOptionLabel =
     bet.options.find((option) => option.id === selectedOption)?.label ?? "opção selecionada";
-  const accent = accentColors[index % accentColors.length];
-
   function handlePlace() {
     const parsed = Number.parseInt(amount, 10);
     if (!selectedOption || !Number.isInteger(parsed) || parsed <= 0) {
@@ -149,7 +120,6 @@ export function BetCard({
     <div
       className="panel-inset p-5"
       style={{
-        borderLeftColor: accent,
         backgroundColor: isResolved ? "var(--color-lilac)" : "var(--color-paper)",
       }}
     >
@@ -161,17 +131,9 @@ export function BetCard({
           >
             {bet.question}
           </h3>
-          <p className="mono mt-1 text-xs uppercase tracking-[0.15em] text-[var(--color-ink-soft)]">
-            {statusLabel(bet, nowMs)}
-          </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
-          <div
-            className="badge-brutal px-3 py-1.5 text-xs text-[var(--color-ink)]"
-            style={{
-              backgroundColor: `color-mix(in srgb, ${accent} 18%, var(--color-paper-warm) 82%)`,
-            }}
-          >
+          <div className="px-3 py-1.5 text-xs font-bold uppercase tracking-[0.06em] text-[var(--color-ink)]">
             Pool: {formatPipetz(bet.totalPool)}
           </div>
           {typeof viewerBalance === "number" ? (
@@ -210,7 +172,6 @@ export function BetCard({
         {bet.options.map((opt, i) => {
           const isWinner = isResolved && bet.winningOptionId === opt.id;
           const isViewerPick = bet.viewerPosition?.optionId === opt.id;
-          const pct = bet.totalPool > 0 ? Math.round((opt.poolAmount / bet.totalPool) * 100) : 0;
           const bgClass = optionBgs[i % optionBgs.length];
           const selectable = isOpen && canBet && !hasViewerBet;
 
@@ -220,26 +181,16 @@ export function BetCard({
               type="button"
               disabled={!selectable}
               onClick={() => setDraftSelectedOption(selectedOption === opt.id ? null : opt.id)}
-              className={`card-flat relative flex items-center justify-between overflow-hidden p-3 text-left ${
+              className={`card-flat relative flex items-center justify-between overflow-hidden !border !border-[1px] p-3 text-left ${
                 isWinner
-                  ? "border-[var(--color-ink)] bg-[var(--color-mint)] ring-2 ring-[var(--color-ink)]"
+                  ? "!border-[var(--color-ink)] bg-[var(--color-mint)] text-[var(--color-accent-ink)] ring-1 ring-[var(--color-ink)]"
                   : selectedOption === opt.id || isViewerPick
-                    ? "border-[var(--color-purple-bold)] bg-[var(--color-lavender)] ring-2 ring-[var(--color-purple-bold)]"
+                    ? "!border-[var(--color-purple-bold)] bg-[var(--color-lavender)] ring-1 ring-[var(--color-purple-bold)]"
                     : bgClass
               } ${selectable ? "cursor-pointer" : "cursor-default"}`}
             >
-              {!isWinner && selectedOption !== opt.id && !isViewerPick ? (
-                <div
-                  className="pointer-events-none absolute inset-y-0 left-0 opacity-[0.12]"
-                  style={{
-                    width: `${pct}%`,
-                    backgroundColor: barColors[i % barColors.length],
-                  }}
-                />
-              ) : null}
-
               <div className="relative flex items-center gap-2">
-                <span className="rounded-[var(--radius)] border-2 border-[var(--color-ink)] bg-[var(--color-paper)] px-2 py-0.5 text-[10px] font-black uppercase">
+                <span className="rounded-[var(--radius)] border-2 border-[var(--color-ink)] bg-transparent px-2 py-0.5 text-[10px] font-black uppercase">
                   #{i + 1}
                 </span>
                 <span
@@ -260,10 +211,7 @@ export function BetCard({
                     sua aposta
                   </span>
                 ) : null}
-                <span className="mono text-xs font-bold text-[var(--color-ink-soft)]">
-                  {pct}%
-                </span>
-                <span className="rounded-[var(--radius)] border-2 border-[var(--color-ink)] bg-[var(--color-paper)] px-2 py-0.5 text-xs font-bold">
+                <span className="text-xs font-bold">
                   {formatPipetz(opt.poolAmount)}
                 </span>
               </div>

--- a/src/components/bet-list.tsx
+++ b/src/components/bet-list.tsx
@@ -46,23 +46,14 @@ export function BetList({
 
   const header = (
     <>
-      <div className="flex items-center gap-3">
-        <span className="mono text-[11px] font-black uppercase tracking-[0.18em] text-[var(--color-ink-soft)]">
-          {title.toLowerCase().includes("encerrada") ? "encerradas" : "ao vivo"}
-        </span>
-        <h2 className="text-2xl font-bold uppercase" style={{ fontFamily: "var(--font-display)" }}>
-          {title}
-        </h2>
-      </div>
-      <p className="mono mt-1 text-xs uppercase tracking-[0.2em] text-[var(--color-ink-soft)]">
-        {bets.length} {bets.length === 1 ? "aposta" : "apostas"}
-      </p>
+      <h2 className="text-2xl font-bold uppercase" style={{ fontFamily: "var(--font-display)" }}>
+        {title}
+      </h2>
       <div className="mt-5 grid gap-4">
-        {bets.map((bet, i) => (
+        {bets.map((bet) => (
           <BetCard
             key={bet.id}
             bet={bet}
-            index={i}
             viewerBalance={viewerBalance}
             loggedIn={loggedIn}
             canBet={canBet}

--- a/src/components/counter-board.tsx
+++ b/src/components/counter-board.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { StreamerbotCounterSummaryRecord } from "@/lib/types";
 import { formatPipetz } from "@/lib/utils";
 
@@ -7,19 +7,11 @@ function scopeHeading(scopeKey: string, scopeLabel: string | null) {
 }
 
 function CounterCard({ counter }: { counter: StreamerbotCounterSummaryRecord }) {
-  const scopeText =
-    counter.scopeType === "global"
-      ? "escopo global"
-      : `jogo: ${scopeHeading(counter.scopeKey, counter.scopeLabel)}`;
-
   return (
     <Card variant="poster" className="h-full bg-[var(--color-paper)] p-5">
       <CardHeader className="gap-0">
-        <CardDescription className="mono text-[10px] uppercase tracking-[0.28em]">
-          {scopeText}
-        </CardDescription>
         <CardTitle
-          className="mt-3 text-3xl uppercase leading-none sm:text-4xl"
+          className="text-3xl uppercase leading-none sm:text-4xl"
           style={{ fontFamily: "var(--font-display)" }}
         >
           {counter.label}
@@ -27,9 +19,9 @@ function CounterCard({ counter }: { counter: StreamerbotCounterSummaryRecord }) 
       </CardHeader>
 
       <CardContent className="mt-6">
-        <div className="inline-flex border-[3px] border-[var(--color-ink)] bg-[var(--color-yellow)] px-4 py-2 shadow-[4px_4px_0_#000]">
+        <div className="micro-flat inline-flex border-[3px] border-[var(--color-ink)] bg-[var(--color-purple)] px-4 py-2 shadow-[4px_4px_0_var(--shadow-color)]">
           <span
-            className="text-3xl uppercase leading-none sm:text-4xl"
+            className="text-3xl uppercase leading-none text-[var(--color-accent-ink)] sm:text-4xl"
             style={{ fontFamily: "var(--font-display)" }}
           >
             {formatPipetz(counter.value)}
@@ -54,16 +46,7 @@ export function CounterBoard({ counters }: { counters: StreamerbotCounterSummary
   return (
     <div className="space-y-10">
       <section>
-        <div className="mb-4 flex items-center gap-2">
-          <span className="text-xl">Global</span>
-          <h2
-            className="text-2xl font-bold uppercase"
-            style={{ fontFamily: "var(--font-display)" }}
-          >
-            Contadores da live inteira
-          </h2>
-        </div>
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
           {globalCounters.map((counter) => (
             <CounterCard key={`${counter.scopeType}:${counter.scopeKey}:${counter.key}`} counter={counter} />
           ))}
@@ -72,37 +55,24 @@ export function CounterBoard({ counters }: { counters: StreamerbotCounterSummary
 
       {gameGroups.size > 0 ? (
         <section className="space-y-8">
-          <div className="mb-4 flex items-center gap-2">
-            <span className="text-xl">Jogos</span>
-            <h2
-              className="text-2xl font-bold uppercase"
-              style={{ fontFamily: "var(--font-display)" }}
-            >
-              Contadores por jogo
-            </h2>
-          </div>
-
-          {Array.from(gameGroups.entries()).map(([scopeKey, entries]) => (
-            <div key={scopeKey} className="landing-plane bg-[var(--color-paper-pink)] p-5 sm:p-6">
-              <div className="mb-5">
-                <p className="mono text-[10px] uppercase tracking-[0.28em] text-[var(--color-ink-soft)]">
-                  jogo monitorado
-                </p>
+          <div className="grid gap-8 xl:grid-cols-2">
+            {Array.from(gameGroups.entries()).map(([scopeKey, entries]) => (
+              <div key={scopeKey} className="landing-plane h-full bg-[var(--color-paper-pink)] p-5 sm:p-6">
                 <h3
-                  className="mt-2 text-3xl uppercase leading-none"
+                  className="mb-5 text-3xl uppercase leading-none"
                   style={{ fontFamily: "var(--font-display)" }}
                 >
                   {scopeHeading(scopeKey, entries[0]?.scopeLabel ?? null)}
                 </h3>
-              </div>
 
-              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-                {entries.map((counter) => (
-                  <CounterCard key={`${counter.scopeType}:${counter.scopeKey}:${counter.key}`} counter={counter} />
-                ))}
+                <div className="grid gap-4">
+                  {entries.map((counter) => (
+                    <CounterCard key={`${counter.scopeType}:${counter.scopeKey}:${counter.key}`} counter={counter} />
+                  ))}
+                </div>
               </div>
-            </div>
-          ))}
+            ))}
+          </div>
         </section>
       ) : null}
     </div>

--- a/src/components/game-suggestion-card.tsx
+++ b/src/components/game-suggestion-card.tsx
@@ -121,7 +121,7 @@ export function GameSuggestionCard({
               {suggestion.name}
             </h3>
             <span
-              className="sticker px-2 py-0.5 text-[10px] text-[var(--color-ink)]"
+              className="sticker micro-flat px-2 py-0.5 text-[10px] text-[var(--color-ink)]"
               style={{ backgroundColor: statusColors[suggestion.status] }}
             >
               {statusLabels[suggestion.status]}
@@ -142,7 +142,7 @@ export function GameSuggestionCard({
           ) : null}
         </div>
 
-        <div className="rounded-[var(--radius)] border-[3px] border-[var(--color-ink)] bg-[var(--color-paper)] px-4 py-2 text-center shadow-purple">
+        <div className="micro-flat rounded-[var(--radius)] border-[3px] border-[var(--color-ink)] bg-[var(--color-paper)] px-4 py-2 text-center shadow-purple">
           <p
             className="text-2xl font-bold text-[var(--color-purple-bold)]"
             style={{ fontFamily: "var(--font-display)" }}

--- a/src/components/leaderboard-table.tsx
+++ b/src/components/leaderboard-table.tsx
@@ -33,8 +33,8 @@ export function LeaderboardTable({
   compact?: boolean;
 }) {
   return (
-    <div className="overflow-hidden rounded-[var(--radius)] border-[3px] border-[var(--color-ink)] shadow-[4px_4px_0_#000]">
-      <div className="grid grid-cols-[60px_minmax(0,1fr)_110px] gap-3 border-b-[3px] border-[var(--color-ink)] bg-[var(--color-blue)] px-4 py-3 text-xs font-bold uppercase tracking-[0.18em] sm:grid-cols-[60px_minmax(0,1fr)_110px_150px]">
+    <div className="overflow-hidden rounded-[var(--radius)] border-[3px] border-[var(--color-ink)] shadow-[4px_4px_0_var(--shadow-color)]">
+      <div className="grid grid-cols-[60px_minmax(0,1fr)_110px] gap-3 border-b-[3px] border-[var(--color-ink)] bg-[var(--color-blue)] px-4 py-3 text-xs font-bold uppercase tracking-[0.18em] text-[var(--color-accent-ink)] sm:grid-cols-[60px_minmax(0,1fr)_110px_150px]">
         <span>#</span>
         <span>Viewer</span>
         <span>Pipetz</span>
@@ -52,16 +52,21 @@ export function LeaderboardTable({
                 youtubeHandle: viewer.youtubeHandle,
               });
           const podium = podiumClass(index);
+          const isPodium = podium.length > 0;
           return (
             <div
               key={viewer.id ?? `${viewer.youtubeDisplayName}-${index}`}
-              className={`grid grid-cols-[60px_minmax(0,1fr)_110px] gap-3 border-b-[3px] border-[var(--color-ink)] bg-[var(--color-paper)] px-4 py-3.5 text-sm sm:grid-cols-[60px_minmax(0,1fr)_110px_150px] ${podium}`}
+              className={`grid grid-cols-[60px_minmax(0,1fr)_110px] gap-3 border-b-[3px] border-[var(--color-ink)] bg-[var(--color-paper)] px-4 py-3.5 text-sm sm:grid-cols-[60px_minmax(0,1fr)_110px_150px] ${podium} ${isPodium ? "text-[var(--color-accent-ink)]" : ""}`}
             >
               <span className="mono self-center font-bold">#{index + 1}</span>
               <div>
                 <p className="font-black uppercase">{viewer.youtubeDisplayName}</p>
                 {handle ? (
-                  <p className="mt-0.5 text-xs tracking-[0.15em] text-[var(--color-ink-soft)]">
+                  <p
+                    className={`mt-0.5 text-xs tracking-[0.15em] ${
+                      isPodium ? "text-[var(--color-accent-ink-soft)]" : "text-[var(--color-ink-soft)]"
+                    }`}
+                  >
                     {handle}
                   </p>
                 ) : null}
@@ -70,7 +75,11 @@ export function LeaderboardTable({
                 {formatPipetz(balance.currentBalance)}
               </span>
               {!compact ? (
-                <span className="hidden self-center text-[var(--color-ink-soft)] sm:block">
+                <span
+                  className={`hidden self-center sm:block ${
+                    isPodium ? "text-[var(--color-accent-ink-soft)]" : "text-[var(--color-ink-soft)]"
+                  }`}
+                >
                   {formatDateTime(balance.lastSyncedAt)}
                 </span>
               ) : null}

--- a/src/components/livestream-indicator.tsx
+++ b/src/components/livestream-indicator.tsx
@@ -10,13 +10,13 @@ export function LivestreamIndicator({
   className?: string;
 }) {
   const liveClasses = isLive
-    ? "bg-[var(--color-mint)] text-[var(--color-ink)]"
+    ? "bg-[var(--color-mint)] text-[var(--color-accent-ink)]"
     : "bg-[var(--color-paper)] text-[var(--color-ink-soft)]";
 
   return (
     <div
       className={cn(
-        "sticker inline-flex items-center gap-2 border-[3px] border-[var(--color-ink)] px-3 py-2 font-black uppercase tracking-[0.14em]",
+        "sticker micro-flat inline-flex items-center gap-2 border-[3px] border-[var(--color-ink)] px-3 py-2 font-black uppercase tracking-[0.14em]",
         compact ? "text-[10px]" : "text-xs sm:text-sm",
         liveClasses,
         className,

--- a/src/components/obs-quote-overlay.tsx
+++ b/src/components/obs-quote-overlay.tsx
@@ -154,16 +154,16 @@ export function ObsQuoteOverlay() {
           aria-live="polite"
         >
           <div className="absolute inset-0 opacity-25">
-            <div className="h-full w-full bg-[radial-gradient(circle_at_20%_20%,#ff66b3_0,transparent_24%),radial-gradient(circle_at_80%_30%,#41d1ff_0,transparent_20%),radial-gradient(circle_at_50%_80%,#b6ff3b_0,transparent_22%)]" />
+            <div className="h-full w-full bg-[radial-gradient(circle_at_20%_20%,#ff66b3_0,transparent_24%),radial-gradient(circle_at_80%_30%,#41d1ff_0,transparent_20%),radial-gradient(circle_at_50%_80%,#00beae_0,transparent_22%)]" />
           </div>
-          <div className="absolute inset-x-0 top-0 h-5 border-b-[4px] border-black bg-[repeating-linear-gradient(90deg,#000_0_28px,#ff66b3_28px_56px,#41d1ff_56px_84px,#b6ff3b_84px_112px)]" />
+          <div className="absolute inset-x-0 top-0 h-5 border-b-[4px] border-black bg-[repeating-linear-gradient(90deg,#000_0_28px,#ff66b3_28px_56px,#41d1ff_56px_84px,#00beae_84px_112px)]" />
           <div className="relative flex flex-col gap-6 px-6 pb-6 pt-10 sm:px-10 sm:pb-10 sm:pt-12">
             <div className="flex flex-col items-start gap-3 text-[11px] font-black uppercase tracking-[0.22em] sm:text-xs">
               <div className="flex flex-wrap items-center gap-3">
                 <span className="border-[3px] border-black bg-black px-3 py-1 text-white">
                   Quote #{overlay.quoteNumber}
                 </span>
-                <span className="border-[3px] border-black bg-[#b6ff3b] px-3 py-1">
+                <span className="border-[3px] border-black bg-[#00beae] px-3 py-1">
                   criado por {overlay.createdByDisplayName}
                 </span>
               </div>

--- a/src/components/pipetz-balance-card.tsx
+++ b/src/components/pipetz-balance-card.tsx
@@ -3,14 +3,10 @@ import { formatPipetz } from "@/lib/utils";
 export function PipetzBalanceCard({
   displayName,
   currentBalance,
-  lifetimeEarned,
-  lifetimeSpent,
   compact = false,
 }: {
   displayName: string;
   currentBalance: number;
-  lifetimeEarned: number;
-  lifetimeSpent: number;
   compact?: boolean;
 }) {
   return (
@@ -48,16 +44,6 @@ export function PipetzBalanceCard({
           </div>
         </div>
 
-        {!compact ? (
-          <div className="relative mt-5 flex flex-wrap gap-3">
-            <span className="accent-chip rounded-[var(--radius)] border-2 border-[var(--color-ink)] px-3 py-1.5 text-sm font-bold">
-              Ganhos: {formatPipetz(lifetimeEarned)}
-            </span>
-            <span className="surface-card-accent rounded-[var(--radius)] border-2 border-[var(--color-ink)] px-3 py-1.5 text-sm font-bold">
-              Gastos: {formatPipetz(lifetimeSpent)}
-            </span>
-          </div>
-        ) : null}
       </div>
     </section>
   );

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,35 +1,49 @@
 "use client";
 
-import { useState } from "react";
+import { useSyncExternalStore } from "react";
 
 import { Button } from "@/components/ui/button";
+import {
+  getPreferredTheme,
+  persistTheme,
+  themeStorageKey,
+  type ThemeMode,
+} from "@/lib/theme";
 
-const storageKey = "pipetz-theme";
+const themeChangeEvent = "pipetz-theme-change";
 
-type ThemeMode = "light" | "dark";
+function subscribe(onStoreChange: () => void) {
+  if (typeof window === "undefined") {
+    return () => undefined;
+  }
 
-function applyTheme(theme: ThemeMode) {
-  document.documentElement.dataset.theme = theme;
-  document.documentElement.style.colorScheme = theme;
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key === null || event.key === themeStorageKey) {
+      onStoreChange();
+    }
+  };
+  const handleThemeChange = () => onStoreChange();
+
+  window.addEventListener("storage", handleStorage);
+  window.addEventListener(themeChangeEvent, handleThemeChange);
+
+  return () => {
+    window.removeEventListener("storage", handleStorage);
+    window.removeEventListener(themeChangeEvent, handleThemeChange);
+  };
 }
 
-export function ThemeToggle() {
-  const [theme, setTheme] = useState<ThemeMode>(() => {
-    if (typeof document !== "undefined") {
-      const rootTheme = document.documentElement.dataset.theme;
-      if (rootTheme === "dark" || rootTheme === "light") {
-        return rootTheme;
-      }
-    }
-
-    return "light";
-  });
+export function ThemeToggle({ initialTheme = null }: { initialTheme?: ThemeMode | null }) {
+  const theme = useSyncExternalStore(
+    subscribe,
+    getPreferredTheme,
+    () => initialTheme ?? "light",
+  );
 
   function handleToggle() {
     const nextTheme = theme === "dark" ? "light" : "dark";
-    window.localStorage.setItem(storageKey, nextTheme);
-    applyTheme(nextTheme);
-    setTheme(nextTheme);
+    persistTheme(nextTheme);
+    window.dispatchEvent(new Event(themeChangeEvent));
   }
 
   const isDark = theme === "dark";

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -13,7 +13,7 @@ const buttonVariants = cva(
         default: "ink-button text-[var(--color-accent-ink)]",
         accent: "accent-button text-[var(--color-accent-ink)]",
         neutral: "bg-[var(--color-paper)] text-[var(--color-ink)]",
-        success: "bg-[var(--color-mint)] text-[var(--color-ink)]",
+        success: "bg-[var(--color-mint)] text-[var(--color-accent-ink)]",
         info: "bg-[var(--color-sky)] text-[var(--color-ink)]",
         danger: "bg-[var(--color-rose)] text-[var(--color-ink)]",
         pink: "bg-[var(--color-pink)] text-[var(--color-accent-ink)]",

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "w-full min-w-0 rounded-[var(--radius)] border-[3px] border-[var(--color-ink)] bg-[var(--color-paper)] px-4 py-3 text-sm font-bold text-[var(--color-ink)] shadow-[3px_3px_0_var(--shadow-color)] outline-none placeholder:font-medium placeholder:text-[var(--color-ink-soft)] focus-visible:outline-[3px] focus-visible:outline-[var(--color-purple-mid)] focus-visible:outline-offset-[1px] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-60",
+        "w-full min-w-0 rounded-[var(--radius)] border-[3px] border-[var(--color-ink)] bg-[var(--color-paper)] px-4 py-3 text-sm font-bold text-[var(--color-ink)] outline-none placeholder:font-medium placeholder:text-[var(--color-ink-soft)] focus-visible:outline-[3px] focus-visible:outline-[var(--color-purple-mid)] focus-visible:outline-offset-[1px] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-60",
         className,
       )}
       {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -41,7 +41,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "flex w-fit min-w-40 items-center justify-between gap-3 rounded-[var(--radius)] border-[3px] border-[var(--color-ink)] bg-[var(--color-paper)] px-4 text-left font-bold text-[var(--color-ink)] shadow-[3px_3px_0_var(--shadow-color)] outline-none transition-transform data-placeholder:text-[var(--color-ink-soft)] data-[size=default]:py-3 data-[size=default]:text-sm data-[size=sm]:px-3 data-[size=sm]:py-2 data-[size=sm]:text-xs focus-visible:outline-[3px] focus-visible:outline-[var(--color-purple-mid)] focus-visible:outline-offset-[1px] disabled:cursor-not-allowed disabled:opacity-60 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "flex w-fit min-w-40 items-center justify-between gap-3 rounded-[var(--radius)] border-[3px] border-[var(--color-ink)] bg-[var(--color-paper)] px-4 text-left font-bold text-[var(--color-ink)] outline-none transition-transform data-placeholder:text-[var(--color-ink-soft)] data-[size=default]:py-3 data-[size=default]:text-sm data-[size=sm]:px-3 data-[size=sm]:py-2 data-[size=sm]:text-xs focus-visible:outline-[3px] focus-visible:outline-[var(--color-purple-mid)] focus-visible:outline-offset-[1px] disabled:cursor-not-allowed disabled:opacity-60 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       {...props}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "flex min-h-28 w-full rounded-[var(--radius)] border-[3px] border-[var(--color-ink)] bg-[var(--color-paper)] px-4 py-3 text-sm text-[var(--color-ink)] shadow-[3px_3px_0_var(--shadow-color)] outline-none placeholder:text-[var(--color-ink-soft)] focus-visible:outline-[3px] focus-visible:outline-[var(--color-purple-mid)] focus-visible:outline-offset-[1px] disabled:cursor-not-allowed disabled:opacity-60",
+        "flex min-h-28 w-full rounded-[var(--radius)] border-[3px] border-[var(--color-ink)] bg-[var(--color-paper)] px-4 py-3 text-sm text-[var(--color-ink)] outline-none placeholder:text-[var(--color-ink-soft)] focus-visible:outline-[3px] focus-visible:outline-[var(--color-purple-mid)] focus-visible:outline-offset-[1px] disabled:cursor-not-allowed disabled:opacity-60",
         className,
       )}
       {...props}

--- a/src/components/viewer-link-card.tsx
+++ b/src/components/viewer-link-card.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import { useEffect, useState, useTransition } from "react";
 
@@ -129,13 +129,13 @@ export function ViewerLinkCard({ isLinked }: { isLinked: boolean }) {
           </div>
 
           <div className="mt-6 grid gap-3 text-sm text-[var(--color-ink-soft)] sm:grid-cols-3">
-            <div className="card-flat bg-[var(--color-mint)] p-4">
+            <div className="card-flat bg-[var(--color-mint)] p-4 text-[var(--color-accent-ink)]">
               1. Entre no site com o login que você preferir.
             </div>
-            <div className="card-flat bg-[var(--color-yellow)] p-4">
+            <div className="card-flat bg-[var(--color-yellow)] p-4 text-[var(--color-accent-ink)]">
               2. Gere o código e mande <span className="font-black">!link CÓDIGO</span> no chat.
             </div>
-            <div className="card-flat bg-[var(--color-pink)] p-4">
+            <div className="card-flat bg-[var(--color-pink)] p-4 text-[var(--color-accent-ink)]">
               3. O bot vincula seu viewer e seu saldo passa a seguir esse canal.
             </div>
           </div>
@@ -144,3 +144,4 @@ export function ViewerLinkCard({ isLinked }: { isLinked: boolean }) {
     </section>
   );
 }
+

--- a/src/lib/theme.test.ts
+++ b/src/lib/theme.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildThemeCookie,
+  getThemeCookieValue,
+  resolveThemePreference,
+} from "@/lib/theme";
+
+describe("resolveThemePreference", () => {
+  it("keeps a valid stored theme", () => {
+    expect(resolveThemePreference("dark", false)).toBe("dark");
+    expect(resolveThemePreference("light", true)).toBe("light");
+  });
+
+  it("falls back to system preference when storage is invalid", () => {
+    expect(resolveThemePreference("system", true)).toBe("dark");
+    expect(resolveThemePreference(null, false)).toBe("light");
+  });
+});
+
+describe("theme cookies", () => {
+  it("extracts the persisted theme from the cookie header", () => {
+    const cookie = buildThemeCookie("dark");
+
+    expect(getThemeCookieValue(`foo=bar; ${cookie}`)).toBe("dark");
+  });
+
+  it("ignores invalid theme cookies", () => {
+    expect(getThemeCookieValue("pipetz-theme=sepia")).toBeNull();
+  });
+});

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,79 @@
+export const themeStorageKey = "pipetz-theme";
+export const themeCookieKey = "pipetz-theme";
+export const themeCookieMaxAge = 60 * 60 * 24 * 365;
+
+export type ThemeMode = "light" | "dark";
+
+export function isThemeMode(value: string | null | undefined): value is ThemeMode {
+  return value === "light" || value === "dark";
+}
+
+export function resolveThemePreference(
+  storedTheme: string | null | undefined,
+  prefersDark: boolean,
+): ThemeMode {
+  if (isThemeMode(storedTheme)) {
+    return storedTheme;
+  }
+
+  return prefersDark ? "dark" : "light";
+}
+
+export function getThemeCookieValue(cookieHeader: string | null | undefined): ThemeMode | null {
+  if (!cookieHeader) {
+    return null;
+  }
+
+  const cookies = cookieHeader.split(";");
+  for (const cookie of cookies) {
+    const [rawName, ...rawValue] = cookie.trim().split("=");
+    if (rawName !== themeCookieKey) {
+      continue;
+    }
+
+    const value = decodeURIComponent(rawValue.join("="));
+    return isThemeMode(value) ? value : null;
+  }
+
+  return null;
+}
+
+export function buildThemeCookie(theme: ThemeMode) {
+  return `${themeCookieKey}=${theme}; Path=/; Max-Age=${themeCookieMaxAge}; SameSite=Lax`;
+}
+
+export function applyTheme(theme: ThemeMode) {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  document.documentElement.dataset.theme = theme;
+  document.documentElement.style.colorScheme = theme;
+}
+
+export function getPreferredTheme(): ThemeMode {
+  if (typeof document === "undefined" || typeof window === "undefined") {
+    return "light";
+  }
+
+  const rootTheme = document.documentElement.dataset.theme;
+  if (isThemeMode(rootTheme)) {
+    return rootTheme;
+  }
+
+  const storedTheme = window.localStorage.getItem(themeStorageKey);
+  return resolveThemePreference(
+    storedTheme,
+    window.matchMedia("(prefers-color-scheme: dark)").matches,
+  );
+}
+
+export function persistTheme(theme: ThemeMode) {
+  if (typeof document === "undefined" || typeof window === "undefined") {
+    return;
+  }
+
+  window.localStorage.setItem(themeStorageKey, theme);
+  document.cookie = buildThemeCookie(theme);
+  applyTheme(theme);
+}


### PR DESCRIPTION
## Summary
- improve dark mode persistence, palette, and contrast rules across public pages and shared UI
- simplify betting, counters, landing, and logged-in screens to reduce visual clutter and tighten layouts
- mask user emails in admin and document the PowerShell UTF-8 editing caveat in AGENTS

## Testing
- npm.cmd run test -- src/lib/theme.test.ts

Closes #69