### PR TITLE
[codex] Add current game spotlight and admin styling fixes

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,4 +1,5 @@
 import { AdminObsOverlaysPanel } from "@/components/admin-obs-overlays-panel";
+import { AdminCurrentGamePanel } from "@/components/admin-current-game-panel";
 import { AdminDashboardTabs } from "@/components/admin-dashboard-tabs";
 import { AdminBetsPanel } from "@/components/admin-bets-panel";
 import { DeathCounterGamePanel } from "@/components/death-counter-game-panel";
@@ -27,6 +28,7 @@ import {
 } from "@/lib/db/repository";
 import { getStreamerbotLivestreamStatus } from "@/lib/streamerbot/live-status";
 import { getActiveDeathCounterGame } from "@/lib/streamerbot/death-counter-game";
+import { getCurrentGame } from "@/lib/current-game";
 import { formatDateTime, formatPipetz } from "@/lib/utils";
 
 const statusColorMap: Record<string, string> = {
@@ -39,12 +41,13 @@ const statusColorMap: Record<string, string> = {
 
 export default async function AdminPage() {
   await requireAdminSession();
-  const [catalog, leaderboard, bridge, liveStatus, activeDeathCounterGame, redemptions, bets, suggestions, videoSuggestions, recommendations, viewers, obsOverlayStatus, pricing] = await Promise.all([
+  const [catalog, leaderboard, bridge, liveStatus, activeDeathCounterGame, currentGame, redemptions, bets, suggestions, videoSuggestions, recommendations, viewers, obsOverlayStatus, pricing] = await Promise.all([
     getCatalog(),
     getLeaderboard(),
     getBridgeStatus(),
     getStreamerbotLivestreamStatus(),
     getActiveDeathCounterGame(),
+    getCurrentGame(),
     listAdminRedemptions(),
     listAdminBets(),
     listAdminGameSuggestions(),
@@ -103,6 +106,7 @@ export default async function AdminPage() {
               <div className="grid gap-6 xl:grid-cols-[0.95fr_1.05fr]">
                 <div className="space-y-6">
                   <LiveStatusPanel bridge={bridge} initialStatus={liveStatus} />
+                  <AdminCurrentGamePanel initialGame={currentGame} />
                   <DeathCounterGamePanel initialGame={activeDeathCounterGame} />
                   <AdminPipetzPricingPanel initialPricing={pricing} />
                 </div>

--- a/src/app/api/admin/current-game/route.ts
+++ b/src/app/api/admin/current-game/route.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+
+import { fail, isTrustedAppMutationRequest, ok, requireAdminApiSession } from "@/lib/api";
+import { clearCurrentGame, setCurrentGame } from "@/lib/current-game";
+
+const currentGameActionSchema = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("set"),
+    igdbId: z.number().int().positive(),
+    name: z.string().trim().min(1, "Digite o nome do jogo."),
+    releaseYear: z.number().int().positive().nullable(),
+    coverImageUrl: z.string().url().nullable(),
+    platforms: z.array(z.string().trim().min(1)).default([]),
+    genres: z.array(z.string().trim().min(1)).default([]),
+  }),
+  z.object({
+    action: z.literal("clear"),
+  }),
+]);
+
+export async function POST(request: Request) {
+  if (!isTrustedAppMutationRequest(request)) {
+    return fail("Forbidden", 403);
+  }
+
+  const session = await requireAdminApiSession();
+  if (!session) {
+    return fail("Forbidden", 403);
+  }
+
+  try {
+    const json = await request.json();
+    const parsed = currentGameActionSchema.safeParse(json);
+    if (!parsed.success) {
+      return fail(parsed.error.issues[0]?.message ?? "Payload inválido.", 400);
+    }
+
+    const updatedBy = session.user?.email?.toLowerCase() ?? null;
+    const data =
+      parsed.data.action === "set"
+        ? await setCurrentGame({
+            igdbId: parsed.data.igdbId,
+            name: parsed.data.name,
+            releaseYear: parsed.data.releaseYear,
+            coverImageUrl: parsed.data.coverImageUrl,
+            platforms: parsed.data.platforms,
+            genres: parsed.data.genres,
+            updatedBy,
+          })
+        : await clearCurrentGame();
+
+    return ok(data);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return fail("Payload inválido.", 400);
+    }
+
+    return fail(error instanceof Error ? error.message : "Falha ao atualizar o jogo atual.", 400);
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,6 +14,9 @@
   --color-pink-hot: #ff59b7;
   --color-blue: #40a9ff;
   --color-yellow: #40a9ff;
+  --color-admin: #ffd44d;
+  --color-admin-hover: #ffe27a;
+  --color-admin-ink: #000000;
   --color-lavender: #f0e8f8;
   --color-sky: #d8efff;
   --color-mint: #00beae;
@@ -113,6 +116,9 @@ html[data-theme="dark"] {
   --color-pink-hot: #ff5fa8;
   --color-blue: #54c7ff;
   --color-yellow: #ffd44d;
+  --color-admin: #ffd44d;
+  --color-admin-hover: #ffe27a;
+  --color-admin-ink: #000000;
   --color-lavender: #151515;
   --color-sky: #101d25;
   --color-mint: #00beae;
@@ -611,6 +617,16 @@ button {
   box-shadow: var(--shadow);
 }
 
+.admin-action {
+  background: var(--color-admin);
+  color: var(--color-admin-ink);
+  box-shadow: var(--shadow);
+}
+
+.admin-action:hover {
+  background: var(--color-admin-hover);
+}
+
 /* Pastel action surfaces should keep dark ink in both light and dark themes. */
 .pastel-action {
   color: var(--color-accent-ink);
@@ -620,8 +636,6 @@ button {
 .btn-brutal[class*="bg-[var(--color-purple)]"],
 .btn-brutal[class*="bg-[var(--color-pink)]"],
 .btn-brutal[class*="bg-[var(--color-yellow)]"],
-.btn-brutal[class*="bg-[var(--color-sky)]"],
-.btn-brutal[class*="bg-[var(--color-lavender)]"],
 .btn-brutal[class*="bg-[var(--color-mint)]"] {
   color: var(--color-accent-ink);
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,10 @@
-﻿import type { ReactNode } from "react";
+import type { ReactNode } from "react";
 import Link from "next/link";
 import Image from "next/image";
 
 import { auth } from "@/auth";
 import { AuthButtons } from "@/components/auth-buttons";
+import { CurrentGameSpotlight } from "@/components/current-game-spotlight";
 import { LivestreamIndicator } from "@/components/livestream-indicator";
 import { QuickNavGrid } from "@/components/quick-nav-grid";
 import { StickerBadge } from "@/components/sticker-badge";
@@ -24,6 +25,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { getCatalog, getLeaderboard, getViewerDashboard, listBets } from "@/lib/db/repository";
+import { getCurrentGame } from "@/lib/current-game";
 import { isStreamerbotLivestreamActive } from "@/lib/streamerbot/live-status";
 import type { BetWithOptionsRecord } from "@/lib/types";
 import { cn, formatPipetz } from "@/lib/utils";
@@ -444,10 +446,10 @@ function FeatureShowcase({
             className="max-w-xl text-4xl uppercase leading-[0.9] sm:text-5xl"
             style={{ fontFamily: "var(--font-display)" }}
           >
-            Voce participa da minha live de verdade.
+            Você participa da minha live de verdade.
           </h2>
           <p className="mt-4 max-w-xl text-base leading-7 text-[var(--color-ink-soft)]">
-            Eu abro a live, voce junta pipetz, entra nas apostas e ainda solta resgates
+            Eu abro a live, você junta pipetz, entra nas apostas e ainda solta resgates
             que aparecem comigo ao vivo.
           </p>
 
@@ -478,7 +480,7 @@ function LiveThermometerSection({
           className="max-w-md text-3xl uppercase leading-[0.92] sm:text-4xl"
           style={{ fontFamily: "var(--font-display)" }}
         >
-          O que voces estao aprontando comigo agora.
+          O que vocês estão aprontando comigo agora.
         </h2>
 
         <div className="mt-6 grid gap-4 sm:grid-cols-2">
@@ -616,11 +618,12 @@ export default async function Home({ searchParams }: HomePageProps) {
     getSessionAccountProtectionStatus(session) ?? getAccountProtectionStatusFromSearchParams(resolvedSearchParams);
   const hasUsableSession = hasUsableAppSession(session) && !accountProtectionStatus;
   const activeViewerId = hasUsableSession ? session?.user?.activeViewerId ?? null : null;
-  const [catalog, leaderboard, bets, isLive] = await Promise.all([
+  const [catalog, leaderboard, bets, isLive, currentGame] = await Promise.all([
     getCatalog(),
     getLeaderboard(),
     listBets(activeViewerId),
     isStreamerbotLivestreamActive(),
+    getCurrentGame(),
   ]);
   const activeBets = bets.filter((bet) => bet.status === "open");
 
@@ -673,13 +676,13 @@ export default async function Home({ searchParams }: HomePageProps) {
     {
       label: "seu ranking",
       value: viewerRank ? `#${viewerRank}` : "--",
-      note: viewerRank ? "posicao atual na disputa" : "sincronize sua conta",
+      note: viewerRank ? "posição atual na disputa" : "sincronize sua conta",
       bg: "bg-[var(--color-blue)]",
     },
     {
       label: "ganhos",
       value: dashboard ? formatPipetz(dashboard.balance.lifetimeEarned) : "--",
-      note: "pipetz que ja passaram pela conta",
+      note: "pipetz que já passaram pela conta",
       bg: "bg-[var(--color-pink)]",
     },
     {
@@ -743,8 +746,8 @@ export default async function Home({ searchParams }: HomePageProps) {
   const heroPosterHeading = hasUsableSession ? dashboard?.viewer.youtubeDisplayName ?? "Conta conectada" : "LUDYLOPS";
 
   const heroPosterDescription = hasUsableSession
-    ? "Esse e o seu cantinho para acompanhar saldo, ranking e o que esta rolando comigo ao vivo."
-    : "Esse painel e o cantinho da minha live para o chat apostar, resgatar e acompanhar o ranking.";
+    ? "Esse é o seu cantinho para acompanhar saldo, ranking e o que está rolando comigo ao vivo."
+    : "Esse painel é o cantinho da minha live para o chat apostar, resgatar e acompanhar o ranking.";
 
   const metrics = hasUsableSession ? authedMetrics : publicMetrics;
   const shouldShowViewerLinkingNotice = Boolean(hasUsableSession && !session?.user?.isLinked);
@@ -834,6 +837,8 @@ export default async function Home({ searchParams }: HomePageProps) {
 
       <FeatureShowcase features={features} />
 
+      <CurrentGameSpotlight game={currentGame} />
+
       <LiveThermometerSection metrics={metrics} loggedIn={hasUsableSession} />
 
       {false ? (
@@ -850,7 +855,7 @@ export default async function Home({ searchParams }: HomePageProps) {
             {
               href: "/jogos",
               label: "Jogos",
-              value: "Sugira proximos",
+              value: "Sugira próximos",
               sublabel: "Me empurre pro proximo caos",
               emoji: "PLAY",
               bg: "bg-[var(--color-blue)]",

--- a/src/components/admin-current-game-panel.tsx
+++ b/src/components/admin-current-game-panel.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { CurrentGameRecord } from "@/lib/types";
+import { formatDateTime } from "@/lib/utils";
+
+type GameSearchResult = {
+  igdbId: number;
+  name: string;
+  releaseYear: number | null;
+  coverImageUrl: string | null;
+  platforms: string[];
+  genres: string[];
+};
+
+export function AdminCurrentGamePanel({
+  initialGame,
+}: {
+  initialGame: CurrentGameRecord | null;
+}) {
+  const router = useRouter();
+  const [currentGame, setCurrentGame] = useState(initialGame);
+  const [query, setQuery] = useState(initialGame?.name ?? "");
+  const [results, setResults] = useState<GameSearchResult[]>([]);
+  const [selectedGame, setSelectedGame] = useState<GameSearchResult | null>(null);
+  const [isSearching, setIsSearching] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    const normalizedQuery = query.trim();
+    if (normalizedQuery.length < 2 || selectedGame?.name === normalizedQuery) {
+      setResults([]);
+      setIsSearching(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    const timer = window.setTimeout(async () => {
+      setIsSearching(true);
+      setFeedback(null);
+
+      try {
+        const response = await fetch(`/api/games/search?q=${encodeURIComponent(normalizedQuery)}`, {
+          signal: controller.signal,
+        });
+        const payload = (await response.json()) as {
+          ok: boolean;
+          data?: GameSearchResult[];
+          error?: string;
+        };
+
+        if (!response.ok || !payload.ok) {
+          setResults([]);
+          setFeedback(payload.error === "igdb_unavailable" ? "Busca IGDB indisponível." : "Falha ao buscar jogos.");
+          return;
+        }
+
+        setResults(payload.data ?? []);
+      } catch (error) {
+        if ((error as DOMException).name !== "AbortError") {
+          setResults([]);
+          setFeedback("Falha ao buscar jogos.");
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsSearching(false);
+        }
+      }
+    }, 350);
+
+    return () => {
+      controller.abort();
+      window.clearTimeout(timer);
+    };
+  }, [query, selectedGame]);
+
+  function selectGame(game: GameSearchResult) {
+    setSelectedGame(game);
+    setQuery(game.name);
+    setResults([]);
+  }
+
+  function saveGame() {
+    if (!selectedGame) {
+      setFeedback("Escolha um jogo da lista do IGDB.");
+      return;
+    }
+
+    setFeedback(null);
+    startTransition(async () => {
+      const response = await fetch("/api/admin/current-game", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          action: "set",
+          igdbId: selectedGame.igdbId,
+          name: selectedGame.name,
+          releaseYear: selectedGame.releaseYear,
+          coverImageUrl: selectedGame.coverImageUrl,
+          platforms: selectedGame.platforms,
+          genres: selectedGame.genres,
+        }),
+      });
+
+      const payload = (await response.json()) as {
+        ok?: boolean;
+        error?: string;
+        data?: CurrentGameRecord | null;
+      };
+
+      if (!response.ok || !payload.ok || !payload.data) {
+        setFeedback(payload.error ?? "Falha ao salvar jogo atual.");
+        return;
+      }
+
+      setCurrentGame(payload.data);
+      setSelectedGame(null);
+      setQuery(payload.data.name);
+      setFeedback("Jogo atual atualizado.");
+      router.refresh();
+    });
+  }
+
+  function clearGame() {
+    setFeedback(null);
+    startTransition(async () => {
+      const response = await fetch("/api/admin/current-game", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ action: "clear" }),
+      });
+
+      const payload = (await response.json()) as {
+        ok?: boolean;
+        error?: string;
+      };
+
+      if (!response.ok || !payload.ok) {
+        setFeedback(payload.error ?? "Falha ao limpar jogo atual.");
+        return;
+      }
+
+      setCurrentGame(null);
+      setSelectedGame(null);
+      setQuery("");
+      setResults([]);
+      setFeedback("Jogo atual removido.");
+      router.refresh();
+    });
+  }
+
+  const previewGame = selectedGame ?? currentGame;
+
+  return (
+    <div className="panel surface-section p-6">
+      <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
+        Landing page
+      </p>
+      <h2 className="mt-2 text-2xl font-bold uppercase" style={{ fontFamily: "var(--font-display)" }}>
+        Jogo atual da live
+      </h2>
+      <p className="mt-3 text-sm leading-7 text-[var(--color-ink-soft)]">
+        Escolha o jogo pelo IGDB para mostrar nome, capa e metadados na primeira página da comunidade.
+      </p>
+
+      <div className="mt-5 grid gap-4 lg:grid-cols-[150px_1fr]">
+        <div className="min-h-48 border-2 border-[var(--color-ink)] bg-[var(--color-lavender)]">
+          {previewGame?.coverImageUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={previewGame.coverImageUrl} alt="" className="h-full min-h-48 w-full object-cover" />
+          ) : (
+            <div className="flex h-full min-h-48 items-center justify-center px-4 text-center text-sm font-black uppercase text-[var(--color-ink-soft)]">
+              Sem capa
+            </div>
+          )}
+        </div>
+
+        <div>
+          <div className="card-brutal-static surface-card p-4">
+            <p className="mono text-[10px] uppercase tracking-[0.28em] text-[var(--color-ink-soft)]">
+              Estado atual
+            </p>
+            {currentGame ? (
+              <>
+                <p className="mt-2 text-xl font-black uppercase">{currentGame.name}</p>
+                <p className="mt-2 text-sm text-[var(--color-ink-soft)]">
+                  IGDB #{currentGame.igdbId}
+                  {currentGame.releaseYear ? ` / ${currentGame.releaseYear}` : ""}
+                </p>
+                <p className="mt-2 text-sm text-[var(--color-ink-soft)]">
+                  atualizado em {formatDateTime(currentGame.updatedAt)}
+                  {currentGame.updatedBy ? ` por ${currentGame.updatedBy}` : ""}
+                </p>
+              </>
+            ) : (
+              <p className="mt-2 text-sm font-bold text-[var(--color-ink-soft)]">
+                Nenhum jogo atual configurado.
+              </p>
+            )}
+          </div>
+
+          <div className="relative mt-4">
+            <label className="mono text-[10px] uppercase tracking-[0.28em] text-[var(--color-ink-soft)]">
+              Buscar no IGDB
+            </label>
+            <Input
+              value={query}
+              onChange={(event) => {
+                setQuery(event.target.value);
+                setSelectedGame(null);
+              }}
+              placeholder="Ex.: Hades II"
+              className="mt-2"
+            />
+
+            {isSearching ? (
+              <p className="mt-2 text-xs font-bold uppercase tracking-[0.12em] text-[var(--color-ink-soft)]">
+                Buscando no IGDB...
+              </p>
+            ) : null}
+
+            {results.length > 0 ? (
+              <div className="absolute z-20 mt-2 grid max-h-72 w-full gap-2 overflow-auto border-[3px] border-[var(--color-ink)] bg-[var(--color-paper)] p-2 shadow-purple">
+                {results.map((game) => (
+                  <button
+                    key={game.igdbId}
+                    type="button"
+                    onClick={() => selectGame(game)}
+                    className="flex w-full items-center gap-3 border-2 border-transparent p-2 text-left hover:border-[var(--color-admin)] hover:bg-[var(--color-admin)] hover:text-[var(--color-admin-ink)] focus-visible:border-[var(--color-admin)] focus-visible:bg-[var(--color-admin)] focus-visible:text-[var(--color-admin-ink)] focus-visible:outline-none"
+                  >
+                    {game.coverImageUrl ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={game.coverImageUrl}
+                        alt=""
+                        className="h-14 w-10 shrink-0 border-2 border-[var(--color-ink)] object-cover"
+                      />
+                    ) : (
+                      <span className="h-14 w-10 shrink-0 border-2 border-[var(--color-ink)] bg-[var(--color-lavender)]" />
+                    )}
+                    <span className="min-w-0">
+                      <span className="block truncate text-sm font-bold">{game.name}</span>
+                      <span className="mono mt-0.5 block truncate text-[10px] uppercase tracking-[0.12em]">
+                        {[game.releaseYear, ...game.platforms.slice(0, 2)].filter(Boolean).join(" / ") || "IGDB"}
+                      </span>
+                    </span>
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </div>
+
+          <div className="mt-4 flex flex-wrap gap-2">
+            <Button type="button" onClick={saveGame} disabled={isPending || !selectedGame} variant="admin" size="sm">
+              {isPending ? "Salvando..." : "Salvar jogo atual"}
+            </Button>
+            <Button type="button" onClick={clearGame} disabled={isPending || !currentGame} variant="neutral" size="sm">
+              Limpar
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {feedback ? <div className="retro-label neutral-chip mt-4">{feedback}</div> : null}
+    </div>
+  );
+}

--- a/src/components/app-chrome.tsx
+++ b/src/components/app-chrome.tsx
@@ -193,7 +193,9 @@ export function AppChrome({
                   key={link.href}
                   href={link.href}
                   className={`rounded-[var(--radius)] border px-3.5 py-1.5 text-xs font-extrabold uppercase tracking-[0.1em] transition-colors duration-[var(--snap)] ${
-                    isActiveLink(link.href)
+                    link.href === "/admin"
+                      ? "admin-action border-[2px] border-[var(--color-ink)] text-[var(--color-admin-ink)] shadow-[4px_4px_0_var(--shadow-color)]"
+                      : isActiveLink(link.href)
                       ? "pastel-action border-[2px] border-[var(--color-ink)] bg-[var(--color-purple)] text-[var(--color-accent-ink)] shadow-[4px_4px_0_var(--shadow-color)]"
                       : "border-transparent text-[var(--color-ink-soft)] hover:border-[var(--color-ink)] hover:bg-[var(--color-paper)] hover:text-[var(--color-ink)]"
                   }`}
@@ -243,7 +245,9 @@ export function AppChrome({
                       href={link.href}
                       onClick={() => setMobileOpen(false)}
                       className={`rounded-[var(--radius)] border px-4 py-3 text-sm font-extrabold uppercase tracking-[0.1em] transition-colors duration-[var(--snap)] ${
-                        isActiveLink(link.href)
+                        link.href === "/admin"
+                          ? "admin-action border-[2px] border-[var(--color-ink)] text-[var(--color-admin-ink)] shadow-[4px_4px_0_var(--shadow-color)]"
+                          : isActiveLink(link.href)
                           ? "pastel-action border-[2px] border-[var(--color-ink)] bg-[var(--color-purple)] text-[var(--color-accent-ink)] shadow-[4px_4px_0_var(--shadow-color)]"
                           : "border-[2px] border-transparent text-[var(--color-ink-soft)] hover:border-[var(--color-ink)] hover:bg-[var(--color-paper)] hover:text-[var(--color-ink)] active:border-[var(--color-ink)] active:bg-[var(--color-paper)] active:text-[var(--color-ink)]"
                       }`}

--- a/src/components/current-game-spotlight.tsx
+++ b/src/components/current-game-spotlight.tsx
@@ -1,0 +1,55 @@
+import type { CurrentGameRecord } from "@/lib/types";
+
+export function CurrentGameSpotlight({
+  game,
+}: {
+  game: CurrentGameRecord | null;
+}) {
+  if (!game) {
+    return null;
+  }
+
+  const metadata = [
+    game.releaseYear,
+    ...game.platforms.slice(0, 2),
+    ...game.genres.slice(0, 2),
+  ]
+    .filter(Boolean)
+    .join(" / ");
+
+  return (
+    <section className="landing-plane landing-divider bg-[var(--color-paper)] py-8 sm:py-10">
+      <div className="mx-auto w-full max-w-[1520px] px-4 sm:px-6 lg:px-10">
+        <div className="grid overflow-hidden border-[3px] border-[var(--color-ink)] bg-[var(--color-paper)] shadow-[6px_6px_0_var(--shadow-color)] lg:grid-cols-[280px_1fr]">
+          <div className="min-h-72 border-b-[3px] border-[var(--color-ink)] bg-[var(--color-lavender)] lg:border-b-0 lg:border-r-[3px]">
+            {game.coverImageUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={game.coverImageUrl} alt={`Capa de ${game.name}`} className="h-full min-h-72 w-full object-cover" />
+            ) : (
+              <div className="flex h-full min-h-72 items-center justify-center px-6 text-center text-3xl font-black uppercase">
+                {game.name}
+              </div>
+            )}
+          </div>
+
+          <div className="flex flex-col justify-center p-6 sm:p-8">
+            <p className="mono text-[11px] font-black uppercase tracking-[0.28em] text-[var(--color-ink-soft)]">
+              jogando agora
+            </p>
+            <h2 className="mt-3 text-4xl uppercase leading-[0.9] sm:text-5xl" style={{ fontFamily: "var(--font-display)" }}>
+              {game.name}
+            </h2>
+            {metadata ? (
+              <p className="mono mt-4 text-[11px] font-bold uppercase tracking-[0.18em] text-[var(--color-ink-soft)]">
+                {metadata}
+              </p>
+            ) : null}
+            <p className="mt-5 max-w-2xl text-sm font-medium leading-7 text-[var(--color-ink-soft)] sm:text-base">
+              Esse é o jogo em destaque da live agora, para a comunidade reconhecer de cara o que está rolando.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/game-suggestion-card.tsx
+++ b/src/components/game-suggestion-card.tsx
@@ -257,7 +257,10 @@ export function GameSuggestionCard({
           </div>
 
           {canEditCatalog ? (
-            <div className="mt-4 border-t border-[var(--color-ink)]/30 pt-4">
+            <div className="mt-4 border-t-2 border-[var(--color-admin)] bg-[var(--color-admin)]/15 p-3">
+              <p className="mono mb-3 text-[10px] font-black uppercase tracking-[0.18em] text-[var(--color-admin)]">
+                Ação admin
+              </p>
               {isEditingCatalog ? (
                 <div className="grid gap-2">
                   <div className="flex flex-wrap items-center gap-2">
@@ -295,7 +298,7 @@ export function GameSuggestionCard({
                           type="button"
                           onClick={() => setSelectedCatalogResult(game)}
                           disabled={isPending}
-                          className="border border-[var(--color-ink)] bg-[var(--color-paper)] px-3 py-2 text-left text-xs font-bold hover:bg-[var(--color-sky)] focus-visible:bg-[var(--color-sky)] focus-visible:outline-none"
+                          className="border border-[var(--color-admin)] bg-[var(--color-paper)] px-3 py-2 text-left text-xs font-bold hover:bg-[var(--color-admin)] hover:text-[var(--color-admin-ink)] focus-visible:bg-[var(--color-admin)] focus-visible:text-[var(--color-admin-ink)] focus-visible:outline-none"
                         >
                           {game.name}
                           {game.releaseYear ? ` (${game.releaseYear})` : ""}
@@ -308,7 +311,7 @@ export function GameSuggestionCard({
                 <Button
                   type="button"
                   size="xs"
-                  variant="neutral"
+                  variant="admin"
                   onClick={() => {
                     setCatalogQuery(suggestion.name);
                     setIsEditingCatalog(true);
@@ -435,7 +438,7 @@ export function GameSuggestionCard({
                   <Button
                     type="button"
                     size="sm"
-                    variant="accent"
+                    variant="admin"
                     onClick={() => applyCatalogResult(selectedCatalogResult)}
                     disabled={isPending}
                   >

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -17,6 +17,7 @@ const buttonVariants = cva(
         info: "bg-[var(--color-sky)] text-[var(--color-ink)]",
         danger: "bg-[var(--color-rose)] text-[var(--color-ink)]",
         pink: "bg-[var(--color-pink)] text-[var(--color-accent-ink)]",
+        admin: "admin-action text-[var(--color-admin-ink)]",
       },
       size: {
         xs: "px-3 py-2 text-[11px]",

--- a/src/lib/current-game.ts
+++ b/src/lib/current-game.ts
@@ -1,0 +1,196 @@
+import { eq } from "drizzle-orm";
+
+import { getDb } from "@/lib/db/client";
+import { streamerbotCounters } from "@/lib/db/schema";
+import type { CurrentGameRecord } from "@/lib/types";
+
+const CURRENT_GAME_KEY = "current_stream_game";
+
+type CurrentGameInput = Omit<CurrentGameRecord, "updatedAt" | "updatedBy">;
+
+declare global {
+  var __lojaCurrentGame: CurrentGameRecord | null | undefined;
+}
+
+function getDemoCurrentGame() {
+  return globalThis.__lojaCurrentGame ?? null;
+}
+
+function setDemoCurrentGame(game: CurrentGameRecord | null) {
+  globalThis.__lojaCurrentGame = game;
+}
+
+function isMissingCounterSchemaError(error: unknown) {
+  const tableNames = ['"streamerbot_counters"', "streamerbot_counters"];
+  const queue: unknown[] = [error];
+  const visited = new Set<unknown>();
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current || visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+
+    const message =
+      current instanceof Error ? current.message : typeof current === "string" ? current : "";
+    const normalized = message.toLowerCase();
+    const mentionsTable = tableNames.some((tableName) => normalized.includes(tableName));
+
+    if (
+      mentionsTable &&
+      (normalized.includes("does not exist") ||
+        normalized.includes("relation") ||
+        normalized.includes("table") ||
+        normalized.includes("failed query"))
+    ) {
+      return true;
+    }
+
+    if (typeof current === "object" && current && "cause" in current) {
+      queue.push((current as { cause?: unknown }).cause);
+    }
+  }
+
+  return false;
+}
+
+function stringArray(value: unknown) {
+  return Array.isArray(value)
+    ? value.map((entry) => (typeof entry === "string" ? entry.trim() : "")).filter(Boolean)
+    : [];
+}
+
+function parseCurrentGameRow(row: {
+  updatedAt: Date | string;
+  metadata: Record<string, unknown>;
+}): CurrentGameRecord | null {
+  const igdbId = row.metadata.igdbId;
+  const name = typeof row.metadata.name === "string" ? row.metadata.name.trim() : "";
+
+  if (!Number.isInteger(igdbId) || typeof igdbId !== "number" || igdbId <= 0 || !name) {
+    return null;
+  }
+
+  const metadataUpdatedAt = row.metadata.updatedAt;
+  const updatedAt =
+    typeof metadataUpdatedAt === "string"
+      ? metadataUpdatedAt
+      : typeof row.updatedAt === "string"
+        ? row.updatedAt
+        : row.updatedAt.toISOString();
+
+  return {
+    igdbId,
+    name,
+    releaseYear: typeof row.metadata.releaseYear === "number" ? row.metadata.releaseYear : null,
+    coverImageUrl:
+      typeof row.metadata.coverImageUrl === "string" && row.metadata.coverImageUrl.trim()
+        ? row.metadata.coverImageUrl.trim()
+        : null,
+    platforms: stringArray(row.metadata.platforms).slice(0, 4),
+    genres: stringArray(row.metadata.genres).slice(0, 3),
+    updatedAt,
+    updatedBy: typeof row.metadata.updatedBy === "string" ? row.metadata.updatedBy : null,
+  };
+}
+
+export async function getCurrentGame(): Promise<CurrentGameRecord | null> {
+  const db = getDb();
+  if (!db) {
+    return getDemoCurrentGame();
+  }
+
+  try {
+    const [row] = await db
+      .select({
+        updatedAt: streamerbotCounters.updatedAt,
+        metadata: streamerbotCounters.metadata,
+      })
+      .from(streamerbotCounters)
+      .where(eq(streamerbotCounters.key, CURRENT_GAME_KEY))
+      .limit(1);
+
+    return row
+      ? parseCurrentGameRow({
+          updatedAt: row.updatedAt,
+          metadata: row.metadata as Record<string, unknown>,
+        })
+      : null;
+  } catch (error) {
+    if (isMissingCounterSchemaError(error)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+export async function setCurrentGame(input: CurrentGameInput & { updatedBy?: string | null }) {
+  const updatedAt = new Date().toISOString();
+  const currentGame: CurrentGameRecord = {
+    igdbId: input.igdbId,
+    name: input.name.trim(),
+    releaseYear: input.releaseYear,
+    coverImageUrl: input.coverImageUrl,
+    platforms: input.platforms.slice(0, 4),
+    genres: input.genres.slice(0, 3),
+    updatedAt,
+    updatedBy: input.updatedBy ?? null,
+  };
+
+  if (!currentGame.name) {
+    throw new Error("Nome do jogo inválido.");
+  }
+
+  const db = getDb();
+  if (!db) {
+    setDemoCurrentGame(currentGame);
+    return currentGame;
+  }
+
+  try {
+    await db
+      .insert(streamerbotCounters)
+      .values({
+        key: CURRENT_GAME_KEY,
+        value: 1,
+        lastResetAt: null,
+        updatedAt: new Date(updatedAt),
+        metadata: currentGame,
+      })
+      .onConflictDoUpdate({
+        target: streamerbotCounters.key,
+        set: {
+          value: 1,
+          updatedAt: new Date(updatedAt),
+          metadata: currentGame,
+        },
+      });
+  } catch (error) {
+    if (isMissingCounterSchemaError(error)) {
+      throw new Error("Schema dos contadores ainda não foi aplicado. Rode npm run db:push.");
+    }
+    throw error;
+  }
+
+  return currentGame;
+}
+
+export async function clearCurrentGame() {
+  const db = getDb();
+  if (!db) {
+    setDemoCurrentGame(null);
+    return null;
+  }
+
+  try {
+    await db.delete(streamerbotCounters).where(eq(streamerbotCounters.key, CURRENT_GAME_KEY));
+  } catch (error) {
+    if (isMissingCounterSchemaError(error)) {
+      throw new Error("Schema dos contadores ainda não foi aplicado. Rode npm run db:push.");
+    }
+    throw error;
+  }
+
+  return null;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -346,6 +346,17 @@ export interface ActiveDeathCounterGameRecord {
   updatedBy: string | null;
 }
 
+export interface CurrentGameRecord {
+  igdbId: number;
+  name: string;
+  releaseYear: number | null;
+  coverImageUrl: string | null;
+  platforms: string[];
+  genres: string[];
+  updatedAt: string;
+  updatedBy: string | null;
+}
+
 export interface LivestreamStatusRecord {
   isLive: boolean;
   source: "automatic" | "manual";


### PR DESCRIPTION
## What changed

- Adds an admin current-game picker backed by the existing IGDB game search flow.
- Shows the selected current game on the landing page with cover art and metadata.
- Adds an admin-only action accent so admin controls stand apart outside the dashboard.
- Fixes dark-mode contrast for brutal buttons/cards that were inheriting low-contrast text colors.

## Why

The app needed a reliable way to feature the game currently being played on stream, while keeping admin-only actions visually distinct and readable across light and dark themes.

## Validation

- `npx.cmd eslint src/app/admin/page.tsx src/app/page.tsx src/components/app-chrome.tsx src/components/game-suggestion-card.tsx src/components/admin-current-game-panel.tsx src/components/current-game-spotlight.tsx src/components/ui/button.tsx src/lib/current-game.ts src/app/api/admin/current-game/route.ts src/lib/types.ts`
- `npm.cmd test -- src/lib/streamerbot/death-counter-game.test.ts src/lib/db/repository.test.ts`
- `npm.cmd run build`

Closes #70, closes #80, closes #81