### PR TITLE
[codex] Add configurable Pipetz pricing and video suggestions

### DIFF
--- a/drizzle/0008_video_suggestions.sql
+++ b/drizzle/0008_video_suggestions.sql
@@ -1,0 +1,26 @@
+CREATE TABLE "video_suggestion_boosts" (
+	"id" varchar(64) PRIMARY KEY NOT NULL,
+	"suggestion_id" varchar(64) NOT NULL,
+	"viewer_id" varchar(64) NOT NULL,
+	"amount" integer NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "video_suggestions" (
+	"id" varchar(64) PRIMARY KEY NOT NULL,
+	"viewer_id" varchar(64) NOT NULL,
+	"youtube_video_id" varchar(32) NOT NULL,
+	"title" varchar(255) NOT NULL,
+	"creator_name" varchar(255) NOT NULL,
+	"thumbnail_url" text NOT NULL,
+	"video_url" text NOT NULL,
+	"reason" text,
+	"status" varchar(32) NOT NULL,
+	"total_votes" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "video_suggestion_boosts" ADD CONSTRAINT "video_suggestion_boosts_suggestion_id_video_suggestions_id_fk" FOREIGN KEY ("suggestion_id") REFERENCES "public"."video_suggestions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "video_suggestion_boosts" ADD CONSTRAINT "video_suggestion_boosts_viewer_id_users_id_fk" FOREIGN KEY ("viewer_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "video_suggestions" ADD CONSTRAINT "video_suggestions_viewer_id_users_id_fk" FOREIGN KEY ("viewer_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1778428800000,
       "tag": "0007_game_suggestion_igdb_metadata",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1778530912160,
+      "tag": "0008_video_suggestions",
+      "breakpoints": true
     }
   ]
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -12,6 +12,10 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "yt3.googleusercontent.com",
       },
+      {
+        protocol: "https",
+        hostname: "i.ytimg.com",
+      },
     ],
   },
 };

--- a/scripts/merge-viewers.ts
+++ b/scripts/merge-viewers.ts
@@ -214,7 +214,7 @@ async function main() {
     );
   }
 
-  const [ledgerCounts, redemptionCounts, betCounts, suggestionCounts, boostCounts] =
+  const [ledgerCounts, redemptionCounts, betCounts, suggestionCounts, boostCounts, videoSuggestionCounts, videoBoostCounts] =
     await Promise.all([
       sql`
         SELECT COUNT(*)::int AS count
@@ -241,6 +241,16 @@ async function main() {
         FROM game_suggestion_boosts
         WHERE viewer_id = ${sourceViewer.id}
       `,
+      sql`
+        SELECT COUNT(*)::int AS count
+        FROM video_suggestions
+        WHERE viewer_id = ${sourceViewer.id}
+      `,
+      sql`
+        SELECT COUNT(*)::int AS count
+        FROM video_suggestion_boosts
+        WHERE viewer_id = ${sourceViewer.id}
+      `,
     ]);
 
   const summary = {
@@ -260,6 +270,8 @@ async function main() {
       betEntries: betCounts[0]?.count ?? 0,
       gameSuggestions: suggestionCounts[0]?.count ?? 0,
       gameSuggestionBoosts: boostCounts[0]?.count ?? 0,
+      videoSuggestions: videoSuggestionCounts[0]?.count ?? 0,
+      videoSuggestionBoosts: videoBoostCounts[0]?.count ?? 0,
     },
   };
 
@@ -286,6 +298,8 @@ async function main() {
       txn`UPDATE bet_entries SET viewer_id = ${targetViewer.id} WHERE viewer_id = ${sourceViewer.id}`,
       txn`UPDATE game_suggestions SET viewer_id = ${targetViewer.id} WHERE viewer_id = ${sourceViewer.id}`,
       txn`UPDATE game_suggestion_boosts SET viewer_id = ${targetViewer.id} WHERE viewer_id = ${sourceViewer.id}`,
+      txn`UPDATE video_suggestions SET viewer_id = ${targetViewer.id} WHERE viewer_id = ${sourceViewer.id}`,
+      txn`UPDATE video_suggestion_boosts SET viewer_id = ${targetViewer.id} WHERE viewer_id = ${sourceViewer.id}`,
       txn`
         UPDATE google_accounts
         SET active_viewer_id = ${targetViewer.id}

--- a/src/app/(public)/quotes/page.tsx
+++ b/src/app/(public)/quotes/page.tsx
@@ -8,7 +8,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { getViewerDashboard, listQuotes } from "@/lib/db/repository";
+import { getPipetzPricing, getViewerDashboard, listQuotes } from "@/lib/db/repository";
 import { cn, formatDateTime, formatPipetz } from "@/lib/utils";
 
 const quoteCardBackgrounds = [
@@ -27,9 +27,10 @@ function usesPastelQuoteBackground(bgClass: string) {
 export default async function QuotesPage() {
   const session = await auth();
   const activeViewerId = session?.user?.activeViewerId ?? null;
-  const [quotes, dashboard] = await Promise.all([
+  const [quotes, dashboard, pricing] = await Promise.all([
     listQuotes(),
     activeViewerId ? getViewerDashboard(activeViewerId) : Promise.resolve(null),
+    getPipetzPricing(),
   ]);
   const canShowOnOverlay = Boolean(activeViewerId);
 
@@ -53,7 +54,7 @@ export default async function QuotesPage() {
               número da quote e quem registrou.
             </p>
             <p className="mt-3 inline-flex items-center gap-2 border-[3px] border-[var(--color-ink)] bg-[var(--color-paper)] px-4 py-2 text-xs font-black uppercase tracking-[0.18em] text-[var(--color-ink)] shadow-[4px_4px_0_var(--shadow-color)]">
-              Mostrar no OBS custa {formatPipetz(50)} pipetz
+              Mostrar no OBS custa {formatPipetz(pricing.quoteOverlayCost)} pipetz
             </p>
           </div>
         </div>
@@ -121,6 +122,7 @@ export default async function QuotesPage() {
                         loggedIn={Boolean(session?.user)}
                         canShow={canShowOnOverlay}
                         viewerBalance={dashboard?.balance.currentBalance}
+                        quoteOverlayCost={pricing.quoteOverlayCost}
                       />
                     </CardFooter>
                   </Card>

--- a/src/app/(public)/videos/page.tsx
+++ b/src/app/(public)/videos/page.tsx
@@ -1,21 +1,19 @@
 import { auth } from "@/auth";
-import { GameSuggestForm } from "@/components/game-suggest-form";
-import { GameSuggestionList } from "@/components/game-suggestion-list";
-import { getPipetzPricing, getViewerDashboard, listGameSuggestions } from "@/lib/db/repository";
-import { adminEmails } from "@/lib/env";
+import { VideoSuggestForm } from "@/components/video-suggest-form";
+import { VideoSuggestionList } from "@/components/video-suggestion-list";
+import { getPipetzPricing, getViewerDashboard, listVideoSuggestions } from "@/lib/db/repository";
 
-export default async function JogosPage() {
+export default async function VideosPage() {
   const session = await auth();
   const activeViewerId = session?.user?.activeViewerId ?? null;
   const [suggestions, dashboard, pricing] = await Promise.all([
-    listGameSuggestions(activeViewerId),
+    listVideoSuggestions(activeViewerId),
     activeViewerId ? getViewerDashboard(activeViewerId) : Promise.resolve(null),
     getPipetzPricing(),
   ]);
 
   const viewerBalance = dashboard?.balance.currentBalance ?? null;
   const canInteract = Boolean(activeViewerId);
-  const isAdmin = Boolean(session?.user?.email && adminEmails.has(session.user.email.toLowerCase()));
 
   return (
     <div className="flex w-full flex-col pb-20">
@@ -23,44 +21,47 @@ export default async function JogosPage() {
         <div className="bg-dots-light pointer-events-none absolute inset-0 opacity-20" />
         <div className="relative mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
           <div>
+            <p className="mono text-xs font-bold uppercase tracking-[0.32em] text-[var(--color-ink-soft)]">
+              Sugestoes de videos
+            </p>
             <h1
-              className="text-4xl uppercase sm:text-6xl lg:text-7xl"
+              className="mt-3 text-4xl uppercase sm:text-6xl lg:text-7xl"
               style={{ fontFamily: "var(--font-display)" }}
             >
-              Me diz o que jogar.
+              Me diz ao que reagir.
             </h1>
             <p className="mt-4 max-w-3xl text-sm leading-7 text-[var(--color-ink-soft)] sm:text-base">
-              Sugere um jogo e, se quiser empurrar sua ideia, gasta pipetz pra dar boost nela.
+              Cola um link do YouTube, eu valido o video, puxo thumb, titulo e criador, e a galera pode gastar pipetz pra dar boost.
             </p>
           </div>
         </div>
       </section>
 
-      <section className="landing-plane landing-divider bg-[var(--color-paper-pink)] py-8 dark:bg-[var(--surface-card-alt)] sm:py-10">
-        <div className="mx-auto grid w-full max-w-[1500px] gap-8 px-4 sm:px-6 lg:grid-cols-[minmax(0,1.15fr)_minmax(360px,0.75fr)] lg:px-10">
+      <section className="landing-plane landing-divider bg-[var(--color-paper-pink)] py-8 sm:py-10">
+        <div className="mx-auto grid w-full max-w-[1500px] gap-8 px-4 sm:px-6 lg:grid-cols-[1fr_0.8fr] lg:px-10">
           <div>
             <div className="mb-4 flex items-center gap-2">
+              <span className="text-xl">Fila</span>
               <h2
                 className="text-2xl font-bold uppercase"
                 style={{ fontFamily: "var(--font-display)" }}
               >
-                Sugestões da galera
+                Videos da galera
               </h2>
             </div>
-            <GameSuggestionList
+            <VideoSuggestionList
               suggestions={suggestions}
               loggedIn={Boolean(session?.user)}
               canInteract={canInteract}
-              isAdmin={isAdmin}
               viewerBalance={viewerBalance}
             />
           </div>
           <div className="self-start lg:sticky lg:top-24">
-            <GameSuggestForm
+            <VideoSuggestForm
               loggedIn={Boolean(session?.user)}
               canSuggest={canInteract}
               viewerBalance={viewerBalance}
-              creationCost={pricing.gameSuggestionCost}
+              creationCost={pricing.videoSuggestionCost}
             />
           </div>
         </div>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -2,6 +2,8 @@ import { AdminObsOverlaysPanel } from "@/components/admin-obs-overlays-panel";
 import { AdminBetsPanel } from "@/components/admin-bets-panel";
 import { DeathCounterGamePanel } from "@/components/death-counter-game-panel";
 import { AdminGameSuggestionsPanel } from "@/components/admin-game-suggestions-panel";
+import { AdminVideoSuggestionsPanel } from "@/components/admin-video-suggestions-panel";
+import { AdminPipetzPricingPanel } from "@/components/admin-pipetz-pricing-panel";
 import { AdminRecommendationsPanel } from "@/components/admin-recommendations-panel";
 import { AdminViewerLinksPanel } from "@/components/admin-viewer-links-panel";
 import { RedemptionGrid } from "@/components/redemption-grid";
@@ -13,8 +15,10 @@ import {
   getCatalog,
   getLeaderboard,
   getObsOverlayAdminStatus,
+  getPipetzPricing,
   listAdminViewerDirectory,
   listAdminGameSuggestions,
+  listAdminVideoSuggestions,
   listAdminProductRecommendations,
   listAdminBets,
   listAdminRedemptions,
@@ -33,7 +37,7 @@ const statusColorMap: Record<string, string> = {
 
 export default async function AdminPage() {
   await requireAdminSession();
-  const [catalog, leaderboard, bridge, liveStatus, activeDeathCounterGame, redemptions, bets, suggestions, recommendations, viewers, obsOverlayStatus] = await Promise.all([
+  const [catalog, leaderboard, bridge, liveStatus, activeDeathCounterGame, redemptions, bets, suggestions, videoSuggestions, recommendations, viewers, obsOverlayStatus, pricing] = await Promise.all([
     getCatalog(),
     getLeaderboard(),
     getBridgeStatus(),
@@ -42,9 +46,11 @@ export default async function AdminPage() {
     listAdminRedemptions(),
     listAdminBets(),
     listAdminGameSuggestions(),
+    listAdminVideoSuggestions(),
     listAdminProductRecommendations(),
     listAdminViewerDirectory(),
     getObsOverlayAdminStatus(),
+    getPipetzPricing(),
   ]);
 
   return (
@@ -68,6 +74,7 @@ export default async function AdminPage() {
           <div className="space-y-6">
             <LiveStatusPanel bridge={bridge} initialStatus={liveStatus} />
             <DeathCounterGamePanel initialGame={activeDeathCounterGame} />
+            <AdminPipetzPricingPanel initialPricing={pricing} />
           </div>
           <div className="panel surface-section p-6">
             <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
@@ -119,6 +126,7 @@ export default async function AdminPage() {
       <AdminBetsPanel bets={bets} />
       <AdminViewerLinksPanel entries={viewers} />
       <AdminGameSuggestionsPanel suggestions={suggestions} />
+      <AdminVideoSuggestionsPanel suggestions={videoSuggestions} />
       <AdminRecommendationsPanel recommendations={recommendations} />
     </div>
   );

--- a/src/app/api/admin/pipetz-pricing/route.ts
+++ b/src/app/api/admin/pipetz-pricing/route.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+
+import { fail, isTrustedAppMutationRequest, ok, requireAdminApiSession } from "@/lib/api";
+import { getPipetzPricing, updatePipetzPricing } from "@/lib/db/repository";
+
+const pricingSchema = z.object({
+  gameSuggestionCost: z.number().int().min(1).max(1_000_000),
+  videoSuggestionCost: z.number().int().min(1).max(1_000_000),
+  quoteOverlayCost: z.number().int().min(1).max(1_000_000),
+});
+
+export async function GET() {
+  const session = await requireAdminApiSession();
+  if (!session) {
+    return fail("Forbidden", 403);
+  }
+
+  return ok(await getPipetzPricing());
+}
+
+export async function PATCH(request: Request) {
+  if (!isTrustedAppMutationRequest(request)) {
+    return fail("Forbidden", 403);
+  }
+
+  const session = await requireAdminApiSession();
+  if (!session) {
+    return fail("Forbidden", 403);
+  }
+
+  try {
+    const parsed = pricingSchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return fail("Precos devem ser numeros inteiros maiores que zero.", 400);
+    }
+
+    const data = await updatePipetzPricing({
+      ...parsed.data,
+      updatedBy: session.user?.email?.toLowerCase() ?? null,
+    });
+
+    return ok(data);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return fail("Payload invalido.", 400);
+    }
+
+    return fail(error instanceof Error ? error.message : "Falha ao salvar precos.", 400);
+  }
+}

--- a/src/app/api/admin/video-suggestions/[id]/route.ts
+++ b/src/app/api/admin/video-suggestions/[id]/route.ts
@@ -1,0 +1,50 @@
+import { ZodError } from "zod";
+
+import { fail, isTrustedAppMutationRequest, ok, requireAdminApiSession } from "@/lib/api";
+import { updateVideoSuggestionStatus } from "@/lib/db/repository";
+import {
+  formatVideoSuggestionSchemaError,
+  updateVideoSuggestionStatusSchema,
+} from "@/lib/video-suggestions/service";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!isTrustedAppMutationRequest(request)) {
+    return fail("Forbidden", 403);
+  }
+
+  const session = await requireAdminApiSession();
+  if (!session) {
+    return fail("Forbidden", 403);
+  }
+
+  const { id } = await params;
+
+  try {
+    const json = await request.json();
+    const parsed = updateVideoSuggestionStatusSchema.safeParse(json);
+    if (!parsed.success) {
+      return fail(formatVideoSuggestionSchemaError(parsed.error), 400);
+    }
+
+    const suggestion = await updateVideoSuggestionStatus({
+      suggestionId: id,
+      status: parsed.data.status,
+    });
+
+    return ok(suggestion);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return fail(formatVideoSuggestionSchemaError(error), 400);
+    }
+
+    if (error instanceof SyntaxError) {
+      return fail("Payload invalido.", 400);
+    }
+
+    const message = error instanceof Error ? error.message : "Falha ao atualizar sugestao.";
+    return fail(message, 400);
+  }
+}

--- a/src/app/api/admin/video-suggestions/route.ts
+++ b/src/app/api/admin/video-suggestions/route.ts
@@ -1,0 +1,11 @@
+import { fail, ok, requireAdminApiSession } from "@/lib/api";
+import { listAdminVideoSuggestions } from "@/lib/db/repository";
+
+export async function GET() {
+  const session = await requireAdminApiSession();
+  if (!session) {
+    return fail("Forbidden", 403);
+  }
+
+  return ok(await listAdminVideoSuggestions());
+}

--- a/src/app/api/internal/streamerbot/quotes/route.ts
+++ b/src/app/api/internal/streamerbot/quotes/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-import { runQuoteCommandFromChat } from "@/lib/db/repository";
+import { getPipetzPricing, runQuoteCommandFromChat } from "@/lib/db/repository";
 import { env } from "@/lib/env";
 import { streamerbotQuoteCommandSchema } from "@/lib/streamerbot/schemas";
 import { verifySignedRequest } from "@/lib/streamerbot/security";
@@ -9,7 +9,7 @@ function formatQuoteReply(input: { quoteNumber: number; body: string }) {
   return `Quote #${input.quoteNumber}: "${input.body}"`;
 }
 
-function mapChatQuoteReply(input: {
+async function mapChatQuoteReply(input: {
   message: string;
   action?: "create" | "get" | "show";
   quoteId?: number;
@@ -33,7 +33,7 @@ function mapChatQuoteReply(input: {
     case "livestream_not_live":
       return "Essa quote so pode ir para o OBS enquanto a live estiver acontecendo.";
     case "saldo_insuficiente":
-      return `${prefix}você precisa de 50 pipetz para colocar a quote no OBS.`;
+      return `${prefix}você precisa de ${(await getPipetzPricing()).quoteOverlayCost} pipetz para colocar a quote no OBS.`;
     case "quote_overlay_busy":
       return "Ja tem uma quote ocupando o overlay. Tenta de novo em alguns segundos.";
     default:
@@ -141,7 +141,7 @@ export async function POST(request: Request) {
       {
         ok: false,
         error: message,
-        replyMessage: mapChatQuoteReply({
+        replyMessage: await mapChatQuoteReply({
           message,
           action: context.action,
           quoteId: context.quoteId,

--- a/src/app/api/me/video-suggestions/[id]/boost/route.ts
+++ b/src/app/api/me/video-suggestions/[id]/boost/route.ts
@@ -1,0 +1,58 @@
+import { ZodError } from "zod";
+
+import { fail, isTrustedAppMutationRequest, ok, requireApiSession } from "@/lib/api";
+import { boostVideoSuggestion } from "@/lib/db/repository";
+import {
+  boostVideoSuggestionSchema,
+  formatVideoSuggestionSchemaError,
+  validateVideoSuggestionBoostAmount,
+} from "@/lib/video-suggestions/service";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!isTrustedAppMutationRequest(request)) {
+    return fail("Forbidden", 403);
+  }
+
+  const session = await requireApiSession();
+  if (!session?.user?.activeViewerId) {
+    return fail("Unauthorized", 401);
+  }
+
+  const { id } = await params;
+
+  try {
+    const json = await request.json();
+    const parsed = boostVideoSuggestionSchema.safeParse(json);
+    if (!parsed.success) {
+      return fail(formatVideoSuggestionSchemaError(parsed.error), 400);
+    }
+
+    const validationError = validateVideoSuggestionBoostAmount(parsed.data.amount);
+    if (validationError) {
+      return fail(validationError, 400);
+    }
+
+    const suggestion = await boostVideoSuggestion({
+      suggestionId: id,
+      viewerId: session.user.activeViewerId,
+      amount: parsed.data.amount,
+      source: "web",
+    });
+
+    return ok(suggestion, { status: 201 });
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return fail(formatVideoSuggestionSchemaError(error), 400);
+    }
+
+    if (error instanceof SyntaxError) {
+      return fail("Payload invalido.", 400);
+    }
+
+    const message = error instanceof Error ? error.message : "Falha ao dar boost.";
+    return fail(message, 400);
+  }
+}

--- a/src/app/api/me/video-suggestions/route.ts
+++ b/src/app/api/me/video-suggestions/route.ts
@@ -1,0 +1,59 @@
+import { ZodError } from "zod";
+
+import { fail, isTrustedAppMutationRequest, ok, requireApiSession } from "@/lib/api";
+import { createVideoSuggestion } from "@/lib/db/repository";
+import {
+  createVideoSuggestionSchema,
+  formatVideoSuggestionSchemaError,
+  resolveYoutubeVideoMetadata,
+  validateVideoSuggestionDraft,
+} from "@/lib/video-suggestions/service";
+
+export async function POST(request: Request) {
+  if (!isTrustedAppMutationRequest(request)) {
+    return fail("Forbidden", 403);
+  }
+
+  const session = await requireApiSession();
+  if (!session?.user?.activeViewerId) {
+    return fail("Unauthorized", 401);
+  }
+
+  try {
+    const json = await request.json();
+    const parsed = createVideoSuggestionSchema.safeParse(json);
+    if (!parsed.success) {
+      return fail(formatVideoSuggestionSchemaError(parsed.error), 400);
+    }
+
+    const validationError = validateVideoSuggestionDraft(parsed.data);
+    if (validationError) {
+      return fail(validationError, 400);
+    }
+
+    const metadata = await resolveYoutubeVideoMetadata(parsed.data.videoUrl);
+    const suggestion = await createVideoSuggestion({
+      viewerId: session.user.activeViewerId,
+      youtubeVideoId: metadata.videoId,
+      title: metadata.title,
+      creatorName: metadata.creatorName,
+      thumbnailUrl: metadata.thumbnailUrl,
+      videoUrl: metadata.videoUrl,
+      reason: parsed.data.reason,
+      source: "web",
+    });
+
+    return ok(suggestion, { status: 201 });
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return fail(formatVideoSuggestionSchemaError(error), 400);
+    }
+
+    if (error instanceof SyntaxError) {
+      return fail("Payload invalido.", 400);
+    }
+
+    const message = error instanceof Error ? error.message : "Falha ao criar sugestao.";
+    return fail(message, 400);
+  }
+}

--- a/src/components/admin-pipetz-pricing-panel.tsx
+++ b/src/components/admin-pipetz-pricing-panel.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { PipetzPricingRecord } from "@/lib/types";
+import { formatDateTime, formatPipetz } from "@/lib/utils";
+
+type PricingField = "gameSuggestionCost" | "videoSuggestionCost" | "quoteOverlayCost";
+
+const pricingFields: Array<{
+  key: PricingField;
+  label: string;
+  description: string;
+}> = [
+  {
+    key: "gameSuggestionCost",
+    label: "Sugestao de jogo",
+    description: "Valor cobrado quando alguem indica um novo jogo.",
+  },
+  {
+    key: "videoSuggestionCost",
+    label: "Sugestao de video",
+    description: "Valor cobrado para enviar um novo video do YouTube.",
+  },
+  {
+    key: "quoteOverlayCost",
+    label: "Quote no OBS",
+    description: "Valor cobrado por !quoteobs e pelo botao publico de OBS.",
+  },
+];
+
+function toFormState(pricing: PipetzPricingRecord) {
+  return {
+    gameSuggestionCost: String(pricing.gameSuggestionCost),
+    videoSuggestionCost: String(pricing.videoSuggestionCost),
+    quoteOverlayCost: String(pricing.quoteOverlayCost),
+  };
+}
+
+export function AdminPipetzPricingPanel({
+  initialPricing,
+}: {
+  initialPricing: PipetzPricingRecord;
+}) {
+  const router = useRouter();
+  const [pricing, setPricing] = useState(initialPricing);
+  const [form, setForm] = useState(toFormState(initialPricing));
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function updateField(field: PricingField, value: string) {
+    setForm((current) => ({
+      ...current,
+      [field]: value,
+    }));
+  }
+
+  function savePricing() {
+    const payload = {
+      gameSuggestionCost: Number(form.gameSuggestionCost),
+      videoSuggestionCost: Number(form.videoSuggestionCost),
+      quoteOverlayCost: Number(form.quoteOverlayCost),
+    };
+
+    if (Object.values(payload).some((value) => !Number.isInteger(value) || value <= 0)) {
+      setFeedback("Use valores inteiros maiores que zero.");
+      return;
+    }
+
+    setFeedback(null);
+    startTransition(async () => {
+      try {
+        const response = await fetch("/api/admin/pipetz-pricing", {
+          method: "PATCH",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify(payload),
+        });
+        const result = (await response.json()) as {
+          ok?: boolean;
+          error?: string;
+          data?: PipetzPricingRecord;
+        };
+
+        if (!response.ok || !result.ok || !result.data) {
+          setFeedback(result.error ?? "Falha ao salvar precos.");
+          return;
+        }
+
+        setPricing(result.data);
+        setForm(toFormState(result.data));
+        setFeedback("Precos atualizados.");
+        router.refresh();
+      } catch (error) {
+        setFeedback(error instanceof Error ? error.message : "Falha ao salvar precos.");
+      }
+    });
+  }
+
+  return (
+    <div className="panel surface-section p-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
+            Precos Pipetz
+          </p>
+          <h2
+            className="mt-2 text-2xl font-bold uppercase"
+            style={{ fontFamily: "var(--font-display)" }}
+          >
+            Acoes pagas
+          </h2>
+        </div>
+        {feedback ? <div className="retro-label neutral-chip">{feedback}</div> : null}
+      </div>
+
+      <div className="mt-5 grid gap-4">
+        {pricingFields.map((field) => (
+          <label key={field.key} className="card-brutal-static surface-card grid gap-3 p-4">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <span className="text-sm font-black uppercase tracking-[0.14em]">
+                  {field.label}
+                </span>
+                <p className="mt-1 text-sm leading-6 text-[var(--color-ink-soft)]">
+                  {field.description}
+                </p>
+              </div>
+              <span className="retro-label accent-chip">
+                atual {formatPipetz(pricing[field.key])}
+              </span>
+            </div>
+            <Input
+              type="number"
+              min={1}
+              step={1}
+              value={form[field.key]}
+              onChange={(event) => updateField(field.key, event.target.value)}
+            />
+          </label>
+        ))}
+      </div>
+
+      <div className="mt-5 flex flex-wrap items-center gap-3">
+        <Button type="button" onClick={savePricing} disabled={isPending} variant="success" size="sm">
+          {isPending ? "Salvando..." : "Salvar precos"}
+        </Button>
+        {pricing.updatedAt ? (
+          <span className="text-sm font-bold text-[var(--color-ink-soft)]">
+            Atualizado em {formatDateTime(pricing.updatedAt)}
+            {pricing.updatedBy ? ` por ${pricing.updatedBy}` : ""}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin-video-suggestions-panel.tsx
+++ b/src/components/admin-video-suggestions-panel.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+
+import { Button } from "@/components/ui/button";
+import type { VideoSuggestionWithMeta } from "@/lib/types";
+import { formatDateTime, formatPipetz } from "@/lib/utils";
+
+const statusLabels: Record<VideoSuggestionWithMeta["status"], string> = {
+  open: "Aberta",
+  accepted: "Aceita",
+  reacted: "Reagida",
+  rejected: "Rejeitada",
+};
+
+const statusBgMap: Record<VideoSuggestionWithMeta["status"], string> = {
+  open: "var(--color-sky)",
+  accepted: "var(--color-mint)",
+  reacted: "var(--color-lavender)",
+  rejected: "var(--color-periwinkle)",
+};
+
+function mapSuggestionError(message: string) {
+  switch (message) {
+    case "suggestion_not_found":
+      return "Sugestao nao encontrada.";
+    default:
+      return message;
+  }
+}
+
+export function AdminVideoSuggestionsPanel({
+  suggestions,
+}: {
+  suggestions: VideoSuggestionWithMeta[];
+}) {
+  const router = useRouter();
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function submitStatus(suggestionId: string, status: VideoSuggestionWithMeta["status"]) {
+    setFeedback(null);
+    startTransition(async () => {
+      const response = await fetch(`/api/admin/video-suggestions/${suggestionId}`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ status }),
+      });
+
+      const payload = (await response.json()) as { ok: boolean; error?: string };
+      if (!response.ok || !payload.ok) {
+        setFeedback(mapSuggestionError(payload.error ?? "Falha ao atualizar sugestao."));
+        return;
+      }
+
+      setFeedback("Status atualizado.");
+      router.refresh();
+    });
+  }
+
+  return (
+    <section className="landing-plane landing-divider bg-[var(--color-sky)] py-8 sm:py-10">
+      <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
+              Videos
+            </p>
+            <h2
+              className="mt-2 text-3xl uppercase"
+              style={{ fontFamily: "var(--font-display)" }}
+            >
+              Fila de reacoes
+            </h2>
+          </div>
+          {feedback ? (
+            <div className="retro-label neutral-chip">
+              {feedback}
+            </div>
+          ) : null}
+        </div>
+
+        <div className="mt-6 grid gap-3">
+          {suggestions.length === 0 ? (
+            <div className="card-brutal-static p-4 text-sm font-bold text-[var(--color-ink-soft)]">
+              Nenhuma sugestao cadastrada.
+            </div>
+          ) : null}
+
+          {suggestions.map((suggestion) => (
+            <article key={suggestion.id} className="card-brutal-static p-4">
+              <div className="grid gap-4 sm:grid-cols-[160px_1fr]">
+                <a
+                  href={suggestion.videoUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="block overflow-hidden rounded-[var(--radius)] border-[3px] border-[var(--color-ink)] bg-[var(--color-paper)]"
+                >
+                  <Image
+                    src={suggestion.thumbnailUrl}
+                    alt=""
+                    width={480}
+                    height={360}
+                    className="aspect-video w-full object-cover"
+                  />
+                </a>
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="text-lg font-bold">
+                          <a href={suggestion.videoUrl} target="_blank" rel="noreferrer" className="break-words hover:underline">
+                            {suggestion.title}
+                          </a>
+                        </p>
+                        <span
+                          className="badge-brutal px-2 py-1 text-[10px] text-[var(--color-ink)]"
+                          style={{ backgroundColor: statusBgMap[suggestion.status] }}
+                        >
+                          {statusLabels[suggestion.status]}
+                        </span>
+                      </div>
+                      <p className="mono mt-1 text-[10px] uppercase tracking-[0.18em] text-[var(--color-ink-soft)]">
+                        {suggestion.creatorName}
+                      </p>
+                      {suggestion.reason ? (
+                        <p className="mt-2 text-sm text-[var(--color-ink-soft)]">
+                          {suggestion.reason}
+                        </p>
+                      ) : null}
+                      <p className="mono mt-2 text-[10px] uppercase tracking-[0.18em] text-[var(--color-ink-soft)]">
+                        por {suggestion.suggestedBy} . {formatDateTime(suggestion.createdAt)}
+                      </p>
+                    </div>
+
+                    <span className="retro-label neutral-chip">
+                      {formatPipetz(suggestion.totalVotes)}
+                    </span>
+                  </div>
+
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {suggestion.status !== "accepted" ? (
+                      <Button
+                        type="button"
+                        onClick={() => submitStatus(suggestion.id, "accepted")}
+                        disabled={isPending}
+                        variant="success"
+                        size="sm"
+                      >
+                        Aceitar
+                      </Button>
+                    ) : null}
+                    {suggestion.status !== "reacted" ? (
+                      <Button
+                        type="button"
+                        onClick={() => submitStatus(suggestion.id, "reacted")}
+                        disabled={isPending}
+                        variant="neutral"
+                        size="sm"
+                      >
+                        Marcar reagido
+                      </Button>
+                    ) : null}
+                    {suggestion.status !== "rejected" ? (
+                      <Button
+                        type="button"
+                        onClick={() => submitStatus(suggestion.id, "rejected")}
+                        disabled={isPending}
+                        variant="danger"
+                        size="sm"
+                      >
+                        Rejeitar
+                      </Button>
+                    ) : null}
+                    {suggestion.status !== "open" ? (
+                      <Button
+                        type="button"
+                        onClick={() => submitStatus(suggestion.id, "open")}
+                        disabled={isPending}
+                        variant="info"
+                        size="sm"
+                      >
+                        Reabrir
+                      </Button>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/app-chrome.tsx
+++ b/src/components/app-chrome.tsx
@@ -58,6 +58,7 @@ export function AppChrome({
     { href: "/apostas", label: "Apostas" },
     { href: "/contadores", label: "Contadores" },
     { href: "/jogos", label: "Jogos" },
+    { href: "/videos", label: "Videos" },
     { href: "/quotes", label: "Quotes" },
     { href: "/ranking", label: "Ranking" },
   ];

--- a/src/components/game-suggest-form.tsx
+++ b/src/components/game-suggest-form.tsx
@@ -19,10 +19,10 @@ type GameSearchResult = {
   genres: string[];
 };
 
-function mapSuggestionError(message: string) {
+function mapSuggestionError(message: string, creationCost: number) {
   switch (message) {
     case "saldo_insuficiente":
-      return `Você precisa de ${formatPipetz(GAME_SUGGESTION_CREATION_COST)} para criar uma sugestão.`;
+      return `Você precisa de ${formatPipetz(creationCost)} para criar uma sugestão.`;
     case "suggestion_already_exists":
       return "Esse jogo já está na lista aberta.";
     case "invalid_name":
@@ -36,10 +36,12 @@ export function GameSuggestForm({
   loggedIn = false,
   canSuggest = false,
   viewerBalance,
+  creationCost = GAME_SUGGESTION_CREATION_COST,
 }: {
   loggedIn?: boolean;
   canSuggest?: boolean;
   viewerBalance?: number | null;
+  creationCost?: number;
 }) {
   const router = useRouter();
   const [name, setName] = useState("");
@@ -51,9 +53,9 @@ export function GameSuggestForm({
   const [feedback, setFeedback] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
   const hasInsufficientBalance =
-    typeof viewerBalance === "number" && viewerBalance < GAME_SUGGESTION_CREATION_COST;
+    typeof viewerBalance === "number" && viewerBalance < creationCost;
   const missingBalance = hasInsufficientBalance
-    ? GAME_SUGGESTION_CREATION_COST - (viewerBalance ?? 0)
+    ? creationCost - (viewerBalance ?? 0)
     : 0;
   const isSubmitDisabled = isPending || hasInsufficientBalance || !selectedGame;
   const canShowSearchResults =
@@ -175,7 +177,7 @@ export function GameSuggestForm({
 
       const payload = (await response.json()) as { ok: boolean; error?: string };
       if (!response.ok || !payload.ok) {
-        setFeedback(mapSuggestionError(payload.error ?? "Falha ao enviar sugestão."));
+        setFeedback(mapSuggestionError(payload.error ?? "Falha ao enviar sugestão.", creationCost));
         return;
       }
 
@@ -183,7 +185,7 @@ export function GameSuggestForm({
       setDescription("");
       setSelectedGame(null);
       setSearchResults([]);
-      setFeedback(`Sugestão enviada. ${formatPipetz(GAME_SUGGESTION_CREATION_COST)} debitados.`);
+      setFeedback(`Sugestão enviada. ${formatPipetz(creationCost)} debitados.`);
       router.refresh();
     });
   }
@@ -210,7 +212,7 @@ export function GameSuggestForm({
           </div>
           <div className="flex flex-wrap items-center justify-end gap-2">
             <span className="retro-label accent-chip !rounded-none !border !shadow-none">
-              custa {formatPipetz(GAME_SUGGESTION_CREATION_COST)}
+              custa {formatPipetz(creationCost)}
             </span>
             {typeof viewerBalance === "number" ? (
               <span className="retro-label neutral-chip !rounded-none !border !shadow-none">
@@ -310,7 +312,7 @@ export function GameSuggestForm({
           >
             {isPending
               ? "Enviando..."
-              : `Enviar sugestão por ${formatPipetz(GAME_SUGGESTION_CREATION_COST)}`}
+              : `Enviar sugestão por ${formatPipetz(creationCost)}`}
           </Button>
         </div>
 

--- a/src/components/quote-overlay-trigger.tsx
+++ b/src/components/quote-overlay-trigger.tsx
@@ -6,8 +6,6 @@ import { useState, useTransition } from "react";
 import { Button } from "@/components/ui/button";
 import { formatPipetz } from "@/lib/utils";
 
-const QUOTE_OVERLAY_COST = 50;
-
 function mapError(message: string) {
   switch (message) {
     case "Unauthorized":
@@ -32,17 +30,19 @@ export function QuoteOverlayTrigger({
   loggedIn,
   canShow,
   viewerBalance,
+  quoteOverlayCost,
 }: {
   quoteId: number;
   loggedIn: boolean;
   canShow: boolean;
   viewerBalance?: number | null;
+  quoteOverlayCost: number;
 }) {
   const router = useRouter();
   const [feedback, setFeedback] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
-  const hasBalance = typeof viewerBalance === "number" && viewerBalance >= QUOTE_OVERLAY_COST;
+  const hasBalance = typeof viewerBalance === "number" && viewerBalance >= quoteOverlayCost;
 
   function handleShow() {
     setFeedback(null);
@@ -101,11 +101,11 @@ export function QuoteOverlayTrigger({
         variant="info"
         size="sm"
       >
-        {isPending ? "Enviando..." : `Mostrar no OBS (-${formatPipetz(QUOTE_OVERLAY_COST)})`}
+        {isPending ? "Enviando..." : `Mostrar no OBS (-${formatPipetz(quoteOverlayCost)})`}
       </Button>
       {!hasBalance ? (
         <p className="text-xs font-bold uppercase tracking-[0.16em] text-[var(--color-ink-soft)]">
-          faltam {formatPipetz(Math.max(QUOTE_OVERLAY_COST - (viewerBalance ?? 0), 0))} pipetz
+          faltam {formatPipetz(Math.max(quoteOverlayCost - (viewerBalance ?? 0), 0))} pipetz
         </p>
       ) : null}
       {feedback ? (

--- a/src/components/video-suggest-form.tsx
+++ b/src/components/video-suggest-form.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { VIDEO_SUGGESTION_CREATION_COST } from "@/lib/video-suggestions/constants";
+import { validateVideoSuggestionDraft } from "@/lib/video-suggestions/service";
+import { formatPipetz } from "@/lib/utils";
+
+function mapSuggestionError(message: string, creationCost: number) {
+  switch (message) {
+    case "saldo_insuficiente":
+      return `Voce precisa de ${formatPipetz(creationCost)} para criar uma sugestao.`;
+    case "suggestion_already_exists":
+      return "Esse video ja esta na lista aberta.";
+    case "invalid_youtube_url":
+      return "Cole um link valido de video do YouTube.";
+    case "youtube_video_not_found":
+      return "Nao consegui validar esse video no YouTube.";
+    default:
+      return message;
+  }
+}
+
+export function VideoSuggestForm({
+  loggedIn = false,
+  canSuggest = false,
+  viewerBalance,
+  creationCost = VIDEO_SUGGESTION_CREATION_COST,
+}: {
+  loggedIn?: boolean;
+  canSuggest?: boolean;
+  viewerBalance?: number | null;
+  creationCost?: number;
+}) {
+  const router = useRouter();
+  const [videoUrl, setVideoUrl] = useState("");
+  const [reason, setReason] = useState("");
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const hasInsufficientBalance =
+    typeof viewerBalance === "number" && viewerBalance < creationCost;
+  const missingBalance = hasInsufficientBalance
+    ? creationCost - (viewerBalance ?? 0)
+    : 0;
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const validationError = validateVideoSuggestionDraft({
+      videoUrl,
+      reason,
+    });
+
+    if (validationError) {
+      setFeedback(validationError);
+      return;
+    }
+
+    if (!canSuggest) {
+      setFeedback(loggedIn ? "Sua conta ainda nao esta pronta para sugerir." : "Faca login para sugerir.");
+      return;
+    }
+
+    if (hasInsufficientBalance) {
+      setFeedback(`Faltam ${formatPipetz(missingBalance)} para criar uma sugestao.`);
+      return;
+    }
+
+    setFeedback("Validando video no YouTube...");
+    startTransition(async () => {
+      const response = await fetch("/api/me/video-suggestions", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          videoUrl: videoUrl.trim(),
+          reason: reason.trim(),
+        }),
+      });
+
+      const payload = (await response.json()) as { ok: boolean; error?: string };
+      if (!response.ok || !payload.ok) {
+        setFeedback(mapSuggestionError(payload.error ?? "Falha ao enviar sugestao.", creationCost));
+        return;
+      }
+
+      setVideoUrl("");
+      setReason("");
+      setFeedback(`Sugestao enviada. ${formatPipetz(creationCost)} debitados.`);
+      router.refresh();
+    });
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="panel surface-section relative overflow-hidden p-5 text-[var(--color-ink)] sm:p-6"
+    >
+      <div className="bg-dots-light pointer-events-none absolute inset-0 opacity-15" />
+
+      <div className="relative">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h3
+              className="text-lg font-bold uppercase"
+              style={{ fontFamily: "var(--font-display)" }}
+            >
+              Sugira um video
+            </h3>
+            <p className="mt-2 text-sm text-[var(--color-ink-soft)]">
+              Manda o link do YouTube e me convence a reagir ao vivo.
+            </p>
+            <p className="mt-2 text-xs font-bold uppercase tracking-[0.12em] text-[var(--color-ink-soft)]">
+              cada nova sugestao custa {formatPipetz(creationCost)}. boost continua separado.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center justify-end gap-2">
+            <span className="retro-label accent-chip">
+              custa {formatPipetz(creationCost)}
+            </span>
+            {typeof viewerBalance === "number" ? (
+              <span className="retro-label neutral-chip">
+                saldo {formatPipetz(viewerBalance)}
+              </span>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="mt-4 grid gap-3">
+          <Input
+            type="url"
+            placeholder="Link do YouTube"
+            value={videoUrl}
+            onChange={(e) => setVideoUrl(e.target.value)}
+            required
+            maxLength={500}
+          />
+          <Textarea
+            placeholder="Por que eu deveria reagir a esse video? (opcional)"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            rows={4}
+            maxLength={500}
+            className="min-h-28 font-medium"
+          />
+          <Button
+            type="submit"
+            disabled={isPending || hasInsufficientBalance}
+            size="lg"
+            className="w-full sm:w-fit"
+          >
+            {isPending
+              ? "Validando..."
+              : `Enviar sugestao por ${formatPipetz(creationCost)}`}
+          </Button>
+        </div>
+
+        {!loggedIn ? (
+          <p className="mt-3 text-xs font-bold uppercase tracking-[0.12em] text-[var(--color-ink-soft)]">
+            faca login para sugerir e dar boost
+          </p>
+        ) : null}
+
+        {loggedIn && hasInsufficientBalance ? (
+          <p className="mt-3 text-xs font-bold uppercase tracking-[0.12em] text-[var(--color-ink-soft)]">
+            faltam {formatPipetz(missingBalance)} para liberar uma nova sugestao
+          </p>
+        ) : null}
+
+        {feedback ? (
+          <div className="sticker sticker-pop accent-chip mt-3 inline-flex px-3 py-1.5 text-sm">
+            {feedback}
+          </div>
+        ) : null}
+      </div>
+    </form>
+  );
+}

--- a/src/components/video-suggestion-card.tsx
+++ b/src/components/video-suggestion-card.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import Image from "next/image";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { VideoSuggestionWithMeta } from "@/lib/types";
+import { formatPipetz } from "@/lib/utils";
+
+const statusLabels: Record<VideoSuggestionWithMeta["status"], string> = {
+  open: "Aberta",
+  accepted: "Aceita",
+  reacted: "Ja reagi",
+  rejected: "Fechada",
+};
+
+const statusColors: Record<VideoSuggestionWithMeta["status"], string> = {
+  open: "var(--color-sky)",
+  accepted: "var(--color-mint)",
+  reacted: "var(--color-lavender)",
+  rejected: "var(--color-periwinkle)",
+};
+
+const cardBgCycle = [
+  "surface-card",
+  "surface-card-alt",
+  "surface-card-accent",
+  "surface-card",
+  "surface-card-alt",
+  "surface-card",
+];
+
+function mapSuggestionError(message: string) {
+  switch (message) {
+    case "saldo_insuficiente":
+      return "Saldo insuficiente.";
+    case "suggestion_not_found":
+      return "Sugestao nao encontrada.";
+    case "suggestion_not_open":
+      return "So da para dar boost em sugestoes abertas.";
+    case "invalid_amount":
+      return "Digite um valor inteiro positivo.";
+    default:
+      return message;
+  }
+}
+
+export function VideoSuggestionCard({
+  suggestion,
+  index = 0,
+  loggedIn = false,
+  canBoost = false,
+  viewerBalance,
+  onBoostSuccess,
+}: {
+  suggestion: VideoSuggestionWithMeta;
+  index?: number;
+  loggedIn?: boolean;
+  canBoost?: boolean;
+  viewerBalance?: number | null;
+  onBoostSuccess?: (suggestion: VideoSuggestionWithMeta, spentAmount: number) => void;
+}) {
+  const [boostAmount, setBoostAmount] = useState("");
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function handleBoost() {
+    const parsed = Number.parseInt(boostAmount, 10);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      setFeedback("Digite um valor inteiro positivo.");
+      return;
+    }
+
+    if (!canBoost) {
+      setFeedback(loggedIn ? "Sua conta ainda nao esta pronta para dar boost." : "Faca login para dar boost.");
+      return;
+    }
+
+    setFeedback(null);
+    startTransition(async () => {
+      try {
+        const response = await fetch(`/api/me/video-suggestions/${suggestion.id}/boost`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ amount: parsed }),
+        });
+
+        const payload = (await response.json()) as {
+          ok: boolean;
+          error?: string;
+          data?: VideoSuggestionWithMeta;
+        };
+
+        if (!response.ok || !payload.ok || !payload.data) {
+          setFeedback(mapSuggestionError(payload.error ?? "Falha ao dar boost."));
+          return;
+        }
+
+        onBoostSuccess?.(payload.data, parsed);
+        setBoostAmount("");
+        setFeedback("Boost enviado.");
+      } catch {
+        setFeedback("Falha ao dar boost.");
+      }
+    });
+  }
+
+  const bgClass = cardBgCycle[index % cardBgCycle.length];
+
+  return (
+    <div className={`card-brutal relative overflow-hidden p-5 ${bgClass}`}>
+      <div className="grid gap-4 sm:grid-cols-[180px_1fr]">
+        <a
+          href={suggestion.videoUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="block overflow-hidden rounded-[var(--radius)] border-[3px] border-[var(--color-ink)] bg-[var(--color-paper)] shadow-purple"
+        >
+          <Image
+            src={suggestion.thumbnailUrl}
+            alt=""
+            width={480}
+            height={360}
+            className="aspect-video w-full object-cover"
+            loading="lazy"
+          />
+        </a>
+
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <h3
+                  className="min-w-0 text-xl font-bold"
+                  style={{ fontFamily: "var(--font-display)" }}
+                >
+                  <a href={suggestion.videoUrl} target="_blank" rel="noreferrer" className="break-words hover:underline">
+                    {suggestion.title}
+                  </a>
+                </h3>
+                <span
+                  className="sticker micro-flat px-2 py-0.5 text-[10px] text-[var(--color-ink)]"
+                  style={{ backgroundColor: statusColors[suggestion.status] }}
+                >
+                  {statusLabels[suggestion.status]}
+                </span>
+              </div>
+              <p className="mono mt-1 text-xs font-bold uppercase tracking-[0.14em] text-[var(--color-ink-soft)]">
+                {suggestion.creatorName}
+              </p>
+              {suggestion.reason ? (
+                <p className="mt-2 text-sm opacity-80">
+                  {suggestion.reason}
+                </p>
+              ) : null}
+              <p className="mono mt-2 text-xs opacity-75">
+                Sugerido por {suggestion.suggestedBy}
+              </p>
+              {suggestion.viewerBoostTotal > 0 ? (
+                <p className="mono mt-1 text-xs font-bold uppercase tracking-[0.14em] text-[var(--color-ink-soft)]">
+                  seu boost: {formatPipetz(suggestion.viewerBoostTotal)}
+                </p>
+              ) : null}
+            </div>
+
+            <div className="micro-flat rounded-[var(--radius)] border-[3px] border-[var(--color-ink)] bg-[var(--color-paper)] px-4 py-2 text-center shadow-purple">
+              <p
+                className="text-2xl font-bold text-[var(--color-purple-bold)]"
+                style={{ fontFamily: "var(--font-display)" }}
+              >
+                {formatPipetz(suggestion.totalVotes)}
+              </p>
+              <p className="mono text-[9px] uppercase tracking-[0.15em] text-[var(--color-ink-soft)]">
+                boost total
+              </p>
+              {typeof viewerBalance === "number" ? (
+                <p className="mono mt-1 text-[9px] uppercase tracking-[0.15em] text-[var(--color-ink-soft)]">
+                  saldo {formatPipetz(viewerBalance)}
+                </p>
+              ) : null}
+            </div>
+          </div>
+
+          {suggestion.status === "open" ? (
+            <div className="mt-4 flex flex-wrap items-center gap-2 rounded-[var(--radius)] border-2 border-dashed border-[var(--color-ink)] bg-[var(--color-paper)]/60 p-3">
+              <span className="text-xs font-bold uppercase text-[var(--color-ink-soft)]">Boost:</span>
+              <Input
+                type="number"
+                min="1"
+                placeholder="Pipetz"
+                value={boostAmount}
+                onChange={(e) => setBoostAmount(e.target.value)}
+                className="w-24 px-3 py-2"
+              />
+              <Button
+                type="button"
+                onClick={handleBoost}
+                disabled={isPending}
+                size="sm"
+              >
+                {isPending ? "Enviando..." : "Dar boost"}
+              </Button>
+            </div>
+          ) : null}
+
+          {!loggedIn ? (
+            <p className="mt-3 text-xs font-bold uppercase tracking-[0.12em] text-[var(--color-ink-soft)]">
+              faca login para sugerir e dar boost
+            </p>
+          ) : null}
+
+          {feedback ? (
+            <div className="sticker sticker-pop accent-chip mt-3 inline-flex px-2 py-1 text-xs">
+              {feedback}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/video-suggestion-list.tsx
+++ b/src/components/video-suggestion-list.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { VideoSuggestionCard } from "@/components/video-suggestion-card";
+import type { VideoSuggestionWithMeta } from "@/lib/types";
+
+export function VideoSuggestionList({
+  suggestions,
+  loggedIn = false,
+  canInteract = false,
+  viewerBalance,
+}: {
+  suggestions: VideoSuggestionWithMeta[];
+  loggedIn?: boolean;
+  canInteract?: boolean;
+  viewerBalance?: number | null;
+}) {
+  const [localSuggestions, setLocalSuggestions] = useState(suggestions);
+  const [localBalance, setLocalBalance] = useState<number | null>(viewerBalance ?? null);
+
+  useEffect(() => {
+    setLocalSuggestions(suggestions);
+  }, [suggestions]);
+
+  useEffect(() => {
+    setLocalBalance(viewerBalance ?? null);
+  }, [viewerBalance]);
+
+  function handleBoostSuccess(updatedSuggestion: VideoSuggestionWithMeta, spentAmount: number) {
+    setLocalSuggestions((current) =>
+      current.map((suggestion) =>
+        suggestion.id === updatedSuggestion.id ? updatedSuggestion : suggestion,
+      ),
+    );
+
+    setLocalBalance((current) =>
+      typeof current === "number" ? Math.max(current - spentAmount, 0) : current,
+    );
+  }
+
+  const sorted = [...localSuggestions].sort((a, b) => {
+    if (b.totalVotes !== a.totalVotes) {
+      return b.totalVotes - a.totalVotes;
+    }
+
+    return +new Date(b.createdAt) - +new Date(a.createdAt);
+  });
+  const visibleSuggestions = sorted.filter((suggestion) => suggestion.status !== "rejected");
+
+  return (
+    <div className="grid gap-4">
+      {visibleSuggestions.map((suggestion, index) => (
+        <VideoSuggestionCard
+          key={suggestion.id}
+          suggestion={suggestion}
+          index={index}
+          loggedIn={loggedIn}
+          canBoost={canInteract}
+          viewerBalance={localBalance}
+          onBoostSuccess={handleBoostSuccess}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/lib/db/repository.test.ts
+++ b/src/lib/db/repository.test.ts
@@ -58,12 +58,15 @@ import {
   viewerBalances,
 } from "@/lib/db/schema";
 import { GAME_SUGGESTION_CREATION_COST } from "@/lib/game-suggestions/constants";
+import { VIDEO_SUGGESTION_CREATION_COST } from "@/lib/video-suggestions/constants";
 import {
   adminLinkGoogleViewerToYoutubeViewer,
   boostGameSuggestion,
+  boostVideoSuggestion,
   cancelBet,
   createBet,
   createGameSuggestion,
+  createVideoSuggestion,
   createProductRecommendationFromInput,
   deleteProductRecommendation,
   applyGoogleCrossAccountProtectionEvent,
@@ -82,6 +85,7 @@ import {
   listBets,
   listGameSuggestions,
   listAdminGameSuggestions,
+  listVideoSuggestions,
   listStreamerbotCounters,
   listViewerChannelsForGoogleAccount,
   lockBet,
@@ -99,6 +103,7 @@ import {
   showQuoteOverlayForViewer,
   cancelQueuedQuoteOverlays,
   updateGameSuggestionStatus,
+  updateVideoSuggestionStatus,
 } from "@/lib/db/repository";
 import { GOOGLE_RISC_EVENT_TYPES } from "@/lib/google/risc";
 
@@ -2018,6 +2023,91 @@ describe("game suggestions", () => {
 
     const suggestions = await listAdminGameSuggestions();
     expect(suggestions.find((entry) => entry.id === "gs-4")?.status).toBe("accepted");
+  });
+});
+
+describe("video suggestions", () => {
+  beforeEach(() => {
+    getDbMock.mockReset();
+    getDbMock.mockReturnValue(null);
+    delete (globalThis as typeof globalThis & { __lojaDemoStore?: unknown }).__lojaDemoStore;
+  });
+
+  it("creates a new video suggestion in demo mode", async () => {
+    const before = await getViewerDashboard("viewer_ana");
+    expect(before).not.toBeNull();
+    const beforeBalance = before?.balance.currentBalance ?? 0;
+    const beforeSpent = before?.balance.lifetimeSpent ?? 0;
+
+    const created = await createVideoSuggestion({
+      viewerId: "viewer_ana",
+      youtubeVideoId: "abc123DEF45",
+      title: "Um video pra reagir",
+      creatorName: "Canal Legal",
+      thumbnailUrl: "https://i.ytimg.com/vi/abc123DEF45/hqdefault.jpg",
+      videoUrl: "https://www.youtube.com/watch?v=abc123DEF45",
+      reason: "Tem uma virada absurda no final.",
+      source: "web",
+    });
+
+    expect(created).toMatchObject({
+      youtubeVideoId: "abc123DEF45",
+      title: "Um video pra reagir",
+      creatorName: "Canal Legal",
+      status: "open",
+      totalVotes: 0,
+      suggestedBy: "Ana Neon",
+    });
+
+    const suggestions = await listVideoSuggestions("viewer_ana");
+    expect(suggestions.some((entry) => entry.youtubeVideoId === "abc123DEF45")).toBe(true);
+
+    const after = await getViewerDashboard("viewer_ana");
+    expect(after?.balance.currentBalance).toBe(beforeBalance - VIDEO_SUGGESTION_CREATION_COST);
+    expect(after?.balance.lifetimeSpent).toBe(beforeSpent + VIDEO_SUGGESTION_CREATION_COST);
+  });
+
+  it("rejects duplicate open video suggestions", async () => {
+    await expect(
+      createVideoSuggestion({
+        viewerId: "viewer_caio",
+        youtubeVideoId: "dQw4w9WgXcQ",
+        title: "Duplicado",
+        creatorName: "Rick Astley",
+        thumbnailUrl: "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
+        videoUrl: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      }),
+    ).rejects.toThrow("suggestion_already_exists");
+  });
+
+  it("spends balance and increases votes when boosting", async () => {
+    const before = await getViewerDashboard("viewer_ana");
+    expect(before).not.toBeNull();
+    const beforeBalance = before?.balance.currentBalance ?? 0;
+    const beforeSpent = before?.balance.lifetimeSpent ?? 0;
+
+    const updated = await boostVideoSuggestion({
+      suggestionId: "vs-1",
+      viewerId: "viewer_ana",
+      amount: 80,
+      source: "web",
+    });
+
+    expect(updated.totalVotes).toBe(980);
+    expect(updated.viewerBoostTotal).toBe(80);
+
+    const after = await getViewerDashboard("viewer_ana");
+    expect(after?.balance.currentBalance).toBe(beforeBalance - 80);
+    expect(after?.balance.lifetimeSpent).toBe(beforeSpent + 80);
+  });
+
+  it("lets the admin update the video suggestion status", async () => {
+    const updated = await updateVideoSuggestionStatus({
+      suggestionId: "vs-1",
+      status: "reacted",
+    });
+
+    expect(updated.status).toBe("reacted");
   });
 });
 

--- a/src/lib/db/repository.ts
+++ b/src/lib/db/repository.ts
@@ -30,6 +30,8 @@ import {
   streamerbotCounters,
   streamerbotEventLog,
   users,
+  videoSuggestionBoosts,
+  videoSuggestions,
   viewerBalances,
   viewerLinks,
 } from "@/lib/db/schema";
@@ -49,10 +51,13 @@ import {
   demoQuotes,
   demoProductRecommendations,
   demoRedemptions,
+  demoVideoSuggestionBoosts,
+  demoVideoSuggestions,
   demoViewers,
 } from "@/lib/demo-data";
 import { adminEmails, isDemoMode } from "@/lib/env";
 import { GAME_SUGGESTION_CREATION_COST } from "@/lib/game-suggestions/constants";
+import { VIDEO_SUGGESTION_CREATION_COST } from "@/lib/video-suggestions/constants";
 import {
   eventRequiresActiveLivestream,
   requireActiveLivestream,
@@ -79,6 +84,7 @@ import {
   LedgerEntryRecord,
   ObsOverlayAdminStatusRecord,
   ObsOverlayControlRecord,
+  PipetzPricingRecord,
   QuoteOverlayStateRecord,
   QuoteOverlayQueueRecord,
   QuoteRecord,
@@ -86,6 +92,9 @@ import {
   RedemptionRecord,
   StreamerbotCounterRecord,
   StreamerbotCounterSummaryRecord,
+  VideoSuggestionBoostRecord,
+  VideoSuggestionRecord,
+  VideoSuggestionWithMeta,
   ViewerChannelOptionRecord,
   ViewerBalanceRecord,
   ViewerLinkRecord,
@@ -114,6 +123,21 @@ const QUOTE_OVERLAY_LOCK_KEY = 42_001;
 const OBS_OVERLAY_CONTROL_KEY = "quotes";
 const QUOTE_OVERLAY_QUEUE_LIMIT = 20;
 const QUOTE_OVERLAY_QUEUE_TTL_MS = 2 * 60 * 60 * 1000;
+const PIPETZ_PRICING_SETTING_SCOPE_TYPE = "setting";
+const PIPETZ_PRICING_SETTING_SCOPE_KEY = "pipetz_pricing";
+const PIPETZ_PRICING_SETTING_KEYS = {
+  gameSuggestionCost: "pricing_game_suggestion",
+  videoSuggestionCost: "pricing_video_suggestion",
+  quoteOverlayCost: "pricing_quote_overlay",
+} as const;
+
+const DEFAULT_PIPETZ_PRICING: PipetzPricingRecord = {
+  gameSuggestionCost: GAME_SUGGESTION_CREATION_COST,
+  videoSuggestionCost: VIDEO_SUGGESTION_CREATION_COST,
+  quoteOverlayCost: QUOTE_OVERLAY_COST,
+  updatedAt: null,
+  updatedBy: null,
+};
 
 type StreamerbotCounterCommandAction = "increment" | "decrement" | "get" | "reset";
 type StreamerbotCounterScopeType = "global" | "game";
@@ -255,6 +279,8 @@ type DemoStore = {
   betEntries: BetEntryRecord[];
   gameSuggestions: GameSuggestionRecord[];
   gameSuggestionBoosts: GameSuggestionBoostRecord[];
+  videoSuggestions: VideoSuggestionRecord[];
+  videoSuggestionBoosts: VideoSuggestionBoostRecord[];
   productRecommendations: ProductRecommendationRecord[];
   bridgeClients: BridgeClientRecord[];
   streamerbotCounters: StreamerbotCounterRecord[];
@@ -285,6 +311,8 @@ function getDemoStore(): DemoStore {
       betEntries: structuredClone(demoBetEntries),
       gameSuggestions: structuredClone(demoGameSuggestions),
       gameSuggestionBoosts: structuredClone(demoGameSuggestionBoosts),
+      videoSuggestions: structuredClone(demoVideoSuggestions),
+      videoSuggestionBoosts: structuredClone(demoVideoSuggestionBoosts),
       productRecommendations: structuredClone(demoProductRecommendations),
       bridgeClients: structuredClone(demoBridgeClients),
       streamerbotCounters: [],
@@ -410,6 +438,162 @@ function buildStreamerbotCounterSummary(counter: StreamerbotCounterRecord): Stre
     lastAmount: typeof counter.metadata.lastAmount === "number" ? counter.metadata.lastAmount : null,
     source: typeof counter.metadata.source === "string" ? counter.metadata.source : null,
   };
+}
+
+function isMissingStreamerbotCountersTableError(error: unknown) {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const maybePostgresError = error as Error & {
+    code?: string;
+    cause?: { code?: string; message?: string };
+  };
+  const message = `${error.message} ${maybePostgresError.cause?.message ?? ""}`;
+
+  return (
+    maybePostgresError.code === "42P01" ||
+    maybePostgresError.cause?.code === "42P01" ||
+    message.includes('relation "streamerbot_counters" does not exist')
+  );
+}
+
+function serializePipetzPricingRow(row: StreamerbotCounterRecord | typeof streamerbotCounters.$inferSelect) {
+  const metadata = row.metadata as Record<string, unknown>;
+
+  return {
+    value: row.value,
+    updatedAt: row.updatedAt instanceof Date ? row.updatedAt.toISOString() : row.updatedAt,
+    updatedBy: typeof metadata.updatedBy === "string" ? metadata.updatedBy : null,
+  };
+}
+
+export async function getPipetzPricing(): Promise<PipetzPricingRecord> {
+  const db = getDb();
+  const keys = Object.values(PIPETZ_PRICING_SETTING_KEYS) as string[];
+  const pricing = { ...DEFAULT_PIPETZ_PRICING };
+
+  if (isDemoMode || !db) {
+    for (const row of getDemoStore().streamerbotCounters.filter((entry) => keys.includes(entry.key))) {
+      const serialized = serializePipetzPricingRow(row);
+      const field = Object.entries(PIPETZ_PRICING_SETTING_KEYS).find(([, key]) => key === row.key)?.[0] as
+        | keyof typeof PIPETZ_PRICING_SETTING_KEYS
+        | undefined;
+      if (!field) {
+        continue;
+      }
+
+      pricing[field] = serialized.value;
+      pricing.updatedAt = serialized.updatedAt;
+      pricing.updatedBy = serialized.updatedBy;
+    }
+
+    return pricing;
+  }
+
+  try {
+    const rows = await db.select().from(streamerbotCounters).where(inArray(streamerbotCounters.key, keys));
+    for (const row of rows) {
+      const serialized = serializePipetzPricingRow(row);
+      const field = Object.entries(PIPETZ_PRICING_SETTING_KEYS).find(([, key]) => key === row.key)?.[0] as
+        | keyof typeof PIPETZ_PRICING_SETTING_KEYS
+        | undefined;
+      if (!field) {
+        continue;
+      }
+
+      pricing[field] = serialized.value;
+      pricing.updatedAt = serialized.updatedAt;
+      pricing.updatedBy = serialized.updatedBy;
+    }
+  } catch (error) {
+    if (!isMissingStreamerbotCountersTableError(error)) {
+      throw error;
+    }
+  }
+
+  return pricing;
+}
+
+export async function updatePipetzPricing(input: {
+  gameSuggestionCost: number;
+  videoSuggestionCost: number;
+  quoteOverlayCost: number;
+  updatedBy: string | null;
+}): Promise<PipetzPricingRecord> {
+  const db = getDb();
+  const updatedAt = new Date();
+  const values = {
+    gameSuggestionCost: input.gameSuggestionCost,
+    videoSuggestionCost: input.videoSuggestionCost,
+    quoteOverlayCost: input.quoteOverlayCost,
+  };
+
+  if (isDemoMode || !db) {
+    const store = getDemoStore();
+    for (const [field, key] of Object.entries(PIPETZ_PRICING_SETTING_KEYS)) {
+      const value = values[field as keyof typeof values];
+      const existing = store.streamerbotCounters.find((entry) => entry.key === key);
+      if (existing) {
+        existing.value = value;
+        existing.updatedAt = updatedAt.toISOString();
+        existing.metadata = {
+          ...existing.metadata,
+          updatedBy: input.updatedBy,
+        };
+      } else {
+        store.streamerbotCounters.push({
+          key,
+          scopeType: PIPETZ_PRICING_SETTING_SCOPE_TYPE,
+          scopeKey: PIPETZ_PRICING_SETTING_SCOPE_KEY,
+          value,
+          lastResetAt: null,
+          updatedAt: updatedAt.toISOString(),
+          metadata: {
+            setting: field,
+            updatedBy: input.updatedBy,
+          },
+        });
+      }
+    }
+
+    return getPipetzPricing();
+  }
+
+  await db.transaction(async (tx) => {
+    for (const [field, key] of Object.entries(PIPETZ_PRICING_SETTING_KEYS)) {
+      const value = values[field as keyof typeof values];
+      await tx
+        .insert(streamerbotCounters)
+        .values({
+          key,
+          value,
+          lastResetAt: null,
+          updatedAt,
+          metadata: {
+            setting: field,
+            scopeType: PIPETZ_PRICING_SETTING_SCOPE_TYPE,
+            scopeKey: PIPETZ_PRICING_SETTING_SCOPE_KEY,
+            updatedBy: input.updatedBy,
+          },
+        })
+        .onConflictDoUpdate({
+          target: streamerbotCounters.key,
+          set: {
+            value,
+            updatedAt,
+            metadata: {
+              setting: field,
+              scopeType: PIPETZ_PRICING_SETTING_SCOPE_TYPE,
+              scopeKey: PIPETZ_PRICING_SETTING_SCOPE_KEY,
+              updatedBy: input.updatedBy,
+            },
+          },
+        });
+    }
+  });
+
+  return getPipetzPricing();
 }
 
 function sanitizePublicCounterSummaries(
@@ -965,6 +1149,16 @@ function mergeDemoViewerIntoTarget(input: {
       entry.viewerId = targetViewerId;
     }
   }
+  for (const entry of store.videoSuggestions) {
+    if (entry.viewerId === sourceViewerId) {
+      entry.viewerId = targetViewerId;
+    }
+  }
+  for (const entry of store.videoSuggestionBoosts) {
+    if (entry.viewerId === sourceViewerId) {
+      entry.viewerId = targetViewerId;
+    }
+  }
   for (const account of store.googleAccounts) {
     if (account.activeViewerId === sourceViewerId) {
       account.activeViewerId = targetViewerId;
@@ -1284,6 +1478,35 @@ function serializeGameSuggestionBoost(
   };
 }
 
+function serializeVideoSuggestion(row: typeof videoSuggestions.$inferSelect): VideoSuggestionRecord {
+  return {
+    id: row.id,
+    viewerId: row.viewerId,
+    youtubeVideoId: row.youtubeVideoId,
+    title: row.title,
+    creatorName: row.creatorName,
+    thumbnailUrl: row.thumbnailUrl,
+    videoUrl: row.videoUrl,
+    reason: row.reason ?? null,
+    status: row.status as VideoSuggestionRecord["status"],
+    totalVotes: row.totalVotes,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+function serializeVideoSuggestionBoost(
+  row: typeof videoSuggestionBoosts.$inferSelect,
+): VideoSuggestionBoostRecord {
+  return {
+    id: row.id,
+    suggestionId: row.suggestionId,
+    viewerId: row.viewerId,
+    amount: row.amount,
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
 function serializeQuote(row: typeof quotes.$inferSelect): QuoteRecord {
   return {
     id: row.id,
@@ -1495,6 +1718,20 @@ function buildGameSuggestionWithMeta(params: {
   viewer: ViewerRecord | null;
   boosts?: GameSuggestionBoostRecord[];
 }): GameSuggestionWithMeta {
+  const boosts = params.boosts ?? [];
+  return {
+    ...params.suggestion,
+    suggestedBy: params.viewer?.youtubeDisplayName ?? "Viewer",
+    suggestedByYoutubeHandle: params.viewer?.youtubeHandle ?? null,
+    viewerBoostTotal: boosts.reduce((sum, entry) => sum + entry.amount, 0),
+  };
+}
+
+function buildVideoSuggestionWithMeta(params: {
+  suggestion: VideoSuggestionRecord;
+  viewer: ViewerRecord | null;
+  boosts?: VideoSuggestionBoostRecord[];
+}): VideoSuggestionWithMeta {
   const boosts = params.boosts ?? [];
   return {
     ...params.suggestion,
@@ -2144,7 +2381,7 @@ async function requestQuoteOverlay(input: {
   durationSeconds?: number;
 }) {
   const control = await getObsOverlayControlRecord();
-  const cost = QUOTE_OVERLAY_COST;
+  const cost = (await getPipetzPricing()).quoteOverlayCost;
   const displayDurationSeconds = input.durationSeconds ?? QUOTE_OVERLAY_DURATION_SECONDS;
 
   if (control.status === "paused" || (await hasPendingQuoteOverlayQueue())) {
@@ -2367,6 +2604,29 @@ function listDemoGameSuggestions(viewerId?: string | null) {
     );
 }
 
+function listDemoVideoSuggestions(viewerId?: string | null) {
+  const store = getDemoStore();
+  const viewerBoosts = viewerId
+    ? store.videoSuggestionBoosts.filter((entry) => entry.viewerId === viewerId)
+    : [];
+
+  return [...store.videoSuggestions]
+    .sort((a, b) => {
+      if (b.totalVotes !== a.totalVotes) {
+        return b.totalVotes - a.totalVotes;
+      }
+
+      return +new Date(b.createdAt) - +new Date(a.createdAt);
+    })
+    .map((suggestion) =>
+      buildVideoSuggestionWithMeta({
+        suggestion,
+        viewer: getDemoViewerById(store, suggestion.viewerId),
+        boosts: viewerBoosts.filter((entry) => entry.suggestionId === suggestion.id),
+      }),
+    );
+}
+
 function resolveChatTargetBet(input: {
   bets: BetWithOptionsRecord[];
   betId?: string | null;
@@ -2507,6 +2767,45 @@ function isMissingGameSuggestionSchemaError(error: unknown) {
     '"game_suggestion_boosts"',
     "game_suggestions",
     "game_suggestion_boosts",
+  ];
+  const queue: unknown[] = [error];
+  const visited = new Set<unknown>();
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current || visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+
+    const message =
+      current instanceof Error ? current.message : typeof current === "string" ? current : "";
+    const normalized = message.toLowerCase();
+    const mentionsTables = tableNames.some((tableName) => normalized.includes(tableName));
+    if (
+      mentionsTables &&
+      (normalized.includes("does not exist") ||
+        normalized.includes("relation") ||
+        normalized.includes("table") ||
+        normalized.includes("failed query"))
+    ) {
+      return true;
+    }
+
+    if (typeof current === "object" && current && "cause" in current) {
+      queue.push((current as { cause?: unknown }).cause);
+    }
+  }
+
+  return false;
+}
+
+function isMissingVideoSuggestionSchemaError(error: unknown) {
+  const tableNames = [
+    '"video_suggestions"',
+    '"video_suggestion_boosts"',
+    "video_suggestions",
+    "video_suggestion_boosts",
   ];
   const queue: unknown[] = [error];
   const visited = new Set<unknown>();
@@ -3935,6 +4234,51 @@ export async function listAdminGameSuggestions() {
   return listGameSuggestions();
 }
 
+export async function listVideoSuggestions(viewerId?: string | null) {
+  const db = getDb();
+
+  if (isDemoMode || !db) {
+    return listDemoVideoSuggestions(viewerId);
+  }
+
+  let suggestionRows: Array<typeof videoSuggestions.$inferSelect>;
+  let boostRows: Array<typeof videoSuggestionBoosts.$inferSelect>;
+
+  try {
+    [suggestionRows, boostRows] = await Promise.all([
+      db.select().from(videoSuggestions).orderBy(desc(videoSuggestions.totalVotes), desc(videoSuggestions.createdAt)),
+      viewerId
+        ? db.select().from(videoSuggestionBoosts).where(eq(videoSuggestionBoosts.viewerId, viewerId))
+        : Promise.resolve([]),
+    ]);
+  } catch (error) {
+    if (isMissingVideoSuggestionSchemaError(error)) {
+      return listDemoVideoSuggestions(viewerId);
+    }
+    throw error;
+  }
+
+  const serializedSuggestions = suggestionRows.map(serializeVideoSuggestion);
+  const viewerIds = [...new Set(serializedSuggestions.map((entry) => entry.viewerId))];
+  const suggestionViewers = viewerIds.length
+    ? await db.select().from(users).where(inArray(users.id, viewerIds))
+    : [];
+  const viewerMap = new Map(suggestionViewers.map((row) => [row.id, serializeViewer(row)]));
+  const serializedBoosts = boostRows.map(serializeVideoSuggestionBoost);
+
+  return serializedSuggestions.map((suggestion) =>
+    buildVideoSuggestionWithMeta({
+      suggestion,
+      viewer: viewerMap.get(suggestion.viewerId) ?? null,
+      boosts: serializedBoosts.filter((entry) => entry.suggestionId === suggestion.id),
+    }),
+  );
+}
+
+export async function listAdminVideoSuggestions() {
+  return listVideoSuggestions();
+}
+
 export async function listStreamerbotCounters() {
   const db = getDb();
 
@@ -4044,6 +4388,7 @@ export async function createGameSuggestion(input: {
 
   const source = input.source ?? "web";
   const suggestionId = randomUUID();
+  const creationCost = (await getPipetzPricing()).gameSuggestionCost;
   const db = getDb();
   if (isDemoMode || !db) {
     const store = getDemoStore();
@@ -4057,13 +4402,13 @@ export async function createGameSuggestion(input: {
     }
 
     const balance = getBalance(store, input.viewerId);
-    if (balance.currentBalance < GAME_SUGGESTION_CREATION_COST) {
+    if (balance.currentBalance < creationCost) {
       throw new Error("saldo_insuficiente");
     }
 
     const createdAt = new Date().toISOString();
-    balance.currentBalance -= GAME_SUGGESTION_CREATION_COST;
-    balance.lifetimeSpent += GAME_SUGGESTION_CREATION_COST;
+    balance.currentBalance -= creationCost;
+    balance.lifetimeSpent += creationCost;
     balance.lastSyncedAt = createdAt;
 
     const suggestion: GameSuggestionRecord = {
@@ -4089,10 +4434,10 @@ export async function createGameSuggestion(input: {
     createLedgerEntry(store, {
       viewerId: input.viewerId,
       kind: "game_suggestion_creation",
-      amount: -GAME_SUGGESTION_CREATION_COST,
+      amount: -creationCost,
       source,
       externalEventId: null,
-      metadata: { suggestionId, slug },
+      metadata: { suggestionId, slug, cost: creationCost },
       createdAt,
     });
 
@@ -4120,14 +4465,14 @@ export async function createGameSuggestion(input: {
     const [debited] = await tx
       .update(viewerBalances)
       .set({
-        currentBalance: sql`${viewerBalances.currentBalance} - ${GAME_SUGGESTION_CREATION_COST}`,
-        lifetimeSpent: sql`${viewerBalances.lifetimeSpent} + ${GAME_SUGGESTION_CREATION_COST}`,
+        currentBalance: sql`${viewerBalances.currentBalance} - ${creationCost}`,
+        lifetimeSpent: sql`${viewerBalances.lifetimeSpent} + ${creationCost}`,
         lastSyncedAt: createdAt,
       })
       .where(
         and(
           eq(viewerBalances.viewerId, input.viewerId),
-          gte(viewerBalances.currentBalance, GAME_SUGGESTION_CREATION_COST),
+          gte(viewerBalances.currentBalance, creationCost),
         ),
       )
       .returning({ viewerId: viewerBalances.viewerId });
@@ -4158,10 +4503,10 @@ export async function createGameSuggestion(input: {
       id: randomUUID(),
       viewerId: input.viewerId,
       kind: "game_suggestion_creation",
-      amount: -GAME_SUGGESTION_CREATION_COST,
+      amount: -creationCost,
       source,
       externalEventId: null,
-      metadata: { suggestionId, slug },
+      metadata: { suggestionId, slug, cost: creationCost },
       createdAt,
     });
   });
@@ -4409,6 +4754,320 @@ export async function updateGameSuggestionCatalog(input: {
   }
 
   const result = (await listAdminGameSuggestions()).find((entry) => entry.id === input.suggestionId);
+  if (!result) {
+    throw new Error("suggestion_not_found");
+  }
+  return result;
+}
+
+export async function createVideoSuggestion(input: {
+  viewerId: string;
+  youtubeVideoId: string;
+  title: string;
+  creatorName: string;
+  thumbnailUrl: string;
+  videoUrl: string;
+  reason?: string | null;
+  source?: string;
+}) {
+  const viewer = await withViewerById(input.viewerId);
+  if (!viewer) {
+    throw new Error("Viewer nao encontrado.");
+  }
+
+  const youtubeVideoId = input.youtubeVideoId.trim();
+  const title = input.title.trim();
+  const creatorName = input.creatorName.trim();
+  const thumbnailUrl = input.thumbnailUrl.trim();
+  const videoUrl = input.videoUrl.trim();
+  const reason = input.reason?.trim() || null;
+  if (!youtubeVideoId || !title || !creatorName || !thumbnailUrl || !videoUrl) {
+    throw new Error("invalid_youtube_video");
+  }
+
+  const source = input.source ?? "web";
+  const suggestionId = randomUUID();
+  const creationCost = (await getPipetzPricing()).videoSuggestionCost;
+  const db = getDb();
+  if (isDemoMode || !db) {
+    const store = getDemoStore();
+    const duplicate = store.videoSuggestions.find(
+      (entry) => entry.youtubeVideoId === youtubeVideoId && (entry.status === "open" || entry.status === "accepted"),
+    );
+    if (duplicate) {
+      throw new Error("suggestion_already_exists");
+    }
+
+    const balance = getBalance(store, input.viewerId);
+    if (balance.currentBalance < creationCost) {
+      throw new Error("saldo_insuficiente");
+    }
+
+    const createdAt = new Date().toISOString();
+    balance.currentBalance -= creationCost;
+    balance.lifetimeSpent += creationCost;
+    balance.lastSyncedAt = createdAt;
+
+    const suggestion: VideoSuggestionRecord = {
+      id: suggestionId,
+      viewerId: input.viewerId,
+      youtubeVideoId,
+      title,
+      creatorName,
+      thumbnailUrl,
+      videoUrl,
+      reason,
+      status: "open",
+      totalVotes: 0,
+      createdAt,
+      updatedAt: createdAt,
+    };
+    store.videoSuggestions.unshift(suggestion);
+
+    createLedgerEntry(store, {
+      viewerId: input.viewerId,
+      kind: "video_suggestion_creation",
+      amount: -creationCost,
+      source,
+      externalEventId: null,
+      metadata: { suggestionId, youtubeVideoId, cost: creationCost },
+      createdAt,
+    });
+
+    return buildVideoSuggestionWithMeta({ suggestion, viewer, boosts: [] });
+  }
+
+  const createdAt = new Date();
+  await db.transaction(async (tx) => {
+    const [existing] = await tx
+      .select()
+      .from(videoSuggestions)
+      .where(and(eq(videoSuggestions.youtubeVideoId, youtubeVideoId), inArray(videoSuggestions.status, ["open", "accepted"])))
+      .limit(1);
+    if (existing) {
+      throw new Error("suggestion_already_exists");
+    }
+
+    const [debited] = await tx
+      .update(viewerBalances)
+      .set({
+        currentBalance: sql`${viewerBalances.currentBalance} - ${creationCost}`,
+        lifetimeSpent: sql`${viewerBalances.lifetimeSpent} + ${creationCost}`,
+        lastSyncedAt: createdAt,
+      })
+      .where(
+        and(
+          eq(viewerBalances.viewerId, input.viewerId),
+          gte(viewerBalances.currentBalance, creationCost),
+        ),
+      )
+      .returning({ viewerId: viewerBalances.viewerId });
+    if (!debited) {
+      throw new Error("saldo_insuficiente");
+    }
+
+    await tx.insert(videoSuggestions).values({
+      id: suggestionId,
+      viewerId: input.viewerId,
+      youtubeVideoId,
+      title,
+      creatorName,
+      thumbnailUrl,
+      videoUrl,
+      reason,
+      status: "open",
+      totalVotes: 0,
+      createdAt,
+      updatedAt: createdAt,
+    });
+
+    await tx.insert(pointLedger).values({
+      id: randomUUID(),
+      viewerId: input.viewerId,
+      kind: "video_suggestion_creation",
+      amount: -creationCost,
+      source,
+      externalEventId: null,
+      metadata: { suggestionId, youtubeVideoId, cost: creationCost },
+      createdAt,
+    });
+  });
+
+  const created = (await listVideoSuggestions(input.viewerId)).find((entry) => entry.id === suggestionId);
+  if (!created) {
+    throw new Error("Falha ao criar sugestao.");
+  }
+  return created;
+}
+
+export async function boostVideoSuggestion(input: {
+  suggestionId: string;
+  viewerId: string;
+  amount: number;
+  source: string;
+}) {
+  if (!Number.isInteger(input.amount) || input.amount <= 0) {
+    throw new Error("invalid_amount");
+  }
+
+  const viewer = await withViewerById(input.viewerId);
+  if (!viewer) {
+    throw new Error("Viewer nao encontrado.");
+  }
+
+  const db = getDb();
+  if (isDemoMode || !db) {
+    const store = getDemoStore();
+    const suggestion = store.videoSuggestions.find((entry) => entry.id === input.suggestionId);
+    if (!suggestion) {
+      throw new Error("suggestion_not_found");
+    }
+    if (suggestion.status !== "open") {
+      throw new Error("suggestion_not_open");
+    }
+
+    const balance = getBalance(store, input.viewerId);
+    if (balance.currentBalance < input.amount) {
+      throw new Error("saldo_insuficiente");
+    }
+
+    const now = new Date().toISOString();
+    balance.currentBalance -= input.amount;
+    balance.lifetimeSpent += input.amount;
+    balance.lastSyncedAt = now;
+
+    suggestion.totalVotes += input.amount;
+    suggestion.updatedAt = now;
+
+    const boost: VideoSuggestionBoostRecord = {
+      id: randomUUID(),
+      suggestionId: suggestion.id,
+      viewerId: input.viewerId,
+      amount: input.amount,
+      createdAt: now,
+    };
+    store.videoSuggestionBoosts.unshift(boost);
+
+    createLedgerEntry(store, {
+      viewerId: input.viewerId,
+      kind: "video_suggestion_boost",
+      amount: -input.amount,
+      source: input.source,
+      externalEventId: null,
+      metadata: { suggestionId: suggestion.id },
+      createdAt: now,
+    });
+
+    return buildVideoSuggestionWithMeta({
+      suggestion,
+      viewer: getDemoViewerById(store, suggestion.viewerId),
+      boosts: store.videoSuggestionBoosts.filter(
+        (entry) => entry.viewerId === input.viewerId && entry.suggestionId === suggestion.id,
+      ),
+    });
+  }
+
+  await db.transaction(async (tx) => {
+    const [suggestion] = await tx
+      .select()
+      .from(videoSuggestions)
+      .where(eq(videoSuggestions.id, input.suggestionId))
+      .limit(1);
+    if (!suggestion) {
+      throw new Error("suggestion_not_found");
+    }
+    if (suggestion.status !== "open") {
+      throw new Error("suggestion_not_open");
+    }
+
+    const now = new Date();
+    const [debited] = await tx
+      .update(viewerBalances)
+      .set({
+        currentBalance: sql`${viewerBalances.currentBalance} - ${input.amount}`,
+        lifetimeSpent: sql`${viewerBalances.lifetimeSpent} + ${input.amount}`,
+        lastSyncedAt: now,
+      })
+      .where(
+        and(
+          eq(viewerBalances.viewerId, input.viewerId),
+          gte(viewerBalances.currentBalance, input.amount),
+        ),
+      )
+      .returning({ viewerId: viewerBalances.viewerId });
+    if (!debited) {
+      throw new Error("saldo_insuficiente");
+    }
+
+    await tx.insert(videoSuggestionBoosts).values({
+      id: randomUUID(),
+      suggestionId: input.suggestionId,
+      viewerId: input.viewerId,
+      amount: input.amount,
+      createdAt: now,
+    });
+
+    await tx
+      .update(videoSuggestions)
+      .set({
+        totalVotes: sql`${videoSuggestions.totalVotes} + ${input.amount}`,
+        updatedAt: now,
+      })
+      .where(eq(videoSuggestions.id, input.suggestionId));
+
+    await tx.insert(pointLedger).values({
+      id: randomUUID(),
+      viewerId: input.viewerId,
+      kind: "video_suggestion_boost",
+      amount: -input.amount,
+      source: input.source,
+      externalEventId: null,
+      metadata: { suggestionId: input.suggestionId },
+      createdAt: now,
+    });
+  });
+
+  const updated = (await listVideoSuggestions(input.viewerId)).find((entry) => entry.id === input.suggestionId);
+  if (!updated) {
+    throw new Error("suggestion_not_found");
+  }
+  return updated;
+}
+
+export async function updateVideoSuggestionStatus(input: {
+  suggestionId: string;
+  status: VideoSuggestionRecord["status"];
+}) {
+  const db = getDb();
+
+  if (isDemoMode || !db) {
+    const store = getDemoStore();
+    const suggestion = store.videoSuggestions.find((entry) => entry.id === input.suggestionId);
+    if (!suggestion) {
+      throw new Error("suggestion_not_found");
+    }
+    suggestion.status = input.status;
+    suggestion.updatedAt = new Date().toISOString();
+    return buildVideoSuggestionWithMeta({
+      suggestion,
+      viewer: getDemoViewerById(store, suggestion.viewerId),
+    });
+  }
+
+  const updatedAt = new Date();
+  const [updated] = await db
+    .update(videoSuggestions)
+    .set({
+      status: input.status,
+      updatedAt,
+    })
+    .where(eq(videoSuggestions.id, input.suggestionId))
+    .returning();
+  if (!updated) {
+    throw new Error("suggestion_not_found");
+  }
+
+  const result = (await listAdminVideoSuggestions()).find((entry) => entry.id === input.suggestionId);
   if (!result) {
     throw new Error("suggestion_not_found");
   }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -225,6 +225,35 @@ export const gameSuggestionBoosts = pgTable("game_suggestion_boosts", {
   createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
 });
 
+export const videoSuggestions = pgTable("video_suggestions", {
+  id: varchar("id", { length: 64 }).primaryKey(),
+  viewerId: varchar("viewer_id", { length: 64 })
+    .references(() => users.id)
+    .notNull(),
+  youtubeVideoId: varchar("youtube_video_id", { length: 32 }).notNull(),
+  title: varchar("title", { length: 255 }).notNull(),
+  creatorName: varchar("creator_name", { length: 255 }).notNull(),
+  thumbnailUrl: text("thumbnail_url").notNull(),
+  videoUrl: text("video_url").notNull(),
+  reason: text("reason"),
+  status: varchar("status", { length: 32 }).notNull(),
+  totalVotes: integer("total_votes").default(0).notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+export const videoSuggestionBoosts = pgTable("video_suggestion_boosts", {
+  id: varchar("id", { length: 64 }).primaryKey(),
+  suggestionId: varchar("suggestion_id", { length: 64 })
+    .references(() => videoSuggestions.id)
+    .notNull(),
+  viewerId: varchar("viewer_id", { length: 64 })
+    .references(() => users.id)
+    .notNull(),
+  amount: integer("amount").notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
 export const productRecommendations = pgTable(
   "product_recommendations",
   {

--- a/src/lib/demo-data.ts
+++ b/src/lib/demo-data.ts
@@ -13,6 +13,8 @@ import {
   QuoteRecord,
   ProductRecommendationRecord,
   RedemptionRecord,
+  VideoSuggestionBoostRecord,
+  VideoSuggestionRecord,
   ViewerBalanceRecord,
   ViewerRecord,
 } from "@/lib/types";
@@ -472,3 +474,36 @@ export const demoGameSuggestions: GameSuggestionRecord[] = [
 ];
 
 export const demoGameSuggestionBoosts: GameSuggestionBoostRecord[] = [];
+
+export const demoVideoSuggestions: VideoSuggestionRecord[] = [
+  {
+    id: "vs-1",
+    viewerId: "viewer_ana",
+    youtubeVideoId: "dQw4w9WgXcQ",
+    title: "Rick Astley - Never Gonna Give You Up (Official Video) (4K Remaster)",
+    creatorName: "Rick Astley",
+    thumbnailUrl: "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
+    videoUrl: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    reason: "Classico absoluto pra reagir com o chat.",
+    totalVotes: 900,
+    status: "open",
+    createdAt: new Date(now.getTime() - 1000 * 60 * 60 * 30).toISOString(),
+    updatedAt: new Date(now.getTime() - 1000 * 60 * 35).toISOString(),
+  },
+  {
+    id: "vs-2",
+    viewerId: "viewer_caio",
+    youtubeVideoId: "M7lc1UVf-VE",
+    title: "YouTube Developers Live: Embedded Web Player Customization",
+    creatorName: "Google for Developers",
+    thumbnailUrl: "https://i.ytimg.com/vi/M7lc1UVf-VE/hqdefault.jpg",
+    videoUrl: "https://www.youtube.com/watch?v=M7lc1UVf-VE",
+    reason: "Quero ver voce comentando o caos tecnico disso.",
+    totalVotes: 520,
+    status: "accepted",
+    createdAt: new Date(now.getTime() - 1000 * 60 * 60 * 18).toISOString(),
+    updatedAt: new Date(now.getTime() - 1000 * 60 * 60 * 3).toISOString(),
+  },
+];
+
+export const demoVideoSuggestionBoosts: VideoSuggestionBoostRecord[] = [];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -16,6 +16,8 @@ export type LedgerKind =
   | "bet_refund"
   | "game_suggestion_creation"
   | "game_suggestion_boost"
+  | "video_suggestion_creation"
+  | "video_suggestion_boost"
   | "quote_overlay_debit";
 
 export type BetStatus =
@@ -41,6 +43,12 @@ export type GameSuggestionStatus =
   | "open"
   | "accepted"
   | "played"
+  | "rejected";
+
+export type VideoSuggestionStatus =
+  | "open"
+  | "accepted"
+  | "reacted"
   | "rejected";
 
 export type ProductRecommendationCategory =
@@ -277,6 +285,14 @@ export interface ObsOverlayAdminStatusRecord {
   failedCount: number;
 }
 
+export interface PipetzPricingRecord {
+  gameSuggestionCost: number;
+  videoSuggestionCost: number;
+  quoteOverlayCost: number;
+  updatedAt: string | null;
+  updatedBy: string | null;
+}
+
 export interface StreamerbotCounterRecord {
   key: string;
   scopeType: string;
@@ -397,6 +413,35 @@ export interface GameSuggestionBoostRecord {
 }
 
 export interface GameSuggestionWithMeta extends GameSuggestionRecord {
+  suggestedBy: string;
+  suggestedByYoutubeHandle: string | null;
+  viewerBoostTotal: number;
+}
+
+export interface VideoSuggestionRecord {
+  id: string;
+  viewerId: string;
+  youtubeVideoId: string;
+  title: string;
+  creatorName: string;
+  thumbnailUrl: string;
+  videoUrl: string;
+  reason: string | null;
+  status: VideoSuggestionStatus;
+  totalVotes: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface VideoSuggestionBoostRecord {
+  id: string;
+  suggestionId: string;
+  viewerId: string;
+  amount: number;
+  createdAt: string;
+}
+
+export interface VideoSuggestionWithMeta extends VideoSuggestionRecord {
   suggestedBy: string;
   suggestedByYoutubeHandle: string | null;
   viewerBoostTotal: number;

--- a/src/lib/video-suggestions/constants.ts
+++ b/src/lib/video-suggestions/constants.ts
@@ -1,0 +1,1 @@
+export const VIDEO_SUGGESTION_CREATION_COST = 200;

--- a/src/lib/video-suggestions/service.ts
+++ b/src/lib/video-suggestions/service.ts
@@ -1,0 +1,141 @@
+import { z } from "zod";
+
+export const videoSuggestionStatusSchema = z.enum(["open", "accepted", "reacted", "rejected"]);
+
+export const createVideoSuggestionSchema = z.object({
+  videoUrl: z.string().trim().min(1, "Cole o link do YouTube.").max(500, "Link muito longo."),
+  reason: z
+    .string()
+    .trim()
+    .max(500, "Use no maximo 500 caracteres.")
+    .optional()
+    .transform((value) => (value ? value : undefined)),
+});
+
+export const boostVideoSuggestionSchema = z.object({
+  amount: z.number().int().positive("Digite um valor inteiro positivo."),
+});
+
+export const updateVideoSuggestionStatusSchema = z.object({
+  status: videoSuggestionStatusSchema,
+});
+
+export type YoutubeVideoMetadata = {
+  videoId: string;
+  title: string;
+  creatorName: string;
+  thumbnailUrl: string;
+  videoUrl: string;
+};
+
+type YoutubeOembedResponse = {
+  title?: unknown;
+  author_name?: unknown;
+  thumbnail_url?: unknown;
+};
+
+export function extractYoutubeVideoId(rawUrl: string) {
+  let url: URL;
+  try {
+    url = new URL(rawUrl.trim());
+  } catch {
+    return null;
+  }
+
+  const host = url.hostname.toLowerCase().replace(/^www\./, "");
+  if (host === "youtu.be") {
+    return normalizeVideoId(url.pathname.split("/").filter(Boolean)[0] ?? "");
+  }
+
+  if (host === "youtube.com" || host === "m.youtube.com" || host === "music.youtube.com") {
+    if (url.pathname === "/watch") {
+      return normalizeVideoId(url.searchParams.get("v") ?? "");
+    }
+
+    const parts = url.pathname.split("/").filter(Boolean);
+    if (["shorts", "live", "embed", "v"].includes(parts[0] ?? "")) {
+      return normalizeVideoId(parts[1] ?? "");
+    }
+  }
+
+  return null;
+}
+
+export function buildYoutubeWatchUrl(videoId: string) {
+  return `https://www.youtube.com/watch?v=${videoId}`;
+}
+
+export function validateVideoSuggestionDraft(input: {
+  videoUrl: string;
+  reason?: string | null;
+}) {
+  const parsed = createVideoSuggestionSchema.safeParse({
+    videoUrl: input.videoUrl,
+    reason: input.reason ?? undefined,
+  });
+
+  if (!parsed.success) {
+    return parsed.error.issues[0]?.message ?? "Sugestao invalida.";
+  }
+
+  if (!extractYoutubeVideoId(parsed.data.videoUrl)) {
+    return "Cole um link valido de video do YouTube.";
+  }
+
+  return null;
+}
+
+export function validateVideoSuggestionBoostAmount(amount: number) {
+  const parsed = boostVideoSuggestionSchema.safeParse({ amount });
+  if (!parsed.success) {
+    return parsed.error.issues[0]?.message ?? "Valor invalido.";
+  }
+  return null;
+}
+
+export async function resolveYoutubeVideoMetadata(rawUrl: string): Promise<YoutubeVideoMetadata> {
+  const videoId = extractYoutubeVideoId(rawUrl);
+  if (!videoId) {
+    throw new Error("invalid_youtube_url");
+  }
+
+  const videoUrl = buildYoutubeWatchUrl(videoId);
+  const response = await fetch(
+    `https://www.youtube.com/oembed?format=json&url=${encodeURIComponent(videoUrl)}`,
+    {
+      headers: {
+        accept: "application/json",
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error("youtube_video_not_found");
+  }
+
+  const payload = (await response.json()) as YoutubeOembedResponse;
+  const title = typeof payload.title === "string" ? payload.title.trim() : "";
+  const creatorName = typeof payload.author_name === "string" ? payload.author_name.trim() : "";
+  const thumbnailUrl = typeof payload.thumbnail_url === "string" ? payload.thumbnail_url.trim() : "";
+
+  if (!title || !creatorName || !thumbnailUrl) {
+    throw new Error("youtube_video_not_found");
+  }
+
+  return {
+    videoId,
+    title,
+    creatorName,
+    thumbnailUrl,
+    videoUrl,
+  };
+}
+
+export function formatVideoSuggestionSchemaError(error: z.ZodError) {
+  return error.issues[0]?.message ?? "Payload invalido.";
+}
+
+function normalizeVideoId(value: string) {
+  const trimmed = value.trim();
+  return /^[a-zA-Z0-9_-]{11}$/.test(trimmed) ? trimmed : null;
+}

--- a/streamerbot/death-counter-from-chat.cs
+++ b/streamerbot/death-counter-from-chat.cs
@@ -16,6 +16,9 @@ public class CPHInline
         "display",
         "displayName",
         "authorName",
+        "userName",
+        "username",
+        "userLogin",
         "targetUser",
         "user",
     };
@@ -24,6 +27,18 @@ public class CPHInline
     {
         "counterAction",
         "action",
+    };
+
+    private static readonly string[] CommandNameArgCandidates = new[]
+    {
+        "command",
+        "commandName",
+    };
+
+    private static readonly string[] CommandPatternArgCandidates = new[]
+    {
+        "command",
+        "commandName",
     };
 
     private static readonly string[] AmountArgCandidates = new[]
@@ -62,9 +77,21 @@ public class CPHInline
         string appBaseUrl = ReadRequiredGlobal("lojaneon.appBaseUrl");
         string sharedSecret = ReadRequiredGlobal("lojaneon.streamerbotSharedSecret");
         bool useBotAccount = ReadOptionalBoolGlobal("lojaneon.useBotAccount", true);
+        bool debugLogging = ReadOptionalBoolGlobal("lojaneon.debugDeathCounter", true);
 
         if (string.IsNullOrWhiteSpace(appBaseUrl) || string.IsNullOrWhiteSpace(sharedSecret))
         {
+            return false;
+        }
+
+        string endpointUrl = BuildEndpointUrl(appBaseUrl);
+        if (string.IsNullOrWhiteSpace(endpointUrl))
+        {
+            CPH.LogError(string.Format(
+                "[Loja Neon] appBaseUrl invalida para contador de mortes: {0}",
+                appBaseUrl ?? "<null>"
+            ));
+            Reply("Nao consegui atualizar o contador agora.", useBotAccount);
             return false;
         }
 
@@ -72,7 +99,11 @@ public class CPHInline
         string action = ResolveAction(rawCommand);
         if (string.IsNullOrWhiteSpace(action))
         {
-            Reply("Comando invalido. Use !morte+, !morte- ou !mortes.", useBotAccount);
+            CPH.LogWarn(string.Format(
+                "[Loja Neon] Nao foi possivel resolver a action do contador. {0}",
+                BuildDiagnosticsSummary(rawCommand, string.Empty, 0, string.Empty, string.Empty)
+            ));
+            Reply("Comando invalido. Use !death+, !death- ou !deaths.", useBotAccount);
             return false;
         }
 
@@ -84,15 +115,26 @@ public class CPHInline
         string timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString();
         string signature = BuildSignature(body, timestamp, sharedSecret);
 
+        if (debugLogging)
+        {
+            CPH.LogInfo(string.Format(
+                "[Loja Neon] Preparando envio do contador de mortes. endpoint={0}; {1}; body={2}",
+                endpointUrl,
+                BuildDiagnosticsSummary(rawCommand, action, amount, scopeKey, scopeLabel),
+                TruncateForLog(body, 600)
+            ));
+        }
+
         try
         {
             using (var request = new HttpRequestMessage(
                 HttpMethod.Post,
-                string.Format("{0}/api/internal/streamerbot/deaths", appBaseUrl.TrimEnd('/'))
+                endpointUrl
             ))
             {
                 request.Headers.TryAddWithoutValidation("x-timestamp", timestamp);
                 request.Headers.TryAddWithoutValidation("x-signature", signature);
+                request.Headers.TryAddWithoutValidation("x-source", "streamerbot");
                 request.Content = new StringContent(body, Encoding.UTF8, "application/json");
 
                 using (HttpResponseMessage response = Http.SendAsync(request).GetAwaiter().GetResult())
@@ -112,9 +154,20 @@ public class CPHInline
                     if (!response.IsSuccessStatusCode)
                     {
                         CPH.LogWarn(string.Format(
-                            "[Loja Neon] Falha ao chamar contador de mortes: HTTP {0} - {1}",
+                            "[Loja Neon] Falha ao chamar contador de mortes: HTTP {0}; endpoint={1}; {2}; response={3}",
                             (int)response.StatusCode,
-                            responseText
+                            endpointUrl,
+                            BuildDiagnosticsSummary(rawCommand, action, amount, scopeKey, scopeLabel),
+                            TruncateForLog(responseText, 600)
+                        ));
+                    }
+                    else if (debugLogging)
+                    {
+                        CPH.LogInfo(string.Format(
+                            "[Loja Neon] Contador de mortes processado com sucesso: HTTP {0}; endpoint={1}; response={2}",
+                            (int)response.StatusCode,
+                            endpointUrl,
+                            TruncateForLog(responseText, 600)
                         ));
                     }
 
@@ -124,7 +177,12 @@ public class CPHInline
         }
         catch (Exception ex)
         {
-            CPH.LogError(string.Format("[Loja Neon] Erro ao chamar API de contadores: {0}", ex));
+            CPH.LogError(string.Format(
+                "[Loja Neon] Erro ao chamar API de contadores. endpoint={0}; {1}; exception={2}",
+                endpointUrl,
+                BuildDiagnosticsSummary(rawCommand, action, amount, scopeKey, scopeLabel),
+                ex
+            ));
             Reply("Nao consegui atualizar o contador agora.", useBotAccount);
             return false;
         }
@@ -143,7 +201,37 @@ public class CPHInline
             return explicitAction;
         }
 
-        string commandName = GetCommandName(rawCommand);
+        string commandName = GetFirstArgString(CommandNameArgCandidates);
+        if (!string.IsNullOrWhiteSpace(commandName))
+        {
+            string actionFromCommandArg = ResolveActionFromCommandName(commandName);
+            if (!string.IsNullOrWhiteSpace(actionFromCommandArg))
+            {
+                return actionFromCommandArg;
+            }
+        }
+
+        string commandPattern = GetFirstArgString(CommandPatternArgCandidates);
+        if (!string.IsNullOrWhiteSpace(commandPattern))
+        {
+            string actionFromPattern = ResolveActionFromPattern(commandPattern);
+            if (!string.IsNullOrWhiteSpace(actionFromPattern))
+            {
+                return actionFromPattern;
+            }
+        }
+
+        commandName = GetCommandName(rawCommand);
+        return ResolveActionFromCommandName(commandName);
+    }
+
+    private string ResolveActionFromCommandName(string commandName)
+    {
+        if (string.IsNullOrWhiteSpace(commandName))
+        {
+            return string.Empty;
+        }
+
         switch (commandName)
         {
             case "!morte+":
@@ -158,6 +246,32 @@ public class CPHInline
             default:
                 return string.Empty;
         }
+    }
+
+    private string ResolveActionFromPattern(string commandPattern)
+    {
+        if (string.IsNullOrWhiteSpace(commandPattern))
+        {
+            return string.Empty;
+        }
+
+        string normalized = commandPattern.Trim().ToLowerInvariant();
+        if (ContainsCommandToken(normalized, "!death+") || ContainsCommandToken(normalized, "!morte+"))
+        {
+            return "increment";
+        }
+
+        if (ContainsCommandToken(normalized, "!death-") || ContainsCommandToken(normalized, "!morte-"))
+        {
+            return "decrement";
+        }
+
+        if (ContainsCommandToken(normalized, "!deaths") || ContainsCommandToken(normalized, "!mortes"))
+        {
+            return "get";
+        }
+
+        return string.Empty;
     }
 
     private int ResolveAmount(string rawCommand)
@@ -280,6 +394,48 @@ public class CPHInline
         return GetFirstArgString(CommandPayloadArgCandidates) ?? string.Empty;
     }
 
+    private string BuildEndpointUrl(string appBaseUrl)
+    {
+        if (string.IsNullOrWhiteSpace(appBaseUrl))
+        {
+            return string.Empty;
+        }
+
+        string trimmed = appBaseUrl.Trim();
+        if (!trimmed.StartsWith("http://", StringComparison.OrdinalIgnoreCase) &&
+            !trimmed.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        {
+            return string.Empty;
+        }
+
+        return string.Format("{0}/api/internal/streamerbot/deaths", trimmed.TrimEnd('/'));
+    }
+
+    private string BuildDiagnosticsSummary(
+        string rawCommand,
+        string action,
+        int amount,
+        string scopeKey,
+        string scopeLabel
+    )
+    {
+        return string.Format(
+            "isTest={0}; trigger={1}; source={2}; command={3}; rawInput={4}; input0={5}; amountArg={6}; resolvedAction={7}; resolvedAmount={8}; requestedBy={9}; scopeKey={10}; scopeLabel={11}",
+            GetArgString("isTest") ?? "<null>",
+            GetArgString("triggerName") ?? "<null>",
+            GetArgString("commandSource") ?? GetArgString("source") ?? "<null>",
+            TruncateForLog(GetFirstArgString(CommandNameArgCandidates) ?? string.Empty, 120),
+            TruncateForLog(rawCommand ?? string.Empty, 120),
+            TruncateForLog(GetArgString("input0") ?? string.Empty, 120),
+            GetArgString("amount") ?? "<null>",
+            string.IsNullOrWhiteSpace(action) ? "<null>" : action,
+            amount,
+            TruncateForLog(GetFirstArgString(RequestedByArgCandidates) ?? string.Empty, 120),
+            string.IsNullOrWhiteSpace(scopeKey) ? "<global>" : scopeKey,
+            string.IsNullOrWhiteSpace(scopeLabel) ? "<null>" : TruncateForLog(scopeLabel, 120)
+        );
+    }
+
     private string GetCommandName(string rawCommand)
     {
         if (string.IsNullOrWhiteSpace(rawCommand))
@@ -337,6 +493,16 @@ public class CPHInline
         }
 
         return value.Trim().ToLowerInvariant().Replace(" ", "_");
+    }
+
+    private bool ContainsCommandToken(string haystack, string token)
+    {
+        if (string.IsNullOrWhiteSpace(haystack) || string.IsNullOrWhiteSpace(token))
+        {
+            return false;
+        }
+
+        return haystack.Contains(token) || haystack.Contains(token.Replace("+", "\\+"));
     }
 
     private string GetArgString(string argName)
@@ -524,5 +690,20 @@ public class CPHInline
             .Replace("\\r", "\r")
             .Replace("\\n", "\n")
             .Replace("\\t", "\t");
+    }
+
+    private string TruncateForLog(string value, int maxLength)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        if (value.Length <= maxLength)
+        {
+            return value;
+        }
+
+        return value.Substring(0, maxLength) + "...";
     }
 }

--- a/streamerbot/list-commands-from-chat.cs
+++ b/streamerbot/list-commands-from-chat.cs
@@ -1,0 +1,172 @@
+using System;
+
+public class CPHInline
+{
+    private static readonly string[] ModeratorArgCandidates = new[]
+    {
+        "isModerator",
+        "isMod",
+        "userIsModerator",
+    };
+
+    private static readonly string[] BroadcasterArgCandidates = new[]
+    {
+        "isBroadcaster",
+        "isStreamer",
+        "userIsBroadcaster",
+    };
+
+    private static readonly string[] AdminArgCandidates = new[]
+    {
+        "isAdmin",
+        "userIsAdmin",
+    };
+
+    private const string DefaultPublicLineOne =
+        "Comandos: !link CODIGO | !pontos / !saldo / !pipetz / !points | !quote [numero] | !quoteobs <numero>";
+
+    private const string DefaultPublicLineTwo =
+        "Mais: !bet <opcao> <valor> | !deaths";
+
+    private const string DefaultModeratorLine =
+        "Mods: !death+ [n] | !death- [n] | !addquote <texto>";
+
+    public bool Execute()
+    {
+        bool useBotAccount = ReadOptionalBoolGlobal("lojaneon.useBotAccount", false);
+        bool isModerator = GetFirstBoolArg(ModeratorArgCandidates, false);
+        bool isBroadcaster = GetFirstBoolArg(BroadcasterArgCandidates, false);
+        bool isAdmin = GetFirstBoolArg(AdminArgCandidates, false);
+        bool showModeratorCommands = isModerator || isBroadcaster || isAdmin;
+
+        string publicLineOne = ReadOptionalGlobal("lojaneon.commandsListPublic1");
+        string publicLineTwo = ReadOptionalGlobal("lojaneon.commandsListPublic2");
+        string moderatorLine = ReadOptionalGlobal("lojaneon.commandsListMod");
+
+        if (string.IsNullOrWhiteSpace(publicLineOne))
+        {
+            publicLineOne = DefaultPublicLineOne;
+        }
+
+        if (string.IsNullOrWhiteSpace(publicLineTwo))
+        {
+            publicLineTwo = DefaultPublicLineTwo;
+        }
+
+        if (string.IsNullOrWhiteSpace(moderatorLine))
+        {
+            moderatorLine = DefaultModeratorLine;
+        }
+
+        Reply(publicLineOne, useBotAccount);
+
+        if (!string.IsNullOrWhiteSpace(publicLineTwo))
+        {
+            Reply(publicLineTwo, useBotAccount);
+        }
+
+        if (showModeratorCommands && !string.IsNullOrWhiteSpace(moderatorLine))
+        {
+            Reply(moderatorLine, useBotAccount);
+        }
+
+        return true;
+    }
+
+    private void Reply(string message, bool useBot)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return;
+        }
+
+        CPH.SendYouTubeMessageToLatestMonitored(message.Trim(), useBot, true);
+    }
+
+    private string ReadOptionalGlobal(string variableName)
+    {
+        try
+        {
+            return CPH.GetGlobalVar<string>(variableName, true) ?? string.Empty;
+        }
+        catch
+        {
+            return string.Empty;
+        }
+    }
+
+    private bool ReadOptionalBoolGlobal(string variableName, bool defaultValue)
+    {
+        try
+        {
+            return CPH.GetGlobalVar<bool>(variableName, true);
+        }
+        catch
+        {
+            return defaultValue;
+        }
+    }
+
+    private bool GetFirstBoolArg(string[] argNames, bool defaultValue)
+    {
+        if (argNames == null)
+        {
+            return defaultValue;
+        }
+
+        foreach (string argName in argNames)
+        {
+            if (string.IsNullOrWhiteSpace(argName))
+            {
+                continue;
+            }
+
+            try
+            {
+                if (args != null && args.ContainsKey(argName) && args[argName] != null)
+                {
+                    object rawValue = args[argName];
+                    if (rawValue is bool directBool)
+                    {
+                        return directBool;
+                    }
+
+                    string rawText = rawValue.ToString();
+                    if (!string.IsNullOrWhiteSpace(rawText) && bool.TryParse(rawText.Trim(), out bool parsedBool))
+                    {
+                        return parsedBool;
+                    }
+                }
+            }
+            catch
+            {
+            }
+
+            try
+            {
+                if (CPH.TryGetArg(argName, out bool typedValue))
+                {
+                    return typedValue;
+                }
+            }
+            catch
+            {
+            }
+
+            try
+            {
+                if (CPH.TryGetArg(argName, out string stringValue) &&
+                    !string.IsNullOrWhiteSpace(stringValue) &&
+                    bool.TryParse(stringValue.Trim(), out bool parsedValue))
+                {
+                    return parsedValue;
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        return defaultValue;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds admin-configurable Pipetz pricing for game suggestions, video suggestions, and quote OBS overlays.
- Adds YouTube video suggestions with public submission, boosting, admin moderation, database schema, demo data, and tests.
- Updates Streamer.bot helper scripts and quote OBS messaging to use the configured Pipetz price.

## Validation

- `npx.cmd tsc --noEmit`
- `npm.cmd test`
- `npm.cmd run build` was attempted, but Next.js could not fetch Google Fonts from the sandboxed network.

No closing issue was provided for this PR.