### PR TITLE
[codex] Fix game suggestion IGDB fallback

### DIFF
--- a/src/app/api/games/search/route.ts
+++ b/src/app/api/games/search/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: Request) {
   }
 
   if (!isIgdbConfigured()) {
-    return ok([]);
+    return fail("igdb_unavailable", 503);
   }
 
   try {

--- a/src/components/game-suggest-form.tsx
+++ b/src/components/game-suggest-form.tsx
@@ -57,7 +57,7 @@ export function GameSuggestForm({
   const missingBalance = hasInsufficientBalance
     ? creationCost - (viewerBalance ?? 0)
     : 0;
-  const isSubmitDisabled = isPending || hasInsufficientBalance || !selectedGame;
+  const isSubmitDisabled = isPending || hasInsufficientBalance;
   const canShowSearchResults =
     searchResults.length > 0 && !selectedGame && name.trim().length >= 2;
 
@@ -148,11 +148,6 @@ export function GameSuggestForm({
 
     if (hasInsufficientBalance) {
       setFeedback(`Faltam ${formatPipetz(missingBalance)} para criar uma sugestão.`);
-      return;
-    }
-
-    if (!selectedGame) {
-      setFeedback("Escolha um jogo reconhecido pelo IGDB antes de enviar.");
       return;
     }
 
@@ -261,7 +256,7 @@ export function GameSuggestForm({
 
             {searchFailed ? (
               <p className="mt-2 text-xs font-bold uppercase tracking-[0.12em] text-[var(--color-ink-soft)]">
-                busca indisponível; tente novamente antes de enviar
+                busca indisponivel; voce ainda pode enviar pelo nome
               </p>
             ) : null}
 

--- a/src/lib/igdb.ts
+++ b/src/lib/igdb.ts
@@ -4,6 +4,7 @@ const TWITCH_TOKEN_URL = "https://id.twitch.tv/oauth2/token";
 const IGDB_GAMES_URL = "https://api.igdb.com/v4/games";
 const IGDB_SEARCH_URL = "https://api.igdb.com/v4/search";
 const MAX_QUERY_LENGTH = 80;
+const IGDB_REQUEST_TIMEOUT_MS = 6_000;
 
 type TwitchTokenResponse = {
   access_token: string;
@@ -135,7 +136,10 @@ async function getIgdbAccessToken() {
   url.searchParams.set("client_secret", env.IGDB_CLIENT_SECRET);
   url.searchParams.set("grant_type", "client_credentials");
 
-  const response = await fetch(url, { method: "POST" });
+  const response = await fetch(url, {
+    method: "POST",
+    signal: AbortSignal.timeout(IGDB_REQUEST_TIMEOUT_MS),
+  });
   if (!response.ok) {
     throw new Error("igdb_auth_failed");
   }
@@ -167,6 +171,7 @@ async function igdbRequest<TResponse>(url: string, body: string) {
       "Client-ID": env.IGDB_CLIENT_ID,
     },
     body,
+    signal: AbortSignal.timeout(IGDB_REQUEST_TIMEOUT_MS),
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## Summary

Fixes the game suggestion form getting stuck when IGDB search does not return a selectable result.

## What changed

- Allow game suggestions to be submitted by typed name even when no IGDB result was selected.
- Add a short timeout to Twitch/IGDB fetches so search failures stop hanging the form.
- Return an explicit IGDB unavailable error when credentials are missing instead of silently returning an empty list.

## Validation

- `npm.cmd test -- src/lib/db/repository.test.ts`
- `npm.cmd run build`
- `npm.cmd run lint` still fails on existing `src/lib/streamerbot/death-counter-game.test.ts` `module` assignment lint errors unrelated to this change.

Fixes #72