### PR TITLE
[codex] Improve viewer link flow

### DIFF
--- a/src/app/(public)/indicacoes/page.tsx
+++ b/src/app/(public)/indicacoes/page.tsx
@@ -91,7 +91,7 @@ export default async function IndicacoesPage() {
     activeViewerId ? getViewerDashboard(activeViewerId) : Promise.resolve(null),
   ]);
   const viewerBalance = dashboard?.balance.currentBalance ?? null;
-  const canInteract = Boolean(activeViewerId);
+  const canInteract = Boolean(activeViewerId && dashboard?.viewer.isLinked);
 
   return (
     <div className="flex w-full flex-col pb-20">

--- a/src/app/(public)/jogos/page.tsx
+++ b/src/app/(public)/jogos/page.tsx
@@ -14,7 +14,7 @@ export default async function JogosPage() {
   ]);
 
   const viewerBalance = dashboard?.balance.currentBalance ?? null;
-  const canInteract = Boolean(activeViewerId);
+  const canInteract = Boolean(activeViewerId && dashboard?.viewer.isLinked);
   const isAdmin = Boolean(session?.user?.email && adminEmails.has(session.user.email.toLowerCase()));
 
   return (

--- a/src/app/(public)/quotes/page.tsx
+++ b/src/app/(public)/quotes/page.tsx
@@ -32,7 +32,7 @@ export default async function QuotesPage() {
     activeViewerId ? getViewerDashboard(activeViewerId) : Promise.resolve(null),
     getPipetzPricing(),
   ]);
-  const canShowOnOverlay = Boolean(activeViewerId);
+  const canShowOnOverlay = Boolean(activeViewerId && dashboard?.viewer.isLinked);
 
   return (
     <div className="flex w-full flex-col pb-20">

--- a/src/app/(public)/videos/page.tsx
+++ b/src/app/(public)/videos/page.tsx
@@ -16,7 +16,7 @@ export default async function VideosPage() {
   ]);
 
   const viewerBalance = dashboard?.balance.currentBalance ?? null;
-  const canInteract = Boolean(activeViewerId);
+  const canInteract = Boolean(activeViewerId && dashboard?.viewer.isLinked);
 
   return (
     <div className="flex w-full flex-col pb-20">

--- a/src/app/(viewer)/me/page.tsx
+++ b/src/app/(viewer)/me/page.tsx
@@ -25,7 +25,7 @@ export default async function MePage() {
         currentBalance={dashboard.balance.currentBalance}
       />
 
-      <ViewerLinkCard isLinked={dashboard.viewer.isLinked} />
+      {dashboard.viewer.isLinked ? null : <ViewerLinkCard />}
 
       <RedemptionGrid
         items={catalog}

--- a/src/app/api/me/bets/[betId]/route.ts
+++ b/src/app/api/me/bets/[betId]/route.ts
@@ -1,4 +1,4 @@
-import { fail, isTrustedAppMutationRequest, ok, requireApiSession } from "@/lib/api";
+import { fail, isTrustedAppMutationRequest, ok, requireLinkedApiSession } from "@/lib/api";
 import { placeBet } from "@/lib/db/repository";
 import { placeBetSchema } from "@/lib/streamerbot/schemas";
 
@@ -10,7 +10,7 @@ export async function POST(
     return fail("Forbidden", 403);
   }
 
-  const session = await requireApiSession();
+  const session = await requireLinkedApiSession();
   if (!session?.user?.activeViewerId) {
     return fail("Unauthorized", 401);
   }

--- a/src/app/api/me/creator-suggestions/[id]/boost/route.ts
+++ b/src/app/api/me/creator-suggestions/[id]/boost/route.ts
@@ -1,6 +1,6 @@
 import { ZodError } from "zod";
 
-import { fail, isTrustedAppMutationRequest, ok, requireApiSession } from "@/lib/api";
+import { fail, isTrustedAppMutationRequest, ok, requireLinkedApiSession } from "@/lib/api";
 import { boostCreatorSuggestion } from "@/lib/db/repository";
 import {
   boostCreatorSuggestionSchema,
@@ -16,7 +16,7 @@ export async function POST(
     return fail("Forbidden", 403);
   }
 
-  const session = await requireApiSession();
+  const session = await requireLinkedApiSession();
   if (!session?.user?.activeViewerId) {
     return fail("Unauthorized", 401);
   }

--- a/src/app/api/me/creator-suggestions/route.ts
+++ b/src/app/api/me/creator-suggestions/route.ts
@@ -1,6 +1,6 @@
 import { ZodError } from "zod";
 
-import { fail, isTrustedAppMutationRequest, ok, requireApiSession } from "@/lib/api";
+import { fail, isTrustedAppMutationRequest, ok, requireLinkedApiSession } from "@/lib/api";
 import { createCreatorSuggestion } from "@/lib/db/repository";
 import {
   createCreatorSuggestionSchema,
@@ -13,7 +13,7 @@ export async function POST(request: Request) {
     return fail("Forbidden", 403);
   }
 
-  const session = await requireApiSession();
+  const session = await requireLinkedApiSession();
   if (!session?.user?.activeViewerId) {
     return fail("Unauthorized", 401);
   }

--- a/src/app/api/me/game-suggestions/[id]/boost/route.ts
+++ b/src/app/api/me/game-suggestions/[id]/boost/route.ts
@@ -1,6 +1,6 @@
 import { ZodError } from "zod";
 
-import { fail, isTrustedAppMutationRequest, ok, requireApiSession } from "@/lib/api";
+import { fail, isTrustedAppMutationRequest, ok, requireLinkedApiSession } from "@/lib/api";
 import { boostGameSuggestion } from "@/lib/db/repository";
 import {
   boostGameSuggestionSchema,
@@ -16,7 +16,7 @@ export async function POST(
     return fail("Forbidden", 403);
   }
 
-  const session = await requireApiSession();
+  const session = await requireLinkedApiSession();
   if (!session?.user?.activeViewerId) {
     return fail("Unauthorized", 401);
   }

--- a/src/app/api/me/game-suggestions/route.ts
+++ b/src/app/api/me/game-suggestions/route.ts
@@ -1,6 +1,6 @@
 import { ZodError } from "zod";
 
-import { fail, isTrustedAppMutationRequest, ok, requireApiSession } from "@/lib/api";
+import { fail, isTrustedAppMutationRequest, ok, requireLinkedApiSession } from "@/lib/api";
 import { createGameSuggestion } from "@/lib/db/repository";
 import {
   createGameSuggestionSchema,
@@ -13,7 +13,7 @@ export async function POST(request: Request) {
     return fail("Forbidden", 403);
   }
 
-  const session = await requireApiSession();
+  const session = await requireLinkedApiSession();
   if (!session?.user?.activeViewerId) {
     return fail("Unauthorized", 401);
   }

--- a/src/app/api/me/quotes/[quoteId]/show/route.ts
+++ b/src/app/api/me/quotes/[quoteId]/show/route.ts
@@ -1,4 +1,4 @@
-import { fail, isTrustedAppMutationRequest, ok, requireApiSession } from "@/lib/api";
+import { fail, isTrustedAppMutationRequest, ok, requireLinkedApiSession } from "@/lib/api";
 import { showQuoteOverlayForViewer } from "@/lib/db/repository";
 import { showQuoteOverlaySchema } from "@/lib/streamerbot/schemas";
 
@@ -10,7 +10,7 @@ export async function POST(
     return fail("Forbidden", 403);
   }
 
-  const session = await requireApiSession();
+  const session = await requireLinkedApiSession();
   if (!session?.user?.activeViewerId) {
     return fail("Unauthorized", 401);
   }

--- a/src/app/api/me/redeem/route.ts
+++ b/src/app/api/me/redeem/route.ts
@@ -1,4 +1,4 @@
-import { fail, isTrustedAppMutationRequest, ok, requireApiSession } from "@/lib/api";
+import { fail, isTrustedAppMutationRequest, ok, requireLinkedApiSession } from "@/lib/api";
 import { redeemItem } from "@/lib/db/repository";
 import { redeemSchema } from "@/lib/streamerbot/schemas";
 
@@ -7,7 +7,7 @@ export async function POST(request: Request) {
     return fail("Forbidden", 403);
   }
 
-  const session = await requireApiSession();
+  const session = await requireLinkedApiSession();
   if (!session?.user?.activeViewerId) {
     return fail("Unauthorized", 401);
   }

--- a/src/app/api/me/video-suggestions/[id]/boost/route.ts
+++ b/src/app/api/me/video-suggestions/[id]/boost/route.ts
@@ -1,6 +1,6 @@
 import { ZodError } from "zod";
 
-import { fail, isTrustedAppMutationRequest, ok, requireApiSession } from "@/lib/api";
+import { fail, isTrustedAppMutationRequest, ok, requireLinkedApiSession } from "@/lib/api";
 import { boostVideoSuggestion } from "@/lib/db/repository";
 import {
   boostVideoSuggestionSchema,
@@ -16,7 +16,7 @@ export async function POST(
     return fail("Forbidden", 403);
   }
 
-  const session = await requireApiSession();
+  const session = await requireLinkedApiSession();
   if (!session?.user?.activeViewerId) {
     return fail("Unauthorized", 401);
   }

--- a/src/app/api/me/video-suggestions/route.ts
+++ b/src/app/api/me/video-suggestions/route.ts
@@ -1,6 +1,6 @@
 import { ZodError } from "zod";
 
-import { fail, isTrustedAppMutationRequest, ok, requireApiSession } from "@/lib/api";
+import { fail, isTrustedAppMutationRequest, ok, requireLinkedApiSession } from "@/lib/api";
 import { createVideoSuggestion } from "@/lib/db/repository";
 import {
   createVideoSuggestionSchema,
@@ -14,7 +14,7 @@ export async function POST(request: Request) {
     return fail("Forbidden", 403);
   }
 
-  const session = await requireApiSession();
+  const session = await requireLinkedApiSession();
   if (!session?.user?.activeViewerId) {
     return fail("Unauthorized", 401);
   }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -89,6 +89,7 @@ export default async function RootLayout({
             isAdmin={isAdmin}
             isLive={isLive}
             initialTheme={initialTheme}
+            showViewerLinkingAlert={Boolean(session?.user?.email && session.user.isLinked === false)}
           >
             {children}
           </AppChrome>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,7 +14,6 @@ import {
   hasUsableAppSession,
   type AccountProtectionStatus,
 } from "@/lib/auth/session-state";
-import { env } from "@/lib/env";
 import {
   Card,
   CardContent,
@@ -48,77 +47,12 @@ type FeatureCard = {
   bg: string;
 };
 
-const DEFAULT_GITHUB_ISSUES_URL =
-  "https://github.com/ludmila-omlopes/ludylops-live/issues/new";
 const LUDYLOPS_PROFILE_IMAGE =
   "/selfie2.png";
 
 function usesPastelSurface(bgClass: string) {
   return ["--color-blue", "--color-purple", "--color-pink", "--color-yellow", "--color-mint"].some((token) =>
     bgClass.includes(token),
-  );
-}
-
-function buildViewerLinkingIssueUrl(input: {
-  isLinked: boolean;
-  hasActiveViewer: boolean;
-}) {
-  const title = "[Linking] Conta logada sem viewer confirmado no chat";
-  const body = [
-    "## O que aconteceu",
-    "O login entrou no site, mas a conta ainda não foi vinculada ao viewer do chat via código.",
-    "",
-    "## Diagnóstico técnico",
-    `- hasActiveViewer: ${input.hasActiveViewer ? "yes" : "no"}`,
-    `- isLinked: ${input.isLinked ? "yes" : "no"}`,
-    `- horário (UTC): ${new Date().toISOString()}`,
-    "",
-    "## O que eu esperava",
-    "- Descreva qual canal deveria ser vinculado e o que apareceu no chat ao usar !link.",
-    "",
-    "## Observações",
-    "- Não inclua token, email privado, cookie nem segredo nesta issue.",
-  ].join("\n");
-
-  const url = new URL(env.NEXT_PUBLIC_GITHUB_ISSUES_URL ?? DEFAULT_GITHUB_ISSUES_URL);
-  url.searchParams.set("title", title);
-  url.searchParams.set("body", body);
-  return url.toString();
-}
-
-function ViewerLinkingNotice({ issueUrl }: { issueUrl: string }) {
-  return (
-    <div className="card-poster mt-6 border-[3px] border-[var(--color-ink)] bg-[var(--color-pink)] p-4 text-[var(--color-accent-ink)]">
-      <p className="mono text-[10px] uppercase tracking-[0.24em]">linking da live</p>
-      <p className="mt-2 text-lg font-black uppercase leading-tight">
-        Falta confirmar seu canal pelo chat.
-      </p>
-      <p className="mt-3 text-sm font-bold leading-6">
-        O login do site entrou, mas o viewer da live agora é vinculado por código no chat do
-        YouTube.
-      </p>
-      <p className="mt-3 text-sm font-medium leading-6">
-        Abra sua área, gere um código curto e envie <span className="font-black">!link CÓDIGO</span>{" "}
-        no chat. Assim eu consigo unir sua conta do site ao viewer que chega pelo Streamer.bot sem
-        depender da API do YouTube.
-      </p>
-      <div className="mt-4 flex flex-wrap gap-3">
-        <Link
-          href="/me"
-          className="btn-brutal bg-[var(--color-paper)] px-4 py-2 text-xs text-[var(--color-ink)]"
-        >
-          Abrir minha área
-        </Link>
-        <a
-          href={issueUrl}
-          target="_blank"
-          rel="noreferrer"
-          className="btn-brutal bg-[var(--color-paper)] px-4 py-2 text-xs text-[var(--color-ink)]"
-        >
-          Abrir issue no GitHub {"->"}
-        </a>
-      </div>
-    </div>
   );
 }
 
@@ -747,14 +681,6 @@ export default async function Home({ searchParams }: HomePageProps) {
     : "Esse painel e o cantinho da minha live para o chat apostar, resgatar e acompanhar o ranking.";
 
   const metrics = hasUsableSession ? authedMetrics : publicMetrics;
-  const shouldShowViewerLinkingNotice = Boolean(hasUsableSession && !session?.user?.isLinked);
-  const viewerLinkingIssueUrl = shouldShowViewerLinkingNotice
-    ? buildViewerLinkingIssueUrl({
-        isLinked: Boolean(session?.user?.isLinked),
-        hasActiveViewer: Boolean(session?.user?.activeViewerId),
-      })
-    : null;
-
   return (
     <div className="flex w-full flex-col pb-20">
       <section className="landing-plane surface-hero relative py-8 sm:py-10 lg:py-12">
@@ -788,10 +714,6 @@ export default async function Home({ searchParams }: HomePageProps) {
             </p>
 
             {accountProtectionStatus ? <AccountProtectionNotice status={accountProtectionStatus} /> : null}
-
-            {shouldShowViewerLinkingNotice ? (
-              <ViewerLinkingNotice issueUrl={viewerLinkingIssueUrl!} />
-            ) : null}
 
             <div className="mt-8 flex flex-wrap items-center gap-3">
               {hasUsableSession ? (

--- a/src/components/app-chrome.tsx
+++ b/src/components/app-chrome.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import type { Session } from "next-auth";
 import { useEffect, useState } from "react";
-import { ChevronDown } from "lucide-react";
+import { AlertTriangle, ChevronDown } from "lucide-react";
 
 import { AuthButtons } from "@/components/auth-buttons";
 import { LivestreamIndicator } from "@/components/livestream-indicator";
@@ -29,12 +29,14 @@ export function AppChrome({
   isAdmin = false,
   isLive = false,
   session,
+  showViewerLinkingAlert = false,
 }: {
   children: React.ReactNode;
   initialTheme?: ThemeMode | null;
   isAdmin?: boolean;
   isLive?: boolean;
   session: Session | null;
+  showViewerLinkingAlert?: boolean;
 }) {
   const [mobileOpen, setMobileOpen] = useState(false);
   const pathname = usePathname();
@@ -76,7 +78,7 @@ export function AppChrome({
         { href: "/indicacoes", label: "Canais que me inspiram" },
         { href: "/produtinhos", label: "Produtinhos que indico" },
         { href: "/jogos", label: "Jogos" },
-        { href: "/videos", label: "Videos" },
+        { href: "/videos", label: "Vídeos" },
       ],
     },
     {
@@ -260,6 +262,21 @@ export function AppChrome({
           </div>
         ) : null}
       </header>
+
+      {showViewerLinkingAlert ? (
+        <Link
+          href="/me"
+          className="sticky top-[75px] z-30 border-b-[3px] border-[var(--color-ink)] bg-[var(--color-yellow)] text-[var(--color-accent-ink)] transition-colors hover:bg-[var(--color-mint)] md:top-[78px]"
+        >
+          <span className="mx-auto flex w-full max-w-[1500px] items-center gap-3 px-4 py-3 text-sm font-black uppercase leading-5 sm:px-6 lg:px-10">
+            <AlertTriangle className="h-5 w-5 shrink-0" aria-hidden="true" />
+            <span>
+              Vincule seu canal do YouTube para interagir com a live. Veja o passo a passo na sua
+              página.
+            </span>
+          </span>
+        </Link>
+      ) : null}
 
       {showTicker ? (
         <div className="marquee-strip" aria-hidden="true">

--- a/src/components/viewer-link-card.tsx
+++ b/src/components/viewer-link-card.tsx
@@ -1,4 +1,4 @@
-﻿"use client";
+"use client";
 
 import { useEffect, useState, useTransition } from "react";
 
@@ -23,7 +23,7 @@ function formatExpiry(value: string) {
   }).format(new Date(value));
 }
 
-export function ViewerLinkCard({ isLinked }: { isLinked: boolean }) {
+export function ViewerLinkCard() {
   const [link, setLink] = useState<ViewerLinkPayload | null>(null);
   const [feedback, setFeedback] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -90,15 +90,15 @@ export function ViewerLinkCard({ isLinked }: { isLinked: boolean }) {
       <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
         <div className="card-brutal-static bg-[var(--color-paper)] p-6 sm:p-8">
           <p className="mono text-[10px] uppercase tracking-[0.28em] text-[var(--color-ink-soft)]">
-            Vinculo da live
+            Vínculo da live
           </p>
           <h2 className="mt-3 text-3xl uppercase" style={{ fontFamily: "var(--font-display)" }}>
-            {isLinked ? "Seu canal já está vinculado." : "Conecte sua conta do chat."}
+            Vincule seu canal do YouTube.
           </h2>
           <p className="mt-4 max-w-3xl text-sm leading-7 text-[var(--color-ink-soft)] sm:text-base">
-            O login entra no site, mas o viewer da live agora é confirmado pelo chat do YouTube.
-            Gere um código curto e envie <span className="font-black">!link CÓDIGO</span> no chat
-            para provar que essa conta também é sua.
+            Para interagir com a live usando seus pipetz, gere um código aqui durante a live e envie{" "}
+            <span className="font-black">!link CÓDIGO</span> no chat do YouTube. O vínculo só pode
+            ser confirmado enquanto a live está acontecendo.
           </p>
 
           <div className="mt-6 grid gap-4 lg:grid-cols-[1fr_auto] lg:items-center">
@@ -133,7 +133,7 @@ export function ViewerLinkCard({ isLinked }: { isLinked: boolean }) {
               1. Entre no site com o login que você preferir.
             </div>
             <div className="card-flat bg-[var(--color-yellow)] p-4 text-[var(--color-accent-ink)]">
-              2. Gere o código e mande <span className="font-black">!link CÓDIGO</span> no chat.
+              2. Durante a live, gere o código e mande <span className="font-black">!link CÓDIGO</span> no chat.
             </div>
             <div className="card-flat bg-[var(--color-pink)] p-4 text-[var(--color-accent-ink)]">
               3. O bot vincula seu viewer e seu saldo passa a seguir esse canal.
@@ -144,4 +144,3 @@ export function ViewerLinkCard({ isLinked }: { isLinked: boolean }) {
     </section>
   );
 }
-

--- a/src/lib/api-session.test.ts
+++ b/src/lib/api-session.test.ts
@@ -1,0 +1,61 @@
+import type { Session } from "next-auth";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const authMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/auth", () => ({
+  auth: authMock,
+}));
+
+import { requireLinkedApiSession } from "@/lib/api";
+
+function sessionWithViewer(input: {
+  activeViewerId?: string;
+  isLinked?: boolean;
+}): Session {
+  return {
+    expires: "2099-01-01T00:00:00.000Z",
+    user: {
+      email: "viewer@example.com",
+      activeViewerId: input.activeViewerId,
+      isLinked: input.isLinked,
+    },
+  };
+}
+
+describe("requireLinkedApiSession", () => {
+  beforeEach(() => {
+    authMock.mockReset();
+  });
+
+  it("returns the session when the active viewer is linked", async () => {
+    const session = sessionWithViewer({
+      activeViewerId: "viewer_123",
+      isLinked: true,
+    });
+    authMock.mockResolvedValue(session);
+
+    await expect(requireLinkedApiSession()).resolves.toBe(session);
+  });
+
+  it("rejects a logged-in viewer that has not linked the YouTube channel", async () => {
+    authMock.mockResolvedValue(
+      sessionWithViewer({
+        activeViewerId: "viewer_123",
+        isLinked: false,
+      }),
+    );
+
+    await expect(requireLinkedApiSession()).resolves.toBeNull();
+  });
+
+  it("rejects a session without an active viewer", async () => {
+    authMock.mockResolvedValue(
+      sessionWithViewer({
+        isLinked: true,
+      }),
+    );
+
+    await expect(requireLinkedApiSession()).resolves.toBeNull();
+  });
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -20,6 +20,14 @@ export async function requireApiSession() {
   return session;
 }
 
+export async function requireLinkedApiSession() {
+  const session = await requireApiSession();
+  if (!session?.user?.activeViewerId || !session.user.isLinked) {
+    return null;
+  }
+  return session;
+}
+
 export async function requireAdminApiSession() {
   const session = await requireApiSession();
   if (!session?.user?.email) {

--- a/src/lib/bets/admin.test.ts
+++ b/src/lib/bets/admin.test.ts
@@ -21,7 +21,7 @@ describe("validateCreateBetDraft", () => {
         closesAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
         options: ["1", "2", "3", "4", "5", "6", "7"],
       }),
-    ).toBe("A aposta pode ter no maximo 6 opcoes.");
+    ).toBe("A aposta pode ter no máximo 6 opções.");
   });
 
   it("rejects closing dates in the past", () => {
@@ -31,7 +31,7 @@ describe("validateCreateBetDraft", () => {
         closesAt: new Date(Date.now() - 60 * 1000).toISOString(),
         options: ["Sim", "Nao"],
       }),
-    ).toBe("Escolha um horario futuro para encerrar a aposta.");
+    ).toBe("Escolha um horário futuro para encerrar a aposta.");
   });
 });
 


### PR DESCRIPTION
## Summary

- Hide the YouTube linking flow from viewers whose channel is already linked.
- Show a fixed global alert for logged-in viewers who still need to link their YouTube channel, pointing them to `/me`.
- Require linked viewer sessions for live interaction API routes while keeping link-code generation available.
- Replace the old home-page GitHub issue guidance with direct in-app guidance.

## Validation

- `npm.cmd test`
- `npm.cmd run build`

Closes #65