### PR TITLE
[codex] Add admin pipetz airdrop

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -4,6 +4,7 @@ import { DeathCounterGamePanel } from "@/components/death-counter-game-panel";
 import { AdminGameSuggestionsPanel } from "@/components/admin-game-suggestions-panel";
 import { AdminVideoSuggestionsPanel } from "@/components/admin-video-suggestions-panel";
 import { AdminPipetzPricingPanel } from "@/components/admin-pipetz-pricing-panel";
+import { AdminPipetzAirdropPanel } from "@/components/admin-pipetz-airdrop-panel";
 import { AdminRecommendationsPanel } from "@/components/admin-recommendations-panel";
 import { AdminViewerLinksPanel } from "@/components/admin-viewer-links-panel";
 import { RedemptionGrid } from "@/components/redemption-grid";
@@ -119,6 +120,7 @@ export default async function AdminPage() {
               <LeaderboardTable entries={leaderboard.slice(0, 10)} />
             </div>
           </div>
+          <AdminPipetzAirdropPanel viewers={viewers} />
           <RedemptionGrid items={catalog} expanded staticCards />
         </div>
       </section>

--- a/src/app/api/admin/viewers/[id]/airdrop/route.ts
+++ b/src/app/api/admin/viewers/[id]/airdrop/route.ts
@@ -1,0 +1,45 @@
+import { ZodError } from "zod";
+
+import { fail, isTrustedAppMutationRequest, ok, requireAdminApiSession } from "@/lib/api";
+import { adjustViewerBalance } from "@/lib/db/repository";
+import { adminAirdropSchema } from "@/lib/streamerbot/schemas";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!isTrustedAppMutationRequest(request)) {
+    return fail("Forbidden", 403);
+  }
+
+  const session = await requireAdminApiSession();
+  if (!session) {
+    return fail("Forbidden", 403);
+  }
+
+  try {
+    const { id } = await params;
+    const payload = adminAirdropSchema.parse(await request.json());
+    const viewerIds = [...new Set(payload.viewerIds?.length ? payload.viewerIds : [id])];
+
+    for (const viewerId of viewerIds) {
+      await adjustViewerBalance({
+        viewerId,
+        amount: payload.amount,
+        reason: payload.reason,
+        kind: "admin_airdrop",
+        source: "admin_airdrop",
+      });
+    }
+
+    return ok({ viewerIds, amount: payload.amount });
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return fail("Dados inválidos para o airdrop.", 400);
+    }
+    if (error instanceof Error && error.message === "viewer_not_found") {
+      return fail("Usuário não encontrado.", 404);
+    }
+    throw error;
+  }
+}

--- a/src/components/admin-pipetz-airdrop-panel.tsx
+++ b/src/components/admin-pipetz-airdrop-panel.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import type { AdminViewerDirectoryRecord } from "@/lib/types";
+import { formatPipetz } from "@/lib/utils";
+
+function buildViewerLabel(entry: AdminViewerDirectoryRecord) {
+  return [entry.youtubeDisplayName, entry.youtubeHandle, entry.youtubeChannelId]
+    .filter(Boolean)
+    .join(" . ");
+}
+
+export function AdminPipetzAirdropPanel({
+  viewers,
+}: {
+  viewers: AdminViewerDirectoryRecord[];
+}) {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+  const [viewerIds, setViewerIds] = useState<string[]>([]);
+  const [amount, setAmount] = useState("100");
+  const [reason, setReason] = useState("");
+  const [confirmationText, setConfirmationText] = useState("");
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const eligibleViewers = useMemo(
+    () => viewers.filter((entry) => !entry.isSyntheticYoutubeChannel),
+    [viewers],
+  );
+  const selectedViewers = eligibleViewers.filter((entry) => viewerIds.includes(entry.id));
+  const parsedAmount = Number.parseInt(amount, 10);
+  const canSubmit =
+    selectedViewers.length > 0 &&
+    Number.isInteger(parsedAmount) &&
+    parsedAmount > 0 &&
+    reason.trim().length >= 3 &&
+    confirmationText.trim().toUpperCase() === "AIRDROP";
+
+  const matchingViewers = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    if (!normalizedQuery) {
+      return eligibleViewers;
+    }
+
+    return eligibleViewers.filter((entry) =>
+      [
+        entry.youtubeDisplayName,
+        entry.youtubeHandle,
+        entry.youtubeChannelId,
+        entry.email,
+        entry.googleAccountEmail,
+      ]
+        .filter(Boolean)
+        .some((value) => value!.toLowerCase().includes(normalizedQuery)),
+    );
+  }, [eligibleViewers, query]);
+  const visibleViewers = matchingViewers.slice(0, 10);
+
+  function toggleViewer(viewerId: string) {
+    setViewerIds((current) =>
+      current.includes(viewerId)
+        ? current.filter((entry) => entry !== viewerId)
+        : [...current, viewerId],
+    );
+  }
+
+  function toggleFilteredViewers() {
+    const matchingIds = matchingViewers.map((entry) => entry.id);
+    const hasSelectedAllMatching = matchingIds.every((id) => viewerIds.includes(id));
+
+    setViewerIds((current) => {
+      if (hasSelectedAllMatching) {
+        return current.filter((id) => !matchingIds.includes(id));
+      }
+
+      return [...new Set([...current, ...matchingIds])];
+    });
+  }
+
+  function submitAirdrop() {
+    if (selectedViewers.length === 0 || !canSubmit) {
+      setFeedback('Escolha pelo menos um usuário, informe valor e motivo, e confirme com "AIRDROP".');
+      return;
+    }
+
+    setFeedback(null);
+    startTransition(async () => {
+      try {
+        const response = await fetch(`/api/admin/viewers/${selectedViewers[0]!.id}/airdrop`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            viewerIds,
+            amount: parsedAmount,
+            reason: reason.trim(),
+            confirmationText: confirmationText.trim(),
+          }),
+        });
+        const payload = (await response.json()) as { ok?: boolean; error?: string };
+        if (!response.ok || !payload.ok) {
+          setFeedback(payload.error ?? "Falha ao fazer airdrop.");
+          return;
+        }
+
+        setFeedback(
+          `Airdrop de ${formatPipetz(parsedAmount)} pipetz enviado para ${selectedViewers.length} usuário${selectedViewers.length === 1 ? "" : "s"}.`,
+        );
+        setViewerIds([]);
+        setAmount("100");
+        setReason("");
+        setConfirmationText("");
+        router.refresh();
+      } catch (error) {
+        setFeedback(error instanceof Error ? error.message : "Falha ao fazer airdrop.");
+      }
+    });
+  }
+
+  return (
+    <section className="panel surface-section p-6">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
+            Airdrop
+          </p>
+          <h2 className="mt-2 text-3xl uppercase" style={{ fontFamily: "var(--font-display)" }}>
+            Dar pipetz
+          </h2>
+        </div>
+        {feedback ? <div className="retro-label neutral-chip max-w-sm">{feedback}</div> : null}
+      </div>
+
+      <div className="mt-6 grid gap-4">
+        <label className="grid gap-2">
+          <span className="text-sm font-black uppercase tracking-[0.14em] text-[var(--color-ink)]">
+            Buscar viewer
+          </span>
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Nome, @handle ou ID do canal"
+          />
+        </label>
+
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <Button
+            type="button"
+            onClick={toggleFilteredViewers}
+            disabled={matchingViewers.length === 0}
+            variant="neutral"
+            size="sm"
+          >
+            {matchingViewers.length > 0 &&
+            matchingViewers.every((entry) => viewerIds.includes(entry.id))
+              ? "Limpar selecionados"
+              : "Selecionar todos"}
+          </Button>
+          <span className="text-xs font-bold text-[var(--color-ink-soft)]">
+            {selectedViewers.length} selecionado{selectedViewers.length === 1 ? "" : "s"} de {matchingViewers.length}
+          </span>
+        </div>
+
+        <div className="grid max-h-64 gap-2 overflow-auto pr-1">
+          {visibleViewers.map((entry) => {
+            const isSelected = viewerIds.includes(entry.id);
+            return (
+              <button
+                key={entry.id}
+                type="button"
+                onClick={() => toggleViewer(entry.id)}
+                className="card-flat grid gap-1 bg-[var(--color-paper)] p-3 text-left text-sm transition hover:-translate-y-0.5"
+                style={{
+                  outline: isSelected ? "3px solid var(--color-purple-mid)" : undefined,
+                }}
+              >
+                <span className="font-black uppercase text-[var(--color-ink)]">
+                  {isSelected ? "[x] " : ""}
+                  {entry.youtubeDisplayName}
+                </span>
+                <span className="truncate text-xs font-bold text-[var(--color-ink-soft)]">
+                  {buildViewerLabel(entry)}
+                </span>
+                <span className="text-xs font-bold text-[var(--color-ink-soft)]">
+                  Saldo atual: {entry.currentBalance !== null ? formatPipetz(entry.currentBalance) : "--"} pipetz
+                </span>
+              </button>
+            );
+          })}
+          {matchingViewers.length > visibleViewers.length ? (
+            <p className="text-xs font-bold text-[var(--color-ink-soft)]">
+              Mostrando 10 de {matchingViewers.length} viewers encontrados. Selecionar todos inclui todos os {matchingViewers.length}.
+            </p>
+          ) : null}
+          {visibleViewers.length === 0 ? (
+            <p className="card-flat bg-[var(--color-paper)] p-3 text-sm font-bold text-[var(--color-ink-soft)]">
+              Nenhum viewer encontrado.
+            </p>
+          ) : null}
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-[160px_1fr]">
+          <label className="grid gap-2">
+            <span className="text-sm font-black uppercase tracking-[0.14em] text-[var(--color-ink)]">
+              Pipetz
+            </span>
+            <Input
+              type="number"
+              min={1}
+              step={1}
+              value={amount}
+              onChange={(event) => setAmount(event.target.value)}
+            />
+          </label>
+          <label className="grid gap-2">
+            <span className="text-sm font-black uppercase tracking-[0.14em] text-[var(--color-ink)]">
+              Motivo
+            </span>
+            <Textarea
+              value={reason}
+              onChange={(event) => setReason(event.target.value)}
+              placeholder="Ex.: prêmio da live, correção de saldo, evento da comunidade"
+              className="min-h-24"
+            />
+          </label>
+        </div>
+
+        <div className="card-flat bg-[var(--color-paper)] p-4">
+          <p className="mono text-[10px] uppercase tracking-[0.2em] text-[var(--color-ink-soft)]">
+            Revisão
+          </p>
+          <p className="mt-2 text-sm text-[var(--color-ink-soft)]">
+            {selectedViewers.length > 0
+              ? `${selectedViewers.length} usuário${selectedViewers.length === 1 ? "" : "s"} receber${selectedViewers.length === 1 ? "á" : "ão"} ${Number.isInteger(parsedAmount) && parsedAmount > 0 ? formatPipetz(parsedAmount) : "--"} pipetz cada.`
+              : "Escolha pelo menos um viewer para revisar o airdrop."}
+          </p>
+          {selectedViewers.length > 0 ? (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {selectedViewers.map((entry) => (
+                <button
+                  key={entry.id}
+                  type="button"
+                  onClick={() => toggleViewer(entry.id)}
+                  className="badge-brutal bg-[var(--color-mint)] px-2 py-1 text-[10px] text-[var(--color-accent-ink)]"
+                >
+                  {entry.youtubeDisplayName} x
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
+
+        <label className="grid gap-2">
+          <span className="text-sm font-black uppercase tracking-[0.14em] text-[var(--color-ink)]">
+            Confirmação
+          </span>
+          <Input
+            value={confirmationText}
+            onChange={(event) => setConfirmationText(event.target.value)}
+            placeholder='Digite "AIRDROP"'
+          />
+        </label>
+
+        <Button
+          type="button"
+          onClick={submitAirdrop}
+          disabled={isPending || !canSubmit}
+          variant="success"
+          className="w-full sm:w-fit"
+        >
+          {isPending ? "Enviando..." : "Fazer airdrop"}
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/db/repository.ts
+++ b/src/lib/db/repository.ts
@@ -6758,15 +6758,23 @@ export async function adjustViewerBalance({
   viewerId,
   amount,
   reason,
+  kind = "manual_adjustment",
+  source = "admin",
 }: {
   viewerId: string;
   amount: number;
   reason: string;
+  kind?: LedgerEntryRecord["kind"];
+  source?: string;
 }) {
   const db = getDb();
 
   if (isDemoMode || !db) {
     const store = getDemoStore();
+    const viewer = getDemoViewerById(store, viewerId);
+    if (!viewer) {
+      throw new Error("viewer_not_found");
+    }
     const balance = getBalance(store, viewerId);
     balance.currentBalance += amount;
     if (amount > 0) {
@@ -6778,15 +6786,20 @@ export async function adjustViewerBalance({
 
     return createLedgerEntry(store, {
       viewerId,
-      kind: "manual_adjustment",
+      kind,
       amount,
-      source: "admin",
+      source,
       externalEventId: null,
       metadata: { reason },
     });
   }
 
-  await db
+  const viewer = await withViewerById(viewerId);
+  if (!viewer) {
+    throw new Error("viewer_not_found");
+  }
+
+  const updated = await db
     .update(viewerBalances)
     .set({
       currentBalance: sql`${viewerBalances.currentBalance} + ${amount}`,
@@ -6794,14 +6807,24 @@ export async function adjustViewerBalance({
       lifetimeSpent: amount < 0 ? sql`${viewerBalances.lifetimeSpent} + ${Math.abs(amount)}` : viewerBalances.lifetimeSpent,
       lastSyncedAt: new Date(),
     })
-    .where(eq(viewerBalances.viewerId, viewerId));
+    .where(eq(viewerBalances.viewerId, viewerId))
+    .returning({ viewerId: viewerBalances.viewerId });
+
+  if (updated.length === 0) {
+    await db.insert(viewerBalances).values({
+      viewerId,
+      currentBalance: amount,
+      lifetimeEarned: amount > 0 ? amount : 0,
+      lifetimeSpent: amount < 0 ? Math.abs(amount) : 0,
+    });
+  }
 
   await db.insert(pointLedger).values({
     id: randomUUID(),
     viewerId,
-    kind: "manual_adjustment",
+    kind,
     amount,
-    source: "admin",
+    source,
     externalEventId: null,
     metadata: { reason },
   });

--- a/src/lib/streamerbot/schemas.ts
+++ b/src/lib/streamerbot/schemas.ts
@@ -190,6 +190,19 @@ export const manualAdjustSchema = z.object({
   reason: z.string().min(3).max(255),
 });
 
+export const adminAirdropSchema = z.object({
+  amount: z.number().int().min(1).max(100000),
+  reason: z.string().trim().min(3).max(255),
+  viewerIds: z.array(z.string().min(1)).min(1).max(100).optional(),
+  confirmationText: z
+    .string()
+    .trim()
+    .transform((value) => value.toUpperCase())
+    .refine((value) => value === "AIRDROP", {
+      message: "Confirmation text must be AIRDROP.",
+    }),
+});
+
 export const streamerbotEventSchema = z.object({
   eventId: z.string().min(3),
   eventType: z.enum(["presence_tick", "chat_bonus", "manual_adjustment"]),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -8,6 +8,7 @@ export type CatalogItemType =
 export type LedgerKind =
   | "presence_tick"
   | "chat_bonus"
+  | "admin_airdrop"
   | "manual_adjustment"
   | "redemption_debit"
   | "redemption_refund"


### PR DESCRIPTION
## Summary

Adds an admin pipetz airdrop flow so admins can grant the same pipetz amount to one or many selected viewers.

## Changes

- Adds an admin panel for searching viewers, selecting multiple recipients, selecting all matching viewers, entering an amount and reason, and confirming with `AIRDROP`.
- Adds a dedicated admin airdrop API route.
- Records each recipient's grant in the point ledger as `admin_airdrop` with `admin_airdrop` source.
- Keeps manual balance adjustment reusable while validating missing viewers instead of creating orphan ledger entries.

## Validation

- `npm.cmd run build`
- `npm.cmd test -- src/lib/db/repository.test.ts`
- `npx.cmd eslint src/app/admin/page.tsx src/components/admin-pipetz-airdrop-panel.tsx src/app/api/admin/viewers/[id]/airdrop/route.ts src/lib/db/repository.ts src/lib/streamerbot/schemas.ts src/lib/types.ts`

Closes #83