### PR TITLE
[codex] Add social links, terms, and active bet overlay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "next-auth": "^5.0.0-beta.30",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "react-icons": "^5.6.0",
         "shadcn": "^4.1.2",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
@@ -10381,6 +10382,15 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
+      "integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "next-auth": "^5.0.0-beta.30",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-icons": "^5.6.0",
     "shadcn": "^4.1.2",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",

--- a/src/app/(public)/apostas/page.tsx
+++ b/src/app/(public)/apostas/page.tsx
@@ -14,7 +14,7 @@ export default async function ApostasPage() {
   const canBet = Boolean(activeViewerId && dashboard?.viewer.isLinked);
 
   return (
-    <div className="flex w-full flex-col pb-20">
+    <div className="flex w-full flex-col">
       <section className="landing-plane surface-hero relative overflow-hidden py-8 sm:py-10">
         <div className="bg-dots-light pointer-events-none absolute inset-0 opacity-20" />
         <div className="relative mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">

--- a/src/app/(public)/contadores/page.tsx
+++ b/src/app/(public)/contadores/page.tsx
@@ -5,7 +5,7 @@ export default async function ContadoresPage() {
   const counters = await listStreamerbotCounters();
 
   return (
-    <div className="flex w-full flex-col pb-20">
+    <div className="flex w-full flex-col">
       <section className="landing-plane surface-hero relative overflow-hidden py-8 sm:py-10">
         <div className="bg-dots-light pointer-events-none absolute inset-0 opacity-15" />
         <div className="relative mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">

--- a/src/app/(public)/indicacoes/page.tsx
+++ b/src/app/(public)/indicacoes/page.tsx
@@ -94,7 +94,7 @@ export default async function IndicacoesPage() {
   const canInteract = Boolean(activeViewerId && dashboard?.viewer.isLinked);
 
   return (
-    <div className="flex w-full flex-col pb-20">
+    <div className="flex w-full flex-col">
       <section className="landing-plane surface-hero relative overflow-hidden py-8 sm:py-10">
         <div className="bg-dots-light pointer-events-none absolute inset-0 opacity-20" />
         <div className="relative mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">

--- a/src/app/(public)/jogos/page.tsx
+++ b/src/app/(public)/jogos/page.tsx
@@ -18,7 +18,7 @@ export default async function JogosPage() {
   const isAdmin = Boolean(session?.user?.email && adminEmails.has(session.user.email.toLowerCase()));
 
   return (
-    <div className="flex w-full flex-col pb-20">
+    <div className="flex w-full flex-col">
       <section className="landing-plane surface-hero relative overflow-hidden py-8 sm:py-10">
         <div className="bg-dots-light pointer-events-none absolute inset-0 opacity-20" />
         <div className="relative mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">

--- a/src/app/(public)/produtinhos/page.tsx
+++ b/src/app/(public)/produtinhos/page.tsx
@@ -17,7 +17,7 @@ export default async function ProdutinhosPage() {
   );
 
   return (
-    <div className="flex w-full flex-col pb-20">
+    <div className="flex w-full flex-col">
       <section className="landing-plane surface-hero relative overflow-hidden py-8 sm:py-10">
         <div className="bg-dots-light pointer-events-none absolute inset-0 opacity-20" />
         <div className="relative mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">

--- a/src/app/(public)/quotes/page.tsx
+++ b/src/app/(public)/quotes/page.tsx
@@ -35,7 +35,7 @@ export default async function QuotesPage() {
   const canShowOnOverlay = Boolean(activeViewerId && dashboard?.viewer.isLinked);
 
   return (
-    <div className="flex w-full flex-col pb-20">
+    <div className="flex w-full flex-col">
       <section className="landing-plane surface-hero relative overflow-hidden py-8 sm:py-10">
         <div className="bg-dots-light pointer-events-none absolute inset-0 opacity-20" />
         <div className="relative mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">

--- a/src/app/(public)/ranking/page.tsx
+++ b/src/app/(public)/ranking/page.tsx
@@ -5,7 +5,7 @@ export default async function RankingPage() {
   const leaderboard = await getLeaderboard();
 
   return (
-    <div className="flex w-full flex-col pb-20">
+    <div className="flex w-full flex-col">
       <section className="landing-plane surface-hero relative overflow-hidden py-8 sm:py-10">
         <div className="bg-dots-light pointer-events-none absolute inset-0 opacity-15" />
         <div className="relative mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">

--- a/src/app/(public)/videos/page.tsx
+++ b/src/app/(public)/videos/page.tsx
@@ -19,7 +19,7 @@ export default async function VideosPage() {
   const canInteract = Boolean(activeViewerId && dashboard?.viewer.isLinked);
 
   return (
-    <div className="flex w-full flex-col pb-20">
+    <div className="flex w-full flex-col">
       <section className="landing-plane surface-hero relative overflow-hidden py-8 sm:py-10">
         <div className="bg-dots-light pointer-events-none absolute inset-0 opacity-20" />
         <div className="relative mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">

--- a/src/app/(viewer)/me/page.tsx
+++ b/src/app/(viewer)/me/page.tsx
@@ -21,7 +21,7 @@ export default async function MePage() {
   }
 
   return (
-    <div className="flex w-full flex-col pb-20">
+    <div className="flex w-full flex-col">
       {/* Balance hero */}
       <PipetzBalanceCard
         displayName={dashboard.viewer.youtubeDisplayName}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -59,7 +59,7 @@ export default async function AdminPage() {
   ]);
 
   return (
-    <div className="flex w-full flex-col pb-20">
+    <div className="flex w-full flex-col">
       <section className="landing-plane surface-hero py-8 sm:py-10">
         <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
           <p className="mono text-xs font-bold uppercase tracking-[0.32em] text-[var(--color-ink-soft)]">

--- a/src/app/api/obs/bets/current/route.ts
+++ b/src/app/api/obs/bets/current/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+
+import { listBets } from "@/lib/db/repository";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const now = Date.now();
+  const bets = await listBets();
+  const activeBet =
+    bets
+      .filter(
+        (bet) =>
+          bet.status === "open" &&
+          new Date(bet.closesAt).getTime() > now,
+      )
+      .sort((left, right) => new Date(right.openedAt ?? right.createdAt).getTime() - new Date(left.openedAt ?? left.createdAt).getTime())[0] ??
+    null;
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: activeBet,
+    },
+    {
+      headers: {
+        "Cache-Control": "no-store, max-age=0, must-revalidate",
+      },
+    },
+  );
+}

--- a/src/app/obs/bets/page.tsx
+++ b/src/app/obs/bets/page.tsx
@@ -1,0 +1,5 @@
+import { ObsBetOverlay } from "@/components/obs-bet-overlay";
+
+export default function ObsBetsPage() {
+  return <ObsBetOverlay />;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -685,7 +685,7 @@ export default async function Home({ searchParams }: HomePageProps) {
 
   const metrics = hasUsableSession ? authedMetrics : publicMetrics;
   return (
-    <div className="flex w-full flex-col pb-20">
+    <div className="flex w-full flex-col">
       <section className="landing-plane surface-hero relative py-8 sm:py-10 lg:py-12">
         <div className="bg-micro-grid pointer-events-none absolute inset-0 opacity-30" />
         <StickerBadge

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -74,7 +74,7 @@ const sections: PolicySection[] = [
 
 export default function PrivacyPage() {
   return (
-    <div className="mx-auto flex w-full max-w-[980px] flex-col gap-6 px-4 pb-20 sm:px-6 lg:px-8">
+    <div className="mx-auto flex w-full max-w-[980px] flex-col gap-6 px-4 sm:px-6 lg:px-8">
       <section className="panel surface-hero p-6 sm:p-8">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div>

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,158 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Termos de Serviço | Pipetz",
+  description:
+    "Regras básicas de uso do Pipetz, incluindo apostas, resgates, indicações, conteúdos externos e disponibilidade da plataforma.",
+};
+
+const LAST_UPDATED = "2026-05-20";
+const SUPPORT_EMAIL = "ludmila.omlopes@gmail.com";
+
+type TermsSection = {
+  title: string;
+  body: string[];
+};
+
+const sections: TermsSection[] = [
+  {
+    title: "Resumo",
+    body: [
+      "O Pipetz é um site de apoio à comunidade da live da Ludylops. Ele reúne ranking, apostas, resgates, indicações, sugestões e integrações usadas durante as transmissões.",
+      "Ao usar o site, você concorda em participar de forma respeitosa, seguir as regras da comunidade e entender que recursos da live podem mudar, pausar ou ficar indisponíveis.",
+    ],
+  },
+  {
+    title: "Uso aceitável",
+    body: [
+      "Você não deve usar o site para assediar pessoas, publicar conteúdo ilegal, tentar burlar regras de pontuação, explorar falhas técnicas ou prejudicar a experiência de outros viewers.",
+      "A Ludylops pode moderar, remover, cancelar ou ajustar interações quando houver abuso, erro técnico, tentativa de fraude ou necessidade de manter a live funcionando bem.",
+    ],
+  },
+  {
+    title: "Pipetz, apostas e resgates",
+    body: [
+      "Pipetz são pontos de comunidade usados dentro da experiência da live. Eles não representam dinheiro, crédito financeiro, prêmio garantido ou direito de saque.",
+      "Apostas, resgates e efeitos dependem das regras exibidas no site, do estado da live e das integrações disponíveis no momento. Em caso de erro, a equipe pode cancelar, reembolsar pontos ou corrigir saldos.",
+    ],
+  },
+  {
+    title: "Conteúdos, indicações e links externos",
+    body: [
+      "Sugestões de jogos, vídeos, canais, produtos e demais indicações podem incluir conteúdo de terceiros. Esses conteúdos seguem as regras e políticas dos serviços externos onde são publicados.",
+      "Links externos podem direcionar para plataformas fora do controle do Pipetz. Antes de comprar, assistir, baixar ou interagir fora do site, confira as condições, privacidade e segurança do serviço de destino.",
+    ],
+  },
+  {
+    title: "Propriedade intelectual",
+    body: [
+      "Textos, identidade visual, organização da experiência e elementos próprios do Pipetz pertencem aos seus respectivos titulares.",
+      "Ao enviar sugestões, mensagens ou conteúdos pela plataforma, você declara ter permissão para compartilhar esse material e autoriza seu uso no contexto da comunidade e da live.",
+    ],
+  },
+  {
+    title: "Disponibilidade e integrações",
+    body: [
+      "O site pode depender de serviços como Google, YouTube, banco de dados, hospedagem, OBS e Streamer.bot. Instabilidades nesses serviços podem afetar login, ranking, apostas, overlays e resgates.",
+      "O Pipetz é oferecido no estado em que se encontra, sem garantia de disponibilidade contínua, ausência de erros ou compatibilidade permanente com todas as integrações.",
+    ],
+  },
+  {
+    title: "Alterações e contato",
+    body: [
+      "Estes termos podem ser atualizados para refletir novas funcionalidades, mudanças na operação da live ou ajustes legais e técnicos.",
+      `Para dúvidas sobre estes termos, entre em contato pelo email de suporte: ${SUPPORT_EMAIL}.`,
+      "Este texto não substitui revisão jurídica. Caso o site passe a lidar com pagamentos, dados sensíveis ou obrigações comerciais específicas, os termos devem ser revisados com orientação adequada.",
+    ],
+  },
+];
+
+export default function TermsPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-[980px] flex-col gap-6 px-4 sm:px-6 lg:px-8">
+      <section className="panel surface-hero p-6 sm:p-8">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <span className="retro-label accent-chip">documento público</span>
+            <h1
+              className="mt-4 text-4xl uppercase leading-[0.9] sm:text-5xl"
+              style={{ fontFamily: "var(--font-display)" }}
+            >
+              Termos de serviço
+            </h1>
+            <p className="mt-4 max-w-2xl text-base leading-8 text-[var(--color-ink-soft)]">
+              Regras básicas para usar o Pipetz e participar das experiências da live.
+            </p>
+          </div>
+
+          <div className="card-poster bg-[var(--color-paper)] p-4">
+            <p className="mono text-[10px] uppercase tracking-[0.24em] text-[var(--color-ink-soft)]">
+              última atualização
+            </p>
+            <p className="mt-2 text-lg font-black uppercase">{LAST_UPDATED}</p>
+          </div>
+        </div>
+      </section>
+
+      {sections.map((section, index) => (
+        <section
+          key={section.title}
+          className={`panel p-6 sm:p-8 ${
+            index % 3 === 0
+              ? "bg-[var(--color-paper)]"
+              : index % 3 === 1
+                ? "bg-[var(--color-blue)] text-[var(--color-accent-ink)]"
+                : "bg-[var(--color-mint)] text-[var(--color-accent-ink)]"
+          }`}
+        >
+          <p
+            className={`mono text-[11px] uppercase tracking-[0.24em] ${
+              index % 3 === 0 ? "text-[var(--color-ink-soft)]" : "text-[var(--color-accent-ink-soft)]"
+            }`}
+          >
+            seção {String(index + 1).padStart(2, "0")}
+          </p>
+          <h2
+            className="mt-3 text-3xl uppercase leading-none sm:text-4xl"
+            style={{ fontFamily: "var(--font-display)" }}
+          >
+            {section.title}
+          </h2>
+          <div
+            className={`mt-5 space-y-4 text-sm font-medium leading-7 sm:text-base ${
+              index % 3 === 0 ? "text-[var(--color-ink-soft)]" : "text-[var(--color-accent-ink-soft)]"
+            }`}
+          >
+            {section.body.map((paragraph) => (
+              <p key={paragraph}>{paragraph}</p>
+            ))}
+          </div>
+        </section>
+      ))}
+
+      <section className="panel bg-[var(--color-pink)] p-6 sm:p-8">
+        <p className="mono text-[11px] uppercase tracking-[0.24em] text-[var(--color-accent-ink)]">
+          links úteis
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <Link href="/" className="btn-brutal bg-[var(--color-paper)] px-5 py-3 text-xs text-[var(--color-ink)]">
+            Voltar para a home
+          </Link>
+          <Link
+            href="/privacy"
+            className="btn-brutal bg-[var(--color-mint)] px-5 py-3 text-xs text-[var(--color-accent-ink)]"
+          >
+            Política de privacidade
+          </Link>
+          <a
+            href={`mailto:${SUPPORT_EMAIL}`}
+            className="btn-brutal bg-[var(--color-accent-yellow)] px-5 py-3 text-xs text-[var(--color-accent-ink)]"
+          >
+            Falar por email
+          </a>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/components/admin-obs-overlays-panel.tsx
+++ b/src/components/admin-obs-overlays-panel.tsx
@@ -25,6 +25,14 @@ const overlays = [
     demoHref: "/obs/quotes?demo=1",
     apiHref: "/api/obs/quotes/current",
   },
+  {
+    id: "bets",
+    name: "Apostas no OBS",
+    description: "Overlay da aposta aberta, com pool, opções e distribuição dos votos atualizados automaticamente.",
+    liveHref: "/obs/bets",
+    demoHref: "/obs/bets?demo=1",
+    apiHref: "/api/obs/bets/current",
+  },
 ];
 
 export function AdminObsOverlaysPanel({
@@ -116,8 +124,8 @@ export function AdminObsOverlaysPanel({
                 </span>
               </div>
               <p className="mt-3 text-sm leading-6 text-[var(--color-ink-soft)]">
-                Quando pausado, novas quotes pagas entram em fila FIFO. A fila aceita ate 20 itens e
-                cada item expira em 2 horas com reembolso automatico se nao for exibido.
+                Quando pausado, novas quotes pagas entram em fila FIFO. A fila aceita até 20 itens e
+                cada item expira em 2 horas com reembolso automático se não for exibido.
               </p>
               {status.control.lastError ? (
                 <p className="mt-3 border-2 border-[var(--color-ink)] bg-[var(--color-rose)] px-3 py-2 text-sm font-black text-[var(--color-ink)]">

--- a/src/components/app-chrome.tsx
+++ b/src/components/app-chrome.tsx
@@ -12,6 +12,7 @@ import { hasUsableAppSession } from "@/lib/auth/session-state";
 import type { ThemeMode } from "@/lib/theme";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
+import { socialLinks } from "@/lib/social-links";
 
 type NavLink = {
   href: string;
@@ -299,19 +300,39 @@ export function AppChrome({
       <main className="flex-1">{children}</main>
 
       <footer className="border-t-[3px] border-[var(--color-ink)] bg-[var(--color-paper)]">
-        <div className="mx-auto flex w-full max-w-[1500px] flex-col gap-3 px-4 py-5 text-sm font-medium text-[var(--color-ink-soft)] sm:px-6 lg:flex-row lg:items-center lg:justify-between lg:px-10">
+        <div className="mx-auto flex w-full max-w-[1500px] flex-col gap-4 px-4 py-5 text-sm font-medium text-[var(--color-ink-soft)] sm:px-6 lg:flex-row lg:items-center lg:justify-between lg:px-10">
           <Link
             href="/privacy"
             className="w-fit font-black uppercase tracking-[0.08em] text-[var(--color-ink)] underline decoration-[3px] underline-offset-4"
           >
             Política de Privacidade
           </Link>
-          <p className="flex items-center gap-2 text-[var(--color-ink)]">
-            <span>Feito com carinho por ludylops</span>
-            <span aria-hidden="true" className="text-lg text-[var(--color-pink)]">
-              💗
+          <Link
+            href="/terms"
+            className="w-fit font-black uppercase tracking-[0.08em] text-[var(--color-ink)] underline decoration-[3px] underline-offset-4"
+          >
+            Termos de Serviço
+          </Link>
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="font-black uppercase tracking-[0.08em] text-[var(--color-ink)]">
+              Siga a Ludylops
             </span>
-          </p>
+            <div className="flex items-center gap-2">
+              {socialLinks.map(({ href, label, Icon }) => (
+                <a
+                  key={href}
+                  href={href}
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label={`Abrir ${label} da Ludylops`}
+                  title={label}
+                  className="flex size-10 items-center justify-center border-[2px] border-[var(--color-ink)] bg-[var(--color-paper)] text-[var(--color-ink)] shadow-[3px_3px_0_var(--shadow-color)] transition-transform hover:-translate-y-0.5"
+                >
+                  <Icon className="size-5" aria-hidden="true" />
+                </a>
+              ))}
+            </div>
+          </div>
         </div>
       </footer>
     </div>

--- a/src/components/obs-bet-overlay.tsx
+++ b/src/components/obs-bet-overlay.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import type { BetWithOptionsRecord } from "@/lib/types";
+import { formatPipetz } from "@/lib/utils";
+
+const DEMO_BET: BetWithOptionsRecord = {
+  id: "demo-bet",
+  question: "Ela passa o boss sem morrer?",
+  status: "open",
+  openedAt: "2026-05-20T18:00:00.000Z",
+  closesAt: "2026-05-20T19:00:00.000Z",
+  lockedAt: null,
+  resolvedAt: null,
+  cancelledAt: null,
+  winningOptionId: null,
+  createdAt: "2026-05-20T18:00:00.000Z",
+  totalPool: 1250,
+  options: [
+    { id: "yes", betId: "demo-bet", label: "Sim", sortOrder: 0, poolAmount: 800 },
+    { id: "no", betId: "demo-bet", label: "Não", sortOrder: 1, poolAmount: 450 },
+  ],
+  viewerPosition: null,
+};
+
+function formatRemaining(closesAt: string, now: number) {
+  const remainingMs = Math.max(new Date(closesAt).getTime() - now, 0);
+  const totalSeconds = Math.floor(remainingMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
+
+export function ObsBetOverlay() {
+  const searchParams = useSearchParams();
+  const isDemo = searchParams.get("demo") === "1";
+  const [liveBet, setLiveBet] = useState<BetWithOptionsRecord | null>(null);
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (isDemo) {
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    async function loadBet() {
+      try {
+        const response = await fetch("/api/obs/bets/current", {
+          cache: "no-store",
+        });
+
+        if (!response.ok) {
+          return;
+        }
+
+        const payload = (await response.json()) as {
+          ok: boolean;
+          data: BetWithOptionsRecord | null;
+        };
+
+        if (!cancelled) {
+          setLiveBet(payload.data ?? null);
+        }
+      } catch {
+        if (!cancelled) {
+          setLiveBet(null);
+        }
+      }
+    }
+
+    void loadBet();
+    const interval = window.setInterval(() => {
+      void loadBet();
+    }, 1000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [isDemo]);
+
+  useEffect(() => {
+    const interval = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(interval);
+  }, []);
+
+  const bet = isDemo ? DEMO_BET : liveBet;
+  const totalPool = bet?.totalPool ?? 0;
+  const remaining = bet ? formatRemaining(bet.closesAt, now) : "00:00";
+
+  return (
+    <div className="pointer-events-none flex min-h-screen items-end justify-center p-6 sm:p-10 lg:p-14">
+      {bet ? (
+        <section
+          key={bet.id}
+          className="relative w-full max-w-[980px] overflow-hidden border-[4px] border-black bg-[#fff6db] text-black shadow-[12px_12px_0_#000]"
+          aria-live="polite"
+        >
+          <div className="absolute inset-0 opacity-25">
+            <div className="h-full w-full bg-[radial-gradient(circle_at_18%_22%,#ff66b3_0,transparent_24%),radial-gradient(circle_at_78%_28%,#41d1ff_0,transparent_20%),radial-gradient(circle_at_55%_82%,#00beae_0,transparent_22%)]" />
+          </div>
+          <div className="absolute inset-x-0 top-0 h-5 border-b-[4px] border-black bg-[repeating-linear-gradient(90deg,#000_0_28px,#ff66b3_28px_56px,#41d1ff_56px_84px,#00beae_84px_112px)]" />
+          <div className="relative flex flex-col gap-6 px-6 pb-6 pt-10 sm:px-10 sm:pb-10 sm:pt-12">
+            <div className="flex flex-wrap items-center justify-between gap-3 text-[11px] font-black uppercase tracking-[0.22em] sm:text-xs">
+              <div className="flex flex-wrap items-center gap-3">
+                <span className="border-[3px] border-black bg-black px-3 py-1 text-white">
+                  Aposta aberta
+                </span>
+                <span className="border-[3px] border-black bg-[#00beae] px-3 py-1">
+                  pool {formatPipetz(totalPool)} pipetz
+                </span>
+              </div>
+              <span className="border-[3px] border-black bg-[#ff66b3] px-3 py-1">
+                fecha em {remaining}
+              </span>
+            </div>
+
+            <h1
+              className="max-w-[22ch] text-[2rem] font-black uppercase leading-[0.94] sm:text-[3rem] lg:text-[4rem]"
+              style={{ fontFamily: "var(--font-display)" }}
+            >
+              {bet.question}
+            </h1>
+
+            <div className="grid gap-3">
+              {bet.options.map((option, index) => {
+                const percentage = totalPool > 0 ? Math.round((option.poolAmount / totalPool) * 100) : 0;
+                return (
+                  <div key={option.id} className="border-[3px] border-black bg-white">
+                    <div className="relative min-h-16 overflow-hidden">
+                      <div
+                        className="absolute inset-y-0 left-0 bg-[#41d1ff]"
+                        style={{ width: `${Math.max(percentage, totalPool > 0 ? 4 : 0)}%` }}
+                      />
+                      <div className="relative flex items-center justify-between gap-4 px-4 py-3 text-lg font-black uppercase sm:text-2xl">
+                        <span>
+                          {index + 1}. {option.label}
+                        </span>
+                        <span className="shrink-0 text-right">
+                          {percentage}% · {formatPipetz(option.poolAmount)}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/social-links.ts
+++ b/src/lib/social-links.ts
@@ -1,0 +1,40 @@
+import { FaBluesky, FaGithub, FaInstagram, FaThreads, FaXTwitter, FaYoutube } from "react-icons/fa6";
+import { TbWorld } from "react-icons/tb";
+
+export const socialLinks = [
+  {
+    label: "YouTube",
+    href: "https://www.youtube.com/@ludylopsgames",
+    Icon: FaYoutube,
+  },
+  {
+    label: "Twitter",
+    href: "https://twitter.com/ludylops",
+    Icon: FaXTwitter,
+  },
+  {
+    label: "Threads",
+    href: "https://www.threads.net/@ludylops",
+    Icon: FaThreads,
+  },
+  {
+    label: "Instagram",
+    href: "https://www.instagram.com/ludylops",
+    Icon: FaInstagram,
+  },
+  {
+    label: "Bluesky",
+    href: "https://bsky.app/profile/ludylops.bsky.social",
+    Icon: FaBluesky,
+  },
+  {
+    label: "Site pessoal",
+    href: "https://ludylops.com",
+    Icon: TbWorld,
+  },
+  {
+    label: "GitHub",
+    href: "https://github.com/ludmila-omlopes",
+    Icon: FaGithub,
+  },
+] as const;

--- a/src/lib/streamerbot/death-counter-game.test.ts
+++ b/src/lib/streamerbot/death-counter-game.test.ts
@@ -17,9 +17,9 @@ describe("active death counter game config", () => {
   });
 
   it("stores and clears the active game in demo mode", async () => {
-    const module = await import("@/lib/streamerbot/death-counter-game");
+    const deathCounterGame = await import("@/lib/streamerbot/death-counter-game");
 
-    const saved = await module.setActiveDeathCounterGame({
+    const saved = await deathCounterGame.setActiveDeathCounterGame({
       gameName: "Hollow Knight: Silksong",
       updatedBy: "admin@example.com",
     });
@@ -31,13 +31,13 @@ describe("active death counter game config", () => {
       updatedBy: "admin@example.com",
     });
 
-    await expect(module.getActiveDeathCounterGame()).resolves.toMatchObject({
+    await expect(deathCounterGame.getActiveDeathCounterGame()).resolves.toMatchObject({
       scopeKey: "hollow-knight-silksong",
       scopeLabel: "Hollow Knight: Silksong",
     });
 
-    await expect(module.clearActiveDeathCounterGame()).resolves.toBeNull();
-    await expect(module.getActiveDeathCounterGame()).resolves.toBeNull();
+    await expect(deathCounterGame.clearActiveDeathCounterGame()).resolves.toBeNull();
+    await expect(deathCounterGame.getActiveDeathCounterGame()).resolves.toBeNull();
   });
 
   it("reads the active game from streamerbot_counters in database mode", async () => {
@@ -61,9 +61,9 @@ describe("active death counter game config", () => {
       }),
     });
 
-    const module = await import("@/lib/streamerbot/death-counter-game");
+    const deathCounterGame = await import("@/lib/streamerbot/death-counter-game");
 
-    await expect(module.getActiveDeathCounterGame()).resolves.toEqual({
+    await expect(deathCounterGame.getActiveDeathCounterGame()).resolves.toEqual({
       scopeType: "game",
       scopeKey: "silksong",
       scopeLabel: "Silksong",


### PR DESCRIPTION
## Summary

- Adds centralized social media links with real brand icons, including YouTube, Twitter/X, Threads, Instagram, Bluesky, personal website, and GitHub.
- Adds a public Terms of Service page and links it from the global footer.
- Adds an OBS browser source for the currently open bet at `/obs/bets`, backed by a no-cache polling API at `/api/obs/bets/current`.
- Adds the bet overlay to the admin OBS overlays panel and removes final page padding that created a white strip before the footer.
- Seeds 22 Ludylops product recommendations from Mercado Livre, AliExpress, Westwing, and Amazon affiliate/external links.

## Impact

Viewers can find Ludylops' social profiles from a consistent global footer, legal navigation now includes Terms of Service, OBS can show the active bet automatically as long as `/obs/bets` is loaded as a browser source, and the produtinhos page has the recommended products available after migrations run.

## Validation

- `npm run lint` passes with one existing warning in `src/components/admin-dashboard-tabs.tsx` about `aria-pressed` on `role="tab"`.
- `npm test` passes: 166 tests.
- `npm run build` passes.

Closes #17
Closes #89
Closes #90