### PR TITLE
[codex] Add admin OBS overlay pause queue

### DIFF
--- a/drizzle/0006_obs_overlay_pause_queue.sql
+++ b/drizzle/0006_obs_overlay_pause_queue.sql
@@ -1,0 +1,31 @@
+CREATE TABLE "obs_overlay_control" (
+	"key" varchar(64) PRIMARY KEY NOT NULL,
+	"status" varchar(32) DEFAULT 'active' NOT NULL,
+	"paused_at" timestamp with time zone,
+	"resumed_at" timestamp with time zone,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_by" varchar(255),
+	"last_error" text
+);
+
+CREATE TABLE "quote_overlay_queue" (
+	"id" varchar(64) PRIMARY KEY NOT NULL,
+	"quote_number" integer NOT NULL,
+	"quote_body" text NOT NULL,
+	"created_by_display_name" varchar(255) NOT NULL,
+	"created_by_youtube_handle" varchar(255),
+	"requested_by_viewer_id" varchar(64) NOT NULL,
+	"requested_by_display_name" varchar(255) NOT NULL,
+	"requested_by_youtube_handle" varchar(255),
+	"source" varchar(64) DEFAULT 'streamerbot_chat' NOT NULL,
+	"cost" integer NOT NULL,
+	"display_duration_seconds" integer NOT NULL,
+	"status" varchar(32) DEFAULT 'queued' NOT NULL,
+	"queued_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"processed_at" timestamp with time zone,
+	"cancelled_at" timestamp with time zone,
+	"failure_reason" text
+);
+
+ALTER TABLE "quote_overlay_queue" ADD CONSTRAINT "quote_overlay_queue_requested_by_viewer_id_users_id_fk" FOREIGN KEY ("requested_by_viewer_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1776180764409,
       "tag": "0005_massive_yellow_claw",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1776272400000,
+      "tag": "0006_obs_overlay_pause_queue",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -12,6 +12,7 @@ import {
   getBridgeStatus,
   getCatalog,
   getLeaderboard,
+  getObsOverlayAdminStatus,
   listAdminViewerDirectory,
   listAdminGameSuggestions,
   listAdminProductRecommendations,
@@ -32,7 +33,7 @@ const statusColorMap: Record<string, string> = {
 
 export default async function AdminPage() {
   await requireAdminSession();
-  const [catalog, leaderboard, bridge, liveStatus, activeDeathCounterGame, redemptions, bets, suggestions, recommendations, viewers] = await Promise.all([
+  const [catalog, leaderboard, bridge, liveStatus, activeDeathCounterGame, redemptions, bets, suggestions, recommendations, viewers, obsOverlayStatus] = await Promise.all([
     getCatalog(),
     getLeaderboard(),
     getBridgeStatus(),
@@ -43,6 +44,7 @@ export default async function AdminPage() {
     listAdminGameSuggestions(),
     listAdminProductRecommendations(),
     listAdminViewerDirectory(),
+    getObsOverlayAdminStatus(),
   ]);
 
   return (
@@ -98,6 +100,8 @@ export default async function AdminPage() {
         </div>
       </section>
 
+      <AdminObsOverlaysPanel initialStatus={obsOverlayStatus} />
+
       <section className="landing-plane landing-divider bg-[var(--color-sky)] py-8 sm:py-10">
         <div className="mx-auto grid w-full max-w-[1500px] gap-6 px-4 sm:px-6 lg:px-10 xl:grid-cols-[1.05fr_0.95fr]">
           <div className="panel surface-section p-6">
@@ -114,7 +118,6 @@ export default async function AdminPage() {
 
       <AdminBetsPanel bets={bets} />
       <AdminViewerLinksPanel entries={viewers} />
-      <AdminObsOverlaysPanel />
       <AdminGameSuggestionsPanel suggestions={suggestions} />
       <AdminRecommendationsPanel recommendations={recommendations} />
     </div>

--- a/src/app/api/admin/obs-overlays/route.ts
+++ b/src/app/api/admin/obs-overlays/route.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+
+import { fail, isTrustedAppMutationRequest, ok, requireAdminApiSession } from "@/lib/api";
+import {
+  cancelQueuedQuoteOverlays,
+  getObsOverlayAdminStatus,
+  setObsOverlayPaused,
+} from "@/lib/db/repository";
+
+const obsOverlayActionSchema = z.object({
+  action: z.enum(["pause", "resume", "cancel_queue"]),
+});
+
+export async function GET() {
+  const session = await requireAdminApiSession();
+  if (!session) {
+    return fail("Forbidden", 403);
+  }
+
+  return ok(await getObsOverlayAdminStatus());
+}
+
+export async function POST(request: Request) {
+  if (!isTrustedAppMutationRequest(request)) {
+    return fail("Forbidden", 403);
+  }
+
+  const session = await requireAdminApiSession();
+  if (!session) {
+    return fail("Forbidden", 403);
+  }
+
+  try {
+    const parsed = obsOverlayActionSchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return fail(parsed.error.issues[0]?.message ?? "Payload invalido.", 400);
+    }
+
+    const updatedBy = session.user?.email?.toLowerCase() ?? null;
+    const status =
+      parsed.data.action === "pause"
+        ? await setObsOverlayPaused({ paused: true, updatedBy })
+        : parsed.data.action === "resume"
+          ? await setObsOverlayPaused({ paused: false, updatedBy })
+          : await cancelQueuedQuoteOverlays({ updatedBy });
+
+    return ok(status);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return fail("Payload invalido.", 400);
+    }
+
+    return fail(error instanceof Error ? error.message : "Falha ao atualizar overlays do OBS.", 400);
+  }
+}

--- a/src/app/api/internal/streamerbot/quotes/route.ts
+++ b/src/app/api/internal/streamerbot/quotes/route.ts
@@ -101,12 +101,16 @@ export async function POST(request: Request) {
       result.action === "create"
         ? `Quote #${result.quote.quoteNumber} salva: "${result.quote.body}"`
         : result.action === "show"
-          ? `${payload.youtubeDisplayName ?? result.viewer?.youtubeDisplayName ?? "Viewer"} colocou a quote #${
-              result.quote.quoteNumber
-            } no OBS por ${Math.round(
-              (new Date(result.overlay.expiresAt).getTime() - new Date(result.overlay.activatedAt).getTime()) /
-                1000,
-            )}s (-${result.overlay.cost} pipetz).`
+          ? result.queued
+            ? `${payload.youtubeDisplayName ?? result.viewer?.youtubeDisplayName ?? "Viewer"}, a quote #${
+                result.quote.quoteNumber
+              } entrou na fila do OBS. Ela aparece quando a admin retomar as chamadas.`
+            : `${payload.youtubeDisplayName ?? result.viewer?.youtubeDisplayName ?? "Viewer"} colocou a quote #${
+                result.quote.quoteNumber
+              } no OBS por ${Math.round(
+                (new Date(result.overlay!.expiresAt).getTime() - new Date(result.overlay!.activatedAt).getTime()) /
+                  1000,
+              )}s (-${result.overlay!.cost} pipetz).`
           : formatQuoteReply(result.quote);
 
     console.info("[streamerbot/quotes] Processed quote command.", {
@@ -124,6 +128,7 @@ export async function POST(request: Request) {
         quoteId: result.quote.quoteNumber,
         quote: result.quote,
         overlay: result.action === "show" ? result.overlay : null,
+        queued: result.action === "show" ? result.queued : null,
         replyMessage,
       },
     });

--- a/src/app/api/me/quotes/[quoteId]/show/route.ts
+++ b/src/app/api/me/quotes/[quoteId]/show/route.ts
@@ -30,7 +30,7 @@ export async function POST(
       source: payload.source,
     });
 
-    return ok(result, { status: 201 });
+    return ok(result, { status: result.queued ? 202 : 201 });
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "Falha ao mostrar quote no overlay.";

--- a/src/app/api/obs/quotes/current/route.ts
+++ b/src/app/api/obs/quotes/current/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from "next/server";
 
-import { getActiveQuoteOverlay } from "@/lib/db/repository";
+import { processNextQueuedQuoteOverlay } from "@/lib/db/repository";
 
 export const dynamic = "force-dynamic";
 
 export async function GET() {
-  const overlay = await getActiveQuoteOverlay();
+  const overlay = await processNextQueuedQuoteOverlay();
 
   return NextResponse.json(
     {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
 import { Archivo_Black, IBM_Plex_Mono, DM_Sans, Geist } from "next/font/google";
-import Script from "next/script";
 
 import { auth } from "@/auth";
 import { AppChrome } from "@/components/app-chrome";
@@ -82,9 +81,7 @@ export default async function RootLayout({
       style={initialTheme ? { colorScheme: initialTheme } : undefined}
     >
       <body className="min-h-full text-[var(--color-ink)]" style={{ fontFamily: "var(--font-body), var(--font-display), sans-serif" }}>
-        <Script id="pipetz-theme" strategy="beforeInteractive">
-          {themeScript}
-        </Script>
+        <script id="pipetz-theme" dangerouslySetInnerHTML={{ __html: themeScript }} />
         <Providers>
           <AppChrome
             session={session}

--- a/src/components/admin-obs-overlays-panel.tsx
+++ b/src/components/admin-obs-overlays-panel.tsx
@@ -1,5 +1,10 @@
-import Link from "next/link";
+"use client";
 
+import Link from "next/link";
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -8,6 +13,8 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import type { ObsOverlayAdminStatusRecord } from "@/lib/types";
+import { formatDateTime, formatPipetz } from "@/lib/utils";
 
 const overlays = [
   {
@@ -20,7 +27,55 @@ const overlays = [
   },
 ];
 
-export function AdminObsOverlaysPanel() {
+export function AdminObsOverlaysPanel({
+  initialStatus,
+}: {
+  initialStatus: ObsOverlayAdminStatusRecord;
+}) {
+  const router = useRouter();
+  const [status, setStatus] = useState(initialStatus);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const isPaused = status.control.status === "paused";
+  const hasConfigurationError = status.control.status === "error";
+
+  function submitAction(action: "pause" | "resume" | "cancel_queue") {
+    setFeedback(null);
+    startTransition(async () => {
+      try {
+        const response = await fetch("/api/admin/obs-overlays", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ action }),
+        });
+        const payload = (await response.json()) as {
+          ok?: boolean;
+          error?: string;
+          data?: ObsOverlayAdminStatusRecord;
+        };
+
+        if (!response.ok || !payload.ok || !payload.data) {
+          setFeedback(payload.error ?? "Falha ao atualizar chamadas do OBS.");
+          return;
+        }
+
+        setStatus(payload.data);
+        setFeedback(
+          action === "pause"
+            ? "Chamadas ao OBS pausadas."
+            : action === "resume"
+              ? "Chamadas ao OBS retomadas."
+              : "Fila pendente cancelada.",
+        );
+        router.refresh();
+      } catch (error) {
+        setFeedback(error instanceof Error ? error.message : "Falha ao atualizar chamadas do OBS.");
+      }
+    });
+  }
+
   return (
     <section className="landing-plane landing-divider bg-[var(--color-paper)] py-8 sm:py-10">
       <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
@@ -38,6 +93,102 @@ export function AdminObsOverlaysPanel() {
             Aqui ficam os overlays hospedados pelo app. Use o link real no OBS e o link de demo
             quando quiser conferir o visual fora da live.
           </p>
+
+          <div className="mt-6 grid gap-4 lg:grid-cols-[0.85fr_1.15fr]">
+            <div className="card-brutal-static surface-card-accent p-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <p className="mono text-[10px] uppercase tracking-[0.24em] text-[var(--color-ink-soft)]">
+                    chamadas ao OBS
+                  </p>
+                  <p className="mt-2 text-2xl font-black uppercase">
+                    {hasConfigurationError
+                      ? "Configurar banco"
+                      : isPaused
+                        ? "Pausadas"
+                        : status.pendingCount > 0
+                          ? "Processando fila"
+                          : "Ativas"}
+                  </p>
+                </div>
+                <span className="sticker px-3 py-1.5 text-xs">
+                  {status.pendingCount} pendente{status.pendingCount === 1 ? "" : "s"}
+                </span>
+              </div>
+              <p className="mt-3 text-sm leading-6 text-[var(--color-ink-soft)]">
+                Quando pausado, novas quotes pagas entram em fila FIFO. A fila aceita ate 20 itens e
+                cada item expira em 2 horas com reembolso automatico se nao for exibido.
+              </p>
+              {status.control.lastError ? (
+                <p className="mt-3 border-2 border-[var(--color-ink)] bg-[var(--color-rose)] px-3 py-2 text-sm font-black text-[var(--color-ink)]">
+                  {status.control.lastError}
+                </p>
+              ) : null}
+              <div className="mt-4 flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  onClick={() => submitAction("pause")}
+                  disabled={isPending || isPaused || hasConfigurationError}
+                  variant="danger"
+                  size="sm"
+                >
+                  Pausar chamadas
+                </Button>
+                <Button
+                  type="button"
+                  onClick={() => submitAction("resume")}
+                  disabled={isPending || !isPaused || hasConfigurationError}
+                  variant="success"
+                  size="sm"
+                >
+                  Retomar fila
+                </Button>
+                <Button
+                  type="button"
+                  onClick={() => submitAction("cancel_queue")}
+                  disabled={isPending || status.pendingCount === 0 || hasConfigurationError}
+                  variant="neutral"
+                  size="sm"
+                >
+                  Cancelar fila
+                </Button>
+              </div>
+              <div className="mt-4 grid gap-2 text-sm text-[var(--color-ink-soft)]">
+                <p>Atualizado em {formatDateTime(status.control.updatedAt)}</p>
+                {status.control.updatedBy ? <p>Por {status.control.updatedBy}</p> : null}
+                {feedback ? <p className="font-bold text-[var(--color-ink)]">{feedback}</p> : null}
+              </div>
+            </div>
+
+            <div className="card-brutal-static surface-card p-4">
+              <p className="mono text-[10px] uppercase tracking-[0.24em] text-[var(--color-ink-soft)]">
+                fila pendente
+              </p>
+              <div className="mt-3 grid gap-3">
+                {status.pending.length > 0 ? (
+                  status.pending.slice(0, 5).map((entry, index) => (
+                    <div
+                      key={entry.id}
+                      className="grid gap-2 border-t-2 border-[var(--color-ink)] pt-3 sm:grid-cols-[auto_1fr_auto]"
+                    >
+                      <span className="mono text-xs font-black">#{index + 1}</span>
+                      <div>
+                        <p className="font-black">Quote #{entry.quoteNumber}</p>
+                        <p className="text-sm text-[var(--color-ink-soft)]">
+                          {entry.requestedByDisplayName} - {formatDateTime(entry.queuedAt)}
+                        </p>
+                      </div>
+                      <span className="mono text-xs font-black">{formatPipetz(entry.cost)}</span>
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-sm font-bold text-[var(--color-ink-soft)]">
+                    Nenhuma chamada aguardando.
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
 
           <div className="mt-6 grid gap-4">
             {overlays.map((overlay, index) => (

--- a/src/components/quote-overlay-trigger.tsx
+++ b/src/components/quote-overlay-trigger.tsx
@@ -61,6 +61,9 @@ export function QuoteOverlayTrigger({
       const payload = (await response.json()) as {
         ok: boolean;
         error?: string;
+        data?: {
+          queued?: unknown;
+        };
       };
 
       if (!response.ok || !payload.ok) {
@@ -68,7 +71,7 @@ export function QuoteOverlayTrigger({
         return;
       }
 
-      setFeedback("Quote enviada para o overlay.");
+      setFeedback(payload.data?.queued ? "Quote entrou na fila do OBS." : "Quote enviada para o overlay.");
       router.refresh();
     });
   }

--- a/src/lib/db/repository.test.ts
+++ b/src/lib/db/repository.test.ts
@@ -71,6 +71,7 @@ import {
   ensureViewerFromSession,
   getViewerDashboard,
   getActiveQuoteOverlay,
+  getObsOverlayAdminStatus,
   getSessionViewerState,
   getViewerLinkCodeState,
   getViewerBalanceFromChatCommand,
@@ -94,7 +95,9 @@ import {
   runStreamerbotCounterCommand,
   resolveBet,
   setActiveViewerForGoogleAccount,
+  setObsOverlayPaused,
   showQuoteOverlayForViewer,
+  cancelQueuedQuoteOverlays,
   updateGameSuggestionStatus,
 } from "@/lib/db/repository";
 import { GOOGLE_RISC_EVENT_TYPES } from "@/lib/google/risc";
@@ -1259,9 +1262,68 @@ describe("runQuoteCommandFromChat", () => {
 
     const activeOverlay = await getActiveQuoteOverlay();
     expect(activeOverlay).toMatchObject({
-      overlayId: result.overlay.overlayId,
+      overlayId: result.overlay!.overlayId,
       quoteNumber: 2,
     });
+  });
+
+  it("queues quote overlay requests while OBS calls are paused and resumes FIFO", async () => {
+    await setObsOverlayPaused({ paused: true, updatedBy: "admin@example.com" });
+
+    const result = await runQuoteCommandFromChat({
+      action: "show",
+      viewerExternalId: "yt_lia",
+      youtubeDisplayName: "Lia Pixel",
+      youtubeHandle: "@liapixel",
+      quoteId: 2,
+      source: "streamerbot_chat",
+    });
+
+    expect(result.overlay).toBeNull();
+    expect(result.queued).toMatchObject({
+      quoteNumber: 2,
+      requestedByDisplayName: "Lia Pixel",
+      status: "queued",
+      cost: 50,
+    });
+    expect(await getActiveQuoteOverlay()).toBeNull();
+
+    let status = await getObsOverlayAdminStatus();
+    expect(status.control.status).toBe("paused");
+    expect(status.pendingCount).toBe(1);
+
+    const dashboardAfterQueue = await getViewerDashboard("viewer_lia");
+    expect(dashboardAfterQueue?.balance.currentBalance).toBe(470);
+
+    status = await setObsOverlayPaused({ paused: false, updatedBy: "admin@example.com" });
+    expect(status.control.status).toBe("active");
+    expect(status.pendingCount).toBe(0);
+
+    const activeOverlay = await getActiveQuoteOverlay();
+    expect(activeOverlay).toMatchObject({
+      quoteNumber: 2,
+      requestedByDisplayName: "Lia Pixel",
+    });
+  });
+
+  it("cancels queued quote overlays and refunds the viewer", async () => {
+    await setObsOverlayPaused({ paused: true, updatedBy: "admin@example.com" });
+    await runQuoteCommandFromChat({
+      action: "show",
+      viewerExternalId: "yt_lia",
+      youtubeDisplayName: "Lia Pixel",
+      quoteId: 1,
+      source: "streamerbot_chat",
+    });
+
+    const dashboardAfterQueue = await getViewerDashboard("viewer_lia");
+    expect(dashboardAfterQueue?.balance.currentBalance).toBe(470);
+
+    const status = await cancelQueuedQuoteOverlays({ updatedBy: "admin@example.com" });
+    expect(status.pendingCount).toBe(0);
+
+    const dashboardAfterCancel = await getViewerDashboard("viewer_lia");
+    expect(dashboardAfterCancel?.balance.currentBalance).toBe(520);
   });
 
   it("rejects quote overlay requests when the viewer lacks pipetz", async () => {

--- a/src/lib/db/repository.ts
+++ b/src/lib/db/repository.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import { and, desc, eq, gte, inArray, sql } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, lt, sql } from "drizzle-orm";
 
 import {
   calculateBetPayouts,
@@ -20,7 +20,9 @@ import {
   googleAccounts,
   googleAccountViewers,
   googleRiscDeliveries,
+  obsOverlayControl,
   pointLedger,
+  quoteOverlayQueue,
   quoteOverlayState,
   quotes,
   productRecommendations,
@@ -75,7 +77,10 @@ import {
   GoogleAccountViewerRecord,
   GoogleRiscDeliveryRecord,
   LedgerEntryRecord,
+  ObsOverlayAdminStatusRecord,
+  ObsOverlayControlRecord,
   QuoteOverlayStateRecord,
+  QuoteOverlayQueueRecord,
   QuoteRecord,
   ProductRecommendationRecord,
   RedemptionRecord,
@@ -106,6 +111,9 @@ const QUOTE_OVERLAY_SLOT = "obs_main";
 const QUOTE_OVERLAY_COST = 50;
 const QUOTE_OVERLAY_DURATION_SECONDS = 12;
 const QUOTE_OVERLAY_LOCK_KEY = 42_001;
+const OBS_OVERLAY_CONTROL_KEY = "quotes";
+const QUOTE_OVERLAY_QUEUE_LIMIT = 20;
+const QUOTE_OVERLAY_QUEUE_TTL_MS = 2 * 60 * 60 * 1000;
 
 type StreamerbotCounterCommandAction = "increment" | "decrement" | "get" | "reset";
 type StreamerbotCounterScopeType = "global" | "game";
@@ -239,6 +247,8 @@ type DemoStore = {
   ledger: LedgerEntryRecord[];
   quotes: QuoteRecord[];
   quoteOverlayState: QuoteOverlayStateRecord | null;
+  obsOverlayControl: ObsOverlayControlRecord | null;
+  quoteOverlayQueue: QuoteOverlayQueueRecord[];
   redemptions: RedemptionRecord[];
   bets: BetRecord[];
   betOptions: BetOptionRecord[];
@@ -267,6 +277,8 @@ function getDemoStore(): DemoStore {
       ledger: structuredClone(demoLedger),
       quotes: structuredClone(demoQuotes),
       quoteOverlayState: null,
+      obsOverlayControl: null,
+      quoteOverlayQueue: [],
       redemptions: structuredClone(demoRedemptions),
       bets: structuredClone(demoBetRecords),
       betOptions: structuredClone(demoBetOptions),
@@ -1296,6 +1308,122 @@ function serializeQuoteOverlayState(
   };
 }
 
+function buildDefaultObsOverlayControl(now = new Date()): ObsOverlayControlRecord {
+  return {
+    key: OBS_OVERLAY_CONTROL_KEY,
+    status: "active",
+    pausedAt: null,
+    resumedAt: null,
+    updatedAt: now.toISOString(),
+    updatedBy: null,
+    lastError: null,
+  };
+}
+
+function isMissingObsOverlayTablesError(error: unknown) {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const maybePostgresError = error as Error & {
+    code?: string;
+    cause?: { code?: string; message?: string };
+  };
+  const message = `${error.message} ${maybePostgresError.cause?.message ?? ""}`;
+
+  return (
+    maybePostgresError.code === "42P01" ||
+    maybePostgresError.cause?.code === "42P01" ||
+    message.includes('relation "quote_overlay_queue" does not exist') ||
+    message.includes('relation "obs_overlay_control" does not exist')
+  );
+}
+
+function serializeObsOverlayControl(
+  row: typeof obsOverlayControl.$inferSelect,
+): ObsOverlayControlRecord {
+  return {
+    key: row.key,
+    status: row.status as ObsOverlayControlRecord["status"],
+    pausedAt: row.pausedAt?.toISOString() ?? null,
+    resumedAt: row.resumedAt?.toISOString() ?? null,
+    updatedAt: row.updatedAt.toISOString(),
+    updatedBy: row.updatedBy ?? null,
+    lastError: row.lastError ?? null,
+  };
+}
+
+function serializeQuoteOverlayQueue(
+  row: typeof quoteOverlayQueue.$inferSelect,
+): QuoteOverlayQueueRecord {
+  return {
+    id: row.id,
+    quoteNumber: row.quoteNumber,
+    quoteBody: row.quoteBody,
+    createdByDisplayName: row.createdByDisplayName,
+    createdByYoutubeHandle: row.createdByYoutubeHandle ?? null,
+    requestedByViewerId: row.requestedByViewerId,
+    requestedByDisplayName: row.requestedByDisplayName,
+    requestedByYoutubeHandle: row.requestedByYoutubeHandle ?? null,
+    source: row.source,
+    cost: row.cost,
+    displayDurationSeconds: row.displayDurationSeconds,
+    status: row.status as QuoteOverlayQueueRecord["status"],
+    queuedAt: row.queuedAt.toISOString(),
+    expiresAt: row.expiresAt.toISOString(),
+    processedAt: row.processedAt?.toISOString() ?? null,
+    cancelledAt: row.cancelledAt?.toISOString() ?? null,
+    failureReason: row.failureReason ?? null,
+  };
+}
+
+async function getObsOverlayControlRecord(): Promise<ObsOverlayControlRecord> {
+  const db = getDb();
+
+  if (isDemoMode || !db) {
+    const store = getDemoStore();
+    store.obsOverlayControl ??= buildDefaultObsOverlayControl();
+    return store.obsOverlayControl;
+  }
+
+  const [control] = await db
+    .select()
+    .from(obsOverlayControl)
+    .where(eq(obsOverlayControl.key, OBS_OVERLAY_CONTROL_KEY))
+    .limit(1);
+
+  return control ? serializeObsOverlayControl(control) : buildDefaultObsOverlayControl();
+}
+
+function buildQuoteOverlayQueueRecord(input: {
+  quote: QuoteRecord;
+  viewer: ViewerRecord;
+  source: string;
+  cost: number;
+  displayDurationSeconds: number;
+}) {
+  const queuedAt = new Date();
+  return {
+    id: randomUUID(),
+    quoteNumber: input.quote.quoteNumber,
+    quoteBody: input.quote.body,
+    createdByDisplayName: input.quote.createdByDisplayName,
+    createdByYoutubeHandle: input.quote.createdByYoutubeHandle,
+    requestedByViewerId: input.viewer.id,
+    requestedByDisplayName: input.viewer.youtubeDisplayName,
+    requestedByYoutubeHandle: input.viewer.youtubeHandle ?? null,
+    source: input.source,
+    cost: input.cost,
+    displayDurationSeconds: input.displayDurationSeconds,
+    status: "queued",
+    queuedAt: queuedAt.toISOString(),
+    expiresAt: new Date(queuedAt.getTime() + QUOTE_OVERLAY_QUEUE_TTL_MS).toISOString(),
+    processedAt: null,
+    cancelledAt: null,
+    failureReason: null,
+  } satisfies QuoteOverlayQueueRecord;
+}
+
 function buildQuoteOverlayState(input: {
   quote: QuoteRecord;
   viewer: ViewerRecord;
@@ -1508,12 +1636,239 @@ export async function getActiveQuoteOverlay() {
   return isQuoteOverlayActive(serialized, now) ? serialized : null;
 }
 
+async function refundQueuedQuoteOverlay(
+  queueEntry: QuoteOverlayQueueRecord,
+  reason: "cancelled" | "expired" | "failed",
+) {
+  const db = getDb();
+
+  if (isDemoMode || !db) {
+    const store = getDemoStore();
+    const balance = getBalance(store, queueEntry.requestedByViewerId);
+    balance.currentBalance += queueEntry.cost;
+    balance.lifetimeSpent = Math.max(0, balance.lifetimeSpent - queueEntry.cost);
+    balance.lastSyncedAt = new Date().toISOString();
+    createLedgerEntry(store, {
+      viewerId: queueEntry.requestedByViewerId,
+      kind: "quote_overlay_debit",
+      amount: queueEntry.cost,
+      source: queueEntry.source,
+      externalEventId: null,
+      metadata: {
+        queueId: queueEntry.id,
+        quoteNumber: queueEntry.quoteNumber,
+        refundReason: reason,
+      },
+    });
+    return;
+  }
+
+  await db.transaction(async (tx) => {
+    await tx
+      .update(viewerBalances)
+      .set({
+        currentBalance: sql`${viewerBalances.currentBalance} + ${queueEntry.cost}`,
+        lifetimeSpent: sql`greatest(${viewerBalances.lifetimeSpent} - ${queueEntry.cost}, 0)`,
+        lastSyncedAt: new Date(),
+      })
+      .where(eq(viewerBalances.viewerId, queueEntry.requestedByViewerId));
+
+    await tx.insert(pointLedger).values({
+      id: randomUUID(),
+      viewerId: queueEntry.requestedByViewerId,
+      kind: "quote_overlay_debit",
+      amount: queueEntry.cost,
+      source: queueEntry.source,
+      externalEventId: null,
+      metadata: {
+        queueId: queueEntry.id,
+        quoteNumber: queueEntry.quoteNumber,
+        refundReason: reason,
+      },
+      createdAt: new Date(),
+    });
+  });
+}
+
+async function expireQueuedQuoteOverlays() {
+  const now = new Date();
+  const db = getDb();
+
+  if (isDemoMode || !db) {
+    const store = getDemoStore();
+    const expired = store.quoteOverlayQueue.filter(
+      (entry) => entry.status === "queued" && new Date(entry.expiresAt).getTime() <= now.getTime(),
+    );
+    for (const entry of expired) {
+      entry.status = "expired";
+      entry.cancelledAt = now.toISOString();
+      entry.failureReason = "queue_expired";
+      await refundQueuedQuoteOverlay(entry, "expired");
+    }
+    return expired.length;
+  }
+
+  const expiredRows = await db
+    .update(quoteOverlayQueue)
+    .set({
+      status: "expired",
+      cancelledAt: now,
+      failureReason: "queue_expired",
+    })
+    .where(and(eq(quoteOverlayQueue.status, "queued"), lt(quoteOverlayQueue.expiresAt, now)))
+    .returning();
+
+  for (const row of expiredRows) {
+    await refundQueuedQuoteOverlay(serializeQuoteOverlayQueue(row), "expired");
+  }
+
+  return expiredRows.length;
+}
+
+async function enqueueQuoteOverlay(input: {
+  quote: QuoteRecord;
+  viewer: ViewerRecord;
+  source: string;
+  cost: number;
+  displayDurationSeconds: number;
+}) {
+  await requireActiveLivestream({
+    failureError: "livestream_not_live",
+  });
+  await expireQueuedQuoteOverlays();
+
+  const queued = buildQuoteOverlayQueueRecord(input);
+  const db = getDb();
+
+  if (isDemoMode || !db) {
+    const store = getDemoStore();
+    const pendingCount = store.quoteOverlayQueue.filter((entry) => entry.status === "queued").length;
+    if (pendingCount >= QUOTE_OVERLAY_QUEUE_LIMIT) {
+      throw new Error("quote_overlay_queue_full");
+    }
+
+    const balance = getBalance(store, input.viewer.id);
+    if (balance.currentBalance < input.cost) {
+      throw new Error("saldo_insuficiente");
+    }
+
+    balance.currentBalance -= input.cost;
+    balance.lifetimeSpent += input.cost;
+    balance.lastSyncedAt = queued.queuedAt;
+    createLedgerEntry(store, {
+      viewerId: input.viewer.id,
+      kind: "quote_overlay_debit",
+      amount: -input.cost,
+      source: input.source,
+      externalEventId: null,
+      metadata: {
+        queueId: queued.id,
+        quoteNumber: input.quote.quoteNumber,
+        queued: true,
+        durationSeconds: input.displayDurationSeconds,
+      },
+      createdAt: queued.queuedAt,
+    });
+    store.quoteOverlayQueue.push(queued);
+    return queued;
+  }
+
+  return db.transaction(async (tx) => {
+    await tx.execute(sql`select pg_advisory_xact_lock(${QUOTE_OVERLAY_LOCK_KEY})`);
+
+    const [{ pendingCount }] = await tx
+      .select({ pendingCount: sql<number>`count(*)::int` })
+      .from(quoteOverlayQueue)
+      .where(eq(quoteOverlayQueue.status, "queued"));
+
+    if ((pendingCount ?? 0) >= QUOTE_OVERLAY_QUEUE_LIMIT) {
+      throw new Error("quote_overlay_queue_full");
+    }
+
+    const debitedBalances = await tx
+      .update(viewerBalances)
+      .set({
+        currentBalance: sql`${viewerBalances.currentBalance} - ${input.cost}`,
+        lifetimeSpent: sql`${viewerBalances.lifetimeSpent} + ${input.cost}`,
+        lastSyncedAt: new Date(queued.queuedAt),
+      })
+      .where(
+        and(
+          eq(viewerBalances.viewerId, input.viewer.id),
+          gte(viewerBalances.currentBalance, input.cost),
+        ),
+      )
+      .returning({ viewerId: viewerBalances.viewerId });
+
+    if (debitedBalances.length === 0) {
+      throw new Error("saldo_insuficiente");
+    }
+
+    await tx.insert(pointLedger).values({
+      id: randomUUID(),
+      viewerId: input.viewer.id,
+      kind: "quote_overlay_debit",
+      amount: -input.cost,
+      source: input.source,
+      externalEventId: null,
+      metadata: {
+        queueId: queued.id,
+        quoteNumber: input.quote.quoteNumber,
+        queued: true,
+        durationSeconds: input.displayDurationSeconds,
+      },
+      createdAt: new Date(queued.queuedAt),
+    });
+
+    const [created] = await tx
+      .insert(quoteOverlayQueue)
+      .values({
+        id: queued.id,
+        quoteNumber: queued.quoteNumber,
+        quoteBody: queued.quoteBody,
+        createdByDisplayName: queued.createdByDisplayName,
+        createdByYoutubeHandle: queued.createdByYoutubeHandle,
+        requestedByViewerId: queued.requestedByViewerId,
+        requestedByDisplayName: queued.requestedByDisplayName,
+        requestedByYoutubeHandle: queued.requestedByYoutubeHandle,
+        source: queued.source,
+        cost: queued.cost,
+        displayDurationSeconds: queued.displayDurationSeconds,
+        status: queued.status,
+        queuedAt: new Date(queued.queuedAt),
+        expiresAt: new Date(queued.expiresAt),
+      })
+      .returning();
+
+    return serializeQuoteOverlayQueue(created!);
+  });
+}
+
+async function hasPendingQuoteOverlayQueue() {
+  await expireQueuedQuoteOverlays();
+  const db = getDb();
+
+  if (isDemoMode || !db) {
+    return getDemoStore().quoteOverlayQueue.some((entry) => entry.status === "queued");
+  }
+
+  const [entry] = await db
+    .select({ id: quoteOverlayQueue.id })
+    .from(quoteOverlayQueue)
+    .where(eq(quoteOverlayQueue.status, "queued"))
+    .limit(1);
+
+  return Boolean(entry);
+}
+
 async function activateQuoteOverlay(input: {
   quote: QuoteRecord;
   viewer: ViewerRecord;
   source: string;
   cost?: number;
   durationSeconds?: number;
+  debit?: boolean;
+  queueId?: string | null;
 }) {
   await requireActiveLivestream({
     failureError: "livestream_not_live",
@@ -1529,6 +1884,7 @@ async function activateQuoteOverlay(input: {
   });
 
   const db = getDb();
+  const shouldDebit = input.debit ?? true;
   if (isDemoMode || !db) {
     const store = getDemoStore();
     const activeOverlay = store.quoteOverlayState;
@@ -1536,28 +1892,31 @@ async function activateQuoteOverlay(input: {
       throw new Error("quote_overlay_busy");
     }
 
-    const balance = getBalance(store, input.viewer.id);
-    if (balance.currentBalance < cost) {
-      throw new Error("saldo_insuficiente");
+    if (shouldDebit) {
+      const balance = getBalance(store, input.viewer.id);
+      if (balance.currentBalance < cost) {
+        throw new Error("saldo_insuficiente");
+      }
+
+      balance.currentBalance -= cost;
+      balance.lifetimeSpent += cost;
+      balance.lastSyncedAt = overlay.activatedAt;
+
+      createLedgerEntry(store, {
+        viewerId: input.viewer.id,
+        kind: "quote_overlay_debit",
+        amount: -cost,
+        source: input.source,
+        externalEventId: null,
+        metadata: {
+          overlayId: overlay.overlayId,
+          queueId: input.queueId ?? null,
+          quoteNumber: input.quote.quoteNumber,
+          durationSeconds: input.durationSeconds ?? QUOTE_OVERLAY_DURATION_SECONDS,
+        },
+        createdAt: overlay.activatedAt,
+      });
     }
-
-    balance.currentBalance -= cost;
-    balance.lifetimeSpent += cost;
-    balance.lastSyncedAt = overlay.activatedAt;
-
-    createLedgerEntry(store, {
-      viewerId: input.viewer.id,
-      kind: "quote_overlay_debit",
-      amount: -cost,
-      source: input.source,
-      externalEventId: null,
-      metadata: {
-        overlayId: overlay.overlayId,
-        quoteNumber: input.quote.quoteNumber,
-        durationSeconds: input.durationSeconds ?? QUOTE_OVERLAY_DURATION_SECONDS,
-      },
-      createdAt: overlay.activatedAt,
-    });
 
     store.quoteOverlayState = overlay;
     return overlay;
@@ -1576,39 +1935,42 @@ async function activateQuoteOverlay(input: {
       throw new Error("quote_overlay_busy");
     }
 
-    const debitedBalances = await tx
-      .update(viewerBalances)
-      .set({
-        currentBalance: sql`${viewerBalances.currentBalance} - ${cost}`,
-        lifetimeSpent: sql`${viewerBalances.lifetimeSpent} + ${cost}`,
-        lastSyncedAt: new Date(overlay.activatedAt),
-      })
-      .where(
-        and(
-          eq(viewerBalances.viewerId, input.viewer.id),
-          gte(viewerBalances.currentBalance, cost),
-        ),
-      )
-      .returning({ viewerId: viewerBalances.viewerId });
+    if (shouldDebit) {
+      const debitedBalances = await tx
+        .update(viewerBalances)
+        .set({
+          currentBalance: sql`${viewerBalances.currentBalance} - ${cost}`,
+          lifetimeSpent: sql`${viewerBalances.lifetimeSpent} + ${cost}`,
+          lastSyncedAt: new Date(overlay.activatedAt),
+        })
+        .where(
+          and(
+            eq(viewerBalances.viewerId, input.viewer.id),
+            gte(viewerBalances.currentBalance, cost),
+          ),
+        )
+        .returning({ viewerId: viewerBalances.viewerId });
 
-    if (debitedBalances.length === 0) {
-      throw new Error("saldo_insuficiente");
+      if (debitedBalances.length === 0) {
+        throw new Error("saldo_insuficiente");
+      }
+
+      await tx.insert(pointLedger).values({
+        id: randomUUID(),
+        viewerId: input.viewer.id,
+        kind: "quote_overlay_debit",
+        amount: -cost,
+        source: input.source,
+        externalEventId: null,
+        metadata: {
+          overlayId: overlay.overlayId,
+          queueId: input.queueId ?? null,
+          quoteNumber: input.quote.quoteNumber,
+          durationSeconds: input.durationSeconds ?? QUOTE_OVERLAY_DURATION_SECONDS,
+        },
+        createdAt: new Date(overlay.activatedAt),
+      });
     }
-
-    await tx.insert(pointLedger).values({
-      id: randomUUID(),
-      viewerId: input.viewer.id,
-      kind: "quote_overlay_debit",
-      amount: -cost,
-      source: input.source,
-      externalEventId: null,
-      metadata: {
-        overlayId: overlay.overlayId,
-        quoteNumber: input.quote.quoteNumber,
-        durationSeconds: input.durationSeconds ?? QUOTE_OVERLAY_DURATION_SECONDS,
-      },
-      createdAt: new Date(overlay.activatedAt),
-    });
 
     await tx
       .insert(quoteOverlayState)
@@ -1647,6 +2009,330 @@ async function activateQuoteOverlay(input: {
   });
 
   return overlay;
+}
+
+async function activateQueuedQuoteOverlay(entry: QuoteOverlayQueueRecord) {
+  const viewer = await withViewerById(entry.requestedByViewerId);
+  if (!viewer) {
+    throw new Error("viewer_not_ready");
+  }
+
+  const quote: QuoteRecord = {
+    id: `queued:${entry.id}`,
+    quoteNumber: entry.quoteNumber,
+    body: entry.quoteBody,
+    createdByViewerId: "",
+    createdByDisplayName: entry.createdByDisplayName,
+    createdByYoutubeHandle: entry.createdByYoutubeHandle,
+    source: entry.source,
+    createdAt: entry.queuedAt,
+  };
+
+  return activateQuoteOverlay({
+    quote,
+    viewer,
+    source: entry.source,
+    cost: entry.cost,
+    durationSeconds: entry.displayDurationSeconds,
+    debit: false,
+    queueId: entry.id,
+  });
+}
+
+export async function processNextQueuedQuoteOverlay() {
+  const control = await getObsOverlayControlRecord();
+  if (control.status === "paused") {
+    return null;
+  }
+
+  await expireQueuedQuoteOverlays();
+
+  const activeOverlay = await getActiveQuoteOverlay();
+  if (activeOverlay) {
+    return activeOverlay;
+  }
+
+  const db = getDb();
+  if (isDemoMode || !db) {
+    const store = getDemoStore();
+    const entry = [...store.quoteOverlayQueue]
+      .filter((item) => item.status === "queued")
+      .sort((left, right) => +new Date(left.queuedAt) - +new Date(right.queuedAt))[0];
+
+    if (!entry) {
+      return null;
+    }
+
+    entry.status = "processing";
+    try {
+      const overlay = await activateQueuedQuoteOverlay(entry);
+      entry.status = "completed";
+      entry.processedAt = overlay.activatedAt;
+      return overlay;
+    } catch (error) {
+      entry.status = "failed";
+      entry.cancelledAt = new Date().toISOString();
+      entry.failureReason = error instanceof Error ? error.message : "queue_processing_failed";
+      throw error;
+    }
+  }
+
+  const [claimed] = await db.transaction(async (tx) => {
+    await tx.execute(sql`select pg_advisory_xact_lock(${QUOTE_OVERLAY_LOCK_KEY})`);
+
+    const [entry] = await tx
+      .select()
+      .from(quoteOverlayQueue)
+      .where(eq(quoteOverlayQueue.status, "queued"))
+      .orderBy(quoteOverlayQueue.queuedAt)
+      .limit(1);
+
+    if (!entry) {
+      return [];
+    }
+
+    return tx
+      .update(quoteOverlayQueue)
+      .set({ status: "processing" })
+      .where(eq(quoteOverlayQueue.id, entry.id))
+      .returning();
+  });
+
+  if (!claimed) {
+    return null;
+  }
+
+  const queued = serializeQuoteOverlayQueue(claimed);
+  try {
+    const overlay = await activateQueuedQuoteOverlay(queued);
+    await db
+      .update(quoteOverlayQueue)
+      .set({
+        status: "completed",
+        processedAt: new Date(overlay.activatedAt),
+      })
+      .where(eq(quoteOverlayQueue.id, queued.id));
+    return overlay;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "queue_processing_failed";
+    await db
+      .update(quoteOverlayQueue)
+      .set({
+        status: "failed",
+        cancelledAt: new Date(),
+        failureReason: message,
+      })
+      .where(eq(quoteOverlayQueue.id, queued.id));
+    await refundQueuedQuoteOverlay(queued, "failed");
+    throw error;
+  }
+}
+
+async function requestQuoteOverlay(input: {
+  quote: QuoteRecord;
+  viewer: ViewerRecord;
+  source: string;
+  durationSeconds?: number;
+}) {
+  const control = await getObsOverlayControlRecord();
+  const cost = QUOTE_OVERLAY_COST;
+  const displayDurationSeconds = input.durationSeconds ?? QUOTE_OVERLAY_DURATION_SECONDS;
+
+  if (control.status === "paused" || (await hasPendingQuoteOverlayQueue())) {
+    const queued = await enqueueQuoteOverlay({
+      quote: input.quote,
+      viewer: input.viewer,
+      source: input.source,
+      cost,
+      displayDurationSeconds,
+    });
+
+    return {
+      mode: "queued" as const,
+      queued,
+    };
+  }
+
+  const overlay = await activateQuoteOverlay({
+    quote: input.quote,
+    viewer: input.viewer,
+    source: input.source,
+    cost,
+    durationSeconds: displayDurationSeconds,
+  });
+
+  return {
+    mode: "activated" as const,
+    overlay,
+  };
+}
+
+export async function getObsOverlayAdminStatus(): Promise<ObsOverlayAdminStatusRecord> {
+  try {
+    await expireQueuedQuoteOverlays();
+    const [control, activeOverlay] = await Promise.all([
+      getObsOverlayControlRecord(),
+      getActiveQuoteOverlay(),
+    ]);
+    const db = getDb();
+
+    if (isDemoMode || !db) {
+      const queue = [...getDemoStore().quoteOverlayQueue];
+      const pending = queue
+        .filter((entry) => entry.status === "queued")
+        .sort((left, right) => +new Date(left.queuedAt) - +new Date(right.queuedAt));
+
+      return {
+        control,
+        activeOverlay,
+        pending,
+        pendingCount: pending.length,
+        processingCount: queue.filter((entry) => entry.status === "processing").length,
+        failedCount: queue.filter((entry) => entry.status === "failed").length,
+      };
+    }
+
+    const queue = (await db
+      .select()
+      .from(quoteOverlayQueue)
+      .orderBy(quoteOverlayQueue.queuedAt)
+      .limit(50)).map(serializeQuoteOverlayQueue);
+    const pending = queue.filter((entry) => entry.status === "queued");
+
+    return {
+      control,
+      activeOverlay,
+      pending,
+      pendingCount: pending.length,
+      processingCount: queue.filter((entry) => entry.status === "processing").length,
+      failedCount: queue.filter((entry) => entry.status === "failed").length,
+    };
+  } catch (error) {
+    if (!isMissingObsOverlayTablesError(error)) {
+      throw error;
+    }
+
+    return {
+      control: {
+        ...buildDefaultObsOverlayControl(),
+        status: "error",
+        lastError: "Migration pendente: crie as tabelas obs_overlay_control e quote_overlay_queue.",
+      },
+      activeOverlay: await getActiveQuoteOverlay(),
+      pending: [],
+      pendingCount: 0,
+      processingCount: 0,
+      failedCount: 0,
+    };
+  }
+}
+
+export async function setObsOverlayPaused(input: { paused: boolean; updatedBy?: string | null }) {
+  const now = new Date();
+  const db = getDb();
+
+  if (isDemoMode || !db) {
+    const store = getDemoStore();
+    store.obsOverlayControl = {
+      ...(store.obsOverlayControl ?? buildDefaultObsOverlayControl(now)),
+      status: input.paused ? "paused" : "active",
+      pausedAt: input.paused ? now.toISOString() : store.obsOverlayControl?.pausedAt ?? null,
+      resumedAt: input.paused ? store.obsOverlayControl?.resumedAt ?? null : now.toISOString(),
+      updatedAt: now.toISOString(),
+      updatedBy: input.updatedBy ?? null,
+      lastError: null,
+    };
+    if (!input.paused) {
+      await processNextQueuedQuoteOverlay();
+    }
+    return getObsOverlayAdminStatus();
+  }
+
+  await db
+    .insert(obsOverlayControl)
+    .values({
+      key: OBS_OVERLAY_CONTROL_KEY,
+      status: input.paused ? "paused" : "active",
+      pausedAt: input.paused ? now : null,
+      resumedAt: input.paused ? null : now,
+      updatedAt: now,
+      updatedBy: input.updatedBy ?? null,
+      lastError: null,
+    })
+    .onConflictDoUpdate({
+      target: obsOverlayControl.key,
+      set: {
+        status: input.paused ? "paused" : "active",
+        pausedAt: input.paused ? now : sql`${obsOverlayControl.pausedAt}`,
+        resumedAt: input.paused ? sql`${obsOverlayControl.resumedAt}` : now,
+        updatedAt: now,
+        updatedBy: input.updatedBy ?? null,
+        lastError: null,
+      },
+    });
+
+  if (!input.paused) {
+    await processNextQueuedQuoteOverlay();
+  }
+
+  return getObsOverlayAdminStatus();
+}
+
+export async function cancelQueuedQuoteOverlays(input: { updatedBy?: string | null }) {
+  const now = new Date();
+  const db = getDb();
+
+  if (isDemoMode || !db) {
+    const store = getDemoStore();
+    const pending = store.quoteOverlayQueue.filter((entry) => entry.status === "queued");
+    for (const entry of pending) {
+      entry.status = "cancelled";
+      entry.cancelledAt = now.toISOString();
+      entry.failureReason = "cancelled_by_admin";
+      await refundQueuedQuoteOverlay(entry, "cancelled");
+    }
+    store.obsOverlayControl = {
+      ...(store.obsOverlayControl ?? buildDefaultObsOverlayControl(now)),
+      updatedAt: now.toISOString(),
+      updatedBy: input.updatedBy ?? null,
+    };
+    return getObsOverlayAdminStatus();
+  }
+
+  const cancelled = await db
+    .update(quoteOverlayQueue)
+    .set({
+      status: "cancelled",
+      cancelledAt: now,
+      failureReason: "cancelled_by_admin",
+    })
+    .where(eq(quoteOverlayQueue.status, "queued"))
+    .returning();
+
+  for (const row of cancelled) {
+    await refundQueuedQuoteOverlay(serializeQuoteOverlayQueue(row), "cancelled");
+  }
+
+  await db
+    .insert(obsOverlayControl)
+    .values({
+      key: OBS_OVERLAY_CONTROL_KEY,
+      status: "active",
+      pausedAt: null,
+      resumedAt: null,
+      updatedAt: now,
+      updatedBy: input.updatedBy ?? null,
+      lastError: null,
+    })
+    .onConflictDoUpdate({
+      target: obsOverlayControl.key,
+      set: {
+        updatedAt: now,
+        updatedBy: input.updatedBy ?? null,
+      },
+    });
+
+  return getObsOverlayAdminStatus();
 }
 
 function listDemoGameSuggestions(viewerId?: string | null) {
@@ -4169,7 +4855,7 @@ export async function runQuoteCommandFromChat(input: {
       youtubeHandle: input.youtubeHandle,
     });
     const quote = await getQuoteRecord({ quoteId: input.quoteId });
-    const overlay = await activateQuoteOverlay({
+    const request = await requestQuoteOverlay({
       quote,
       viewer,
       source: input.source,
@@ -4180,7 +4866,8 @@ export async function runQuoteCommandFromChat(input: {
       action: "show" as const,
       quote,
       viewer,
-      overlay,
+      overlay: request.mode === "activated" ? request.overlay : null,
+      queued: request.mode === "queued" ? request.queued : null,
     };
   }
 
@@ -4204,7 +4891,7 @@ export async function showQuoteOverlayForViewer(input: {
   }
 
   const quote = await getQuoteRecord({ quoteId: input.quoteId });
-  const overlay = await activateQuoteOverlay({
+  const request = await requestQuoteOverlay({
     quote,
     viewer,
     source: input.source,
@@ -4214,7 +4901,8 @@ export async function showQuoteOverlayForViewer(input: {
   return {
     quote,
     viewer,
-    overlay,
+    overlay: request.mode === "activated" ? request.overlay : null,
+    queued: request.mode === "queued" ? request.queued : null,
   };
 }
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -337,6 +337,38 @@ export const quoteOverlayState = pgTable("quote_overlay_state", {
   expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
 });
 
+export const obsOverlayControl = pgTable("obs_overlay_control", {
+  key: varchar("key", { length: 64 }).primaryKey(),
+  status: varchar("status", { length: 32 }).default("active").notNull(),
+  pausedAt: timestamp("paused_at", { withTimezone: true }),
+  resumedAt: timestamp("resumed_at", { withTimezone: true }),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedBy: varchar("updated_by", { length: 255 }),
+  lastError: text("last_error"),
+});
+
+export const quoteOverlayQueue = pgTable("quote_overlay_queue", {
+  id: varchar("id", { length: 64 }).primaryKey(),
+  quoteNumber: integer("quote_number").notNull(),
+  quoteBody: text("quote_body").notNull(),
+  createdByDisplayName: varchar("created_by_display_name", { length: 255 }).notNull(),
+  createdByYoutubeHandle: varchar("created_by_youtube_handle", { length: 255 }),
+  requestedByViewerId: varchar("requested_by_viewer_id", { length: 64 })
+    .references(() => users.id)
+    .notNull(),
+  requestedByDisplayName: varchar("requested_by_display_name", { length: 255 }).notNull(),
+  requestedByYoutubeHandle: varchar("requested_by_youtube_handle", { length: 255 }),
+  source: varchar("source", { length: 64 }).default("streamerbot_chat").notNull(),
+  cost: integer("cost").notNull(),
+  displayDurationSeconds: integer("display_duration_seconds").notNull(),
+  status: varchar("status", { length: 32 }).default("queued").notNull(),
+  queuedAt: timestamp("queued_at", { withTimezone: true }).defaultNow().notNull(),
+  expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+  processedAt: timestamp("processed_at", { withTimezone: true }),
+  cancelledAt: timestamp("cancelled_at", { withTimezone: true }),
+  failureReason: text("failure_reason"),
+});
+
 export const streamerbotCounters = pgTable("streamerbot_counters", {
   key: varchar("key", { length: 64 }).primaryKey(),
   value: integer("value").default(0).notNull(),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -234,6 +234,49 @@ export interface QuoteOverlayStateRecord {
   expiresAt: string;
 }
 
+export type ObsOverlayControlStatus = "active" | "paused" | "processing" | "error";
+
+export type QuoteOverlayQueueStatus = "queued" | "processing" | "completed" | "cancelled" | "expired" | "failed";
+
+export interface ObsOverlayControlRecord {
+  key: string;
+  status: ObsOverlayControlStatus;
+  pausedAt: string | null;
+  resumedAt: string | null;
+  updatedAt: string;
+  updatedBy: string | null;
+  lastError: string | null;
+}
+
+export interface QuoteOverlayQueueRecord {
+  id: string;
+  quoteNumber: number;
+  quoteBody: string;
+  createdByDisplayName: string;
+  createdByYoutubeHandle: string | null;
+  requestedByViewerId: string;
+  requestedByDisplayName: string;
+  requestedByYoutubeHandle: string | null;
+  source: string;
+  cost: number;
+  displayDurationSeconds: number;
+  status: QuoteOverlayQueueStatus;
+  queuedAt: string;
+  expiresAt: string;
+  processedAt: string | null;
+  cancelledAt: string | null;
+  failureReason: string | null;
+}
+
+export interface ObsOverlayAdminStatusRecord {
+  control: ObsOverlayControlRecord;
+  activeOverlay: QuoteOverlayStateRecord | null;
+  pending: QuoteOverlayQueueRecord[];
+  pendingCount: number;
+  processingCount: number;
+  failedCount: number;
+}
+
 export interface StreamerbotCounterRecord {
   key: string;
   scopeType: string;


### PR DESCRIPTION
## Summary

- Adds an admin OBS overlay control to pause and resume quote calls.
- Queues quote overlay requests while paused, then processes pending calls FIFO when resumed.
- Adds persistence for the OBS overlay control and quote overlay queue, including expiration and refund handling.
- Shows queued feedback to chat/site callers and keeps the admin panel visible even when the migration is pending.
- Replaces the layout theme `next/script` usage with an inline script compatible with the current Next.js behavior.

## Validation

- `npm.cmd test`
- `npm.cmd run build`

Closes #73