### PR TITLE
[codex] Use current game for death counters

### DIFF
--- a/src/app/(public)/contadores/page.tsx
+++ b/src/app/(public)/contadores/page.tsx
@@ -1,8 +1,14 @@
 import { CounterBoard } from "@/components/counter-board";
+import { getCurrentGame } from "@/lib/current-game";
 import { listStreamerbotCounters } from "@/lib/db/repository";
+import { slugify } from "@/lib/utils";
 
 export default async function ContadoresPage() {
-  const counters = await listStreamerbotCounters();
+  const [counters, currentGame] = await Promise.all([
+    listStreamerbotCounters(),
+    getCurrentGame(),
+  ]);
+  const currentGameScopeKey = currentGame ? slugify(currentGame.name) || String(currentGame.igdbId) : null;
 
   return (
     <div className="flex w-full flex-col">
@@ -17,7 +23,7 @@ export default async function ContadoresPage() {
               Contadores da live.
             </h1>
             <p className="mt-4 max-w-3xl text-sm leading-7 text-[var(--color-ink-soft)] sm:text-base">
-              Aqui ficam os totais globais e os contadores por jogo que o chat e o Streamer.bot estao mexendo ao vivo.
+              Aqui ficam os totais globais e os contadores por jogo que o chat e o Streamer.bot estão mexendo ao vivo.
             </p>
           </div>
         </div>
@@ -25,7 +31,7 @@ export default async function ContadoresPage() {
 
       <section className="landing-plane landing-divider bg-[var(--color-paper-pink)] py-8 sm:py-10">
         <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
-          <CounterBoard counters={counters} />
+          <CounterBoard counters={counters} currentScopeKey={currentGameScopeKey} />
         </div>
       </section>
     </div>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -2,7 +2,6 @@ import { AdminObsOverlaysPanel } from "@/components/admin-obs-overlays-panel";
 import { AdminCurrentGamePanel } from "@/components/admin-current-game-panel";
 import { AdminDashboardTabs } from "@/components/admin-dashboard-tabs";
 import { AdminBetsPanel } from "@/components/admin-bets-panel";
-import { DeathCounterGamePanel } from "@/components/death-counter-game-panel";
 import { AdminGameSuggestionsPanel } from "@/components/admin-game-suggestions-panel";
 import { AdminVideoSuggestionsPanel } from "@/components/admin-video-suggestions-panel";
 import { AdminPipetzPricingPanel } from "@/components/admin-pipetz-pricing-panel";
@@ -27,7 +26,6 @@ import {
   listAdminRedemptions,
 } from "@/lib/db/repository";
 import { getStreamerbotLivestreamStatus } from "@/lib/streamerbot/live-status";
-import { getActiveDeathCounterGame } from "@/lib/streamerbot/death-counter-game";
 import { getCurrentGame } from "@/lib/current-game";
 import { formatDateTime, formatPipetz } from "@/lib/utils";
 
@@ -41,12 +39,11 @@ const statusColorMap: Record<string, string> = {
 
 export default async function AdminPage() {
   await requireAdminSession();
-  const [catalog, leaderboard, bridge, liveStatus, activeDeathCounterGame, currentGame, redemptions, bets, suggestions, videoSuggestions, recommendations, viewers, obsOverlayStatus, pricing] = await Promise.all([
+  const [catalog, leaderboard, bridge, liveStatus, currentGame, redemptions, bets, suggestions, videoSuggestions, recommendations, viewers, obsOverlayStatus, pricing] = await Promise.all([
     getCatalog(),
     getLeaderboard(),
     getBridgeStatus(),
     getStreamerbotLivestreamStatus(),
-    getActiveDeathCounterGame(),
     getCurrentGame(),
     listAdminRedemptions(),
     listAdminBets(),
@@ -107,7 +104,6 @@ export default async function AdminPage() {
                 <div className="space-y-6">
                   <LiveStatusPanel bridge={bridge} initialStatus={liveStatus} />
                   <AdminCurrentGamePanel initialGame={currentGame} />
-                  <DeathCounterGamePanel initialGame={activeDeathCounterGame} />
                   <AdminPipetzPricingPanel initialPricing={pricing} />
                 </div>
                 <AdminObsOverlaysPanel initialStatus={obsOverlayStatus} />

--- a/src/components/counter-board.tsx
+++ b/src/components/counter-board.tsx
@@ -32,7 +32,47 @@ function CounterCard({ counter }: { counter: StreamerbotCounterSummaryRecord }) 
   );
 }
 
-export function CounterBoard({ counters }: { counters: StreamerbotCounterSummaryRecord[] }) {
+function GameCounterGroup({
+  scopeKey,
+  entries,
+  current,
+}: {
+  scopeKey: string;
+  entries: StreamerbotCounterSummaryRecord[];
+  current?: boolean;
+}) {
+  return (
+    <div className="landing-plane h-full bg-[var(--color-paper-pink)] p-5 sm:p-6">
+      <div className="mb-5 flex flex-wrap items-center gap-3">
+        <h3
+          className="text-3xl uppercase leading-none"
+          style={{ fontFamily: "var(--font-display)" }}
+        >
+          {scopeHeading(scopeKey, entries[0]?.scopeLabel ?? null)}
+        </h3>
+        {current ? (
+          <span className="mono border-2 border-[var(--color-ink)] bg-[var(--color-mint)] px-2 py-1 text-[10px] font-black uppercase tracking-[0.18em]">
+            contador atual
+          </span>
+        ) : null}
+      </div>
+
+      <div className="grid gap-4">
+        {entries.map((counter) => (
+          <CounterCard key={`${counter.scopeType}:${counter.scopeKey}:${counter.key}`} counter={counter} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function CounterBoard({
+  counters,
+  currentScopeKey,
+}: {
+  counters: StreamerbotCounterSummaryRecord[];
+  currentScopeKey?: string | null;
+}) {
   const globalCounters = counters.filter((counter) => counter.scopeType === "global");
   const gameGroups = counters
     .filter((counter) => counter.scopeType === "game")
@@ -42,35 +82,37 @@ export function CounterBoard({ counters }: { counters: StreamerbotCounterSummary
       groups.set(counter.scopeKey, existing);
       return groups;
     }, new Map());
+  const gameGroupEntries = Array.from(gameGroups.entries());
+  const currentGameGroup = currentScopeKey
+    ? gameGroupEntries.find(([scopeKey]) => scopeKey === currentScopeKey)
+    : undefined;
+  const otherGameGroups = currentScopeKey
+    ? gameGroupEntries.filter(([scopeKey]) => scopeKey !== currentScopeKey)
+    : gameGroupEntries;
 
   return (
     <div className="space-y-10">
-      <section>
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
-          {globalCounters.map((counter) => (
-            <CounterCard key={`${counter.scopeType}:${counter.scopeKey}:${counter.key}`} counter={counter} />
-          ))}
-        </div>
-      </section>
+      {currentGameGroup ? (
+        <section>
+          <GameCounterGroup scopeKey={currentGameGroup[0]} entries={currentGameGroup[1]} current />
+        </section>
+      ) : null}
 
-      {gameGroups.size > 0 ? (
+      {globalCounters.length > 0 ? (
+        <section>
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+            {globalCounters.map((counter) => (
+              <CounterCard key={`${counter.scopeType}:${counter.scopeKey}:${counter.key}`} counter={counter} />
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {otherGameGroups.length > 0 ? (
         <section className="space-y-8">
           <div className="grid gap-8 xl:grid-cols-2">
-            {Array.from(gameGroups.entries()).map(([scopeKey, entries]) => (
-              <div key={scopeKey} className="landing-plane h-full bg-[var(--color-paper-pink)] p-5 sm:p-6">
-                <h3
-                  className="mb-5 text-3xl uppercase leading-none"
-                  style={{ fontFamily: "var(--font-display)" }}
-                >
-                  {scopeHeading(scopeKey, entries[0]?.scopeLabel ?? null)}
-                </h3>
-
-                <div className="grid gap-4">
-                  {entries.map((counter) => (
-                    <CounterCard key={`${counter.scopeType}:${counter.scopeKey}:${counter.key}`} counter={counter} />
-                  ))}
-                </div>
-              </div>
+            {otherGameGroups.map(([scopeKey, entries]) => (
+              <GameCounterGroup key={scopeKey} scopeKey={scopeKey} entries={entries} />
             ))}
           </div>
         </section>

--- a/src/lib/db/repository.test.ts
+++ b/src/lib/db/repository.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getDbMock = vi.hoisted(() => vi.fn());
 const isStreamerbotLivestreamActiveMock = vi.hoisted(() => vi.fn());
-const getActiveDeathCounterGameMock = vi.hoisted(() => vi.fn());
+const getCurrentGameMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/db/client", () => ({
   getDb: getDbMock,
@@ -41,8 +41,8 @@ vi.mock("@/lib/streamerbot/live-status", () => ({
   },
 }));
 
-vi.mock("@/lib/streamerbot/death-counter-game", () => ({
-  getActiveDeathCounterGame: getActiveDeathCounterGameMock,
+vi.mock("@/lib/current-game", () => ({
+  getCurrentGame: getCurrentGameMock,
 }));
 
 import { demoBetRecords, demoQuotes } from "@/lib/demo-data";
@@ -718,8 +718,8 @@ describe("listBets", () => {
   beforeEach(() => {
     getDbMock.mockReset();
     delete (globalThis as typeof globalThis & { __lojaDemoStore?: unknown }).__lojaDemoStore;
-    getActiveDeathCounterGameMock.mockReset();
-    getActiveDeathCounterGameMock.mockResolvedValue(null);
+    getCurrentGameMock.mockReset();
+    getCurrentGameMock.mockResolvedValue(null);
   });
 
   it("falls back to demo bets when the bets table query is unavailable", async () => {
@@ -1441,8 +1441,8 @@ describe("showQuoteOverlayForViewer", () => {
 describe("runStreamerbotCounterCommand", () => {
   beforeEach(() => {
     getDbMock.mockReset();
-    getActiveDeathCounterGameMock.mockReset();
-    getActiveDeathCounterGameMock.mockResolvedValue(null);
+    getCurrentGameMock.mockReset();
+    getCurrentGameMock.mockResolvedValue(null);
     delete (globalThis as typeof globalThis & { __lojaDemoStore?: unknown }).__lojaDemoStore;
   });
 
@@ -1749,6 +1749,17 @@ describe("runStreamerbotCounterCommand", () => {
           },
         },
         {
+          key: "current_stream_game",
+          value: 1,
+          lastResetAt: null,
+          updatedAt: new Date("2026-04-07T11:03:00.000Z"),
+          metadata: {
+            igdbId: 103837,
+            name: "Silksong",
+            updatedBy: "admin@example.com",
+          },
+        },
+        {
           key: "death_count",
           value: 154,
           lastResetAt: null,
@@ -1834,13 +1845,16 @@ describe("runStreamerbotCounterCommand", () => {
     expect(rows[0]?.lastResetAt?.toISOString()).toBe("2026-04-07T12:00:00.000Z");
   });
 
-  it("routes death commands to the configured active game when no game scope is provided", async () => {
+  it("routes death commands to the current stream game", async () => {
     const { db, rows } = createStreamerbotCounterDb();
     getDbMock.mockReturnValue(db);
-    getActiveDeathCounterGameMock.mockResolvedValue({
-      scopeType: "game",
-      scopeKey: "silksong",
-      scopeLabel: "Silksong",
+    getCurrentGameMock.mockResolvedValue({
+      igdbId: 103837,
+      name: "Hollow Knight: Silksong",
+      releaseYear: 2025,
+      coverImageUrl: null,
+      platforms: [],
+      genres: [],
       updatedAt: "2026-04-07T10:00:00.000Z",
       updatedBy: "admin@example.com",
     });
@@ -1855,28 +1869,31 @@ describe("runStreamerbotCounterCommand", () => {
       mode: "database",
       action: "increment",
       count: 3,
-      replyMessage: "Mod, contador de mortes em Silksong: 3 (+3).",
+      replyMessage: "Mod, contador de mortes em Hollow Knight: Silksong: 3 (+3).",
     });
     expect(rows[0]).toMatchObject({
-      key: "game::silksong::death_count",
+      key: "game::hollow-knight-silksong::death_count",
       value: 3,
       metadata: {
         counterKey: "death_count",
         counterLabel: "mortes",
         scopeType: "game",
-        scopeKey: "silksong",
-        scopeLabel: "Silksong",
+        scopeKey: "hollow-knight-silksong",
+        scopeLabel: "Hollow Knight: Silksong",
       },
     });
   });
 
-  it("preserves an explicit game scope even when an active game is configured", async () => {
+  it("uses the current stream game even when an explicit game scope is provided", async () => {
     const { db, rows } = createStreamerbotCounterDb();
     getDbMock.mockReturnValue(db);
-    getActiveDeathCounterGameMock.mockResolvedValue({
-      scopeType: "game",
-      scopeKey: "silksong",
-      scopeLabel: "Silksong",
+    getCurrentGameMock.mockResolvedValue({
+      igdbId: 103837,
+      name: "Silksong",
+      releaseYear: 2025,
+      coverImageUrl: null,
+      platforms: [],
+      genres: [],
       updatedAt: "2026-04-07T10:00:00.000Z",
       updatedBy: "admin@example.com",
     });
@@ -1889,8 +1906,8 @@ describe("runStreamerbotCounterCommand", () => {
       amount: 1,
     });
 
-    expect(result.replyMessage).toBe("contador de mortes em Hades 2: 1.");
-    expect(rows[0]?.key).toBe("game::hades_2::death_count");
+    expect(result.replyMessage).toBe("contador de mortes em Silksong: 1.");
+    expect(rows[0]?.key).toBe("game::silksong::death_count");
   });
 });
 

--- a/src/lib/db/repository.ts
+++ b/src/lib/db/repository.ts
@@ -68,7 +68,7 @@ import {
   eventRequiresActiveLivestream,
   requireActiveLivestream,
 } from "@/lib/streamerbot/live-status";
-import { getActiveDeathCounterGame } from "@/lib/streamerbot/death-counter-game";
+import { getCurrentGame } from "@/lib/current-game";
 import { normalizeYoutubeHandle } from "@/lib/youtube/identity";
 import { evaluateRedeemability } from "@/lib/redemptions/service";
 import {
@@ -613,7 +613,11 @@ export async function updatePipetzPricing(input: {
 function sanitizePublicCounterSummaries(
   counters: StreamerbotCounterSummaryRecord[],
 ): StreamerbotCounterSummaryRecord[] {
-  const hiddenCounterKeys = new Set(["livestream_override", "death_counter_active_game"]);
+  const hiddenCounterKeys = new Set([
+    "livestream_override",
+    "death_counter_active_game",
+    "current_stream_game",
+  ]);
 
   return counters
     .filter((counter) => !hiddenCounterKeys.has(counter.key))
@@ -6814,14 +6818,20 @@ export async function runDeathCounterCommand(input: {
   confirmReset?: boolean;
   resetReason?: string | null;
 }) {
-  const hasExplicitGameScope = input.scopeType === "game" && Boolean(input.scopeKey?.trim());
-  const activeGame = hasExplicitGameScope ? null : await getActiveDeathCounterGame();
+  const currentGame = await getCurrentGame();
+  const currentGameScope = currentGame
+    ? {
+        scopeType: "game" as const,
+        scopeKey: slugify(currentGame.name) || String(currentGame.igdbId),
+        scopeLabel: currentGame.name,
+      }
+    : null;
 
   return runStreamerbotCounterCommand({
     ...input,
-    scopeType: hasExplicitGameScope ? input.scopeType : activeGame?.scopeType ?? input.scopeType,
-    scopeKey: hasExplicitGameScope ? input.scopeKey : activeGame?.scopeKey ?? input.scopeKey,
-    scopeLabel: hasExplicitGameScope ? input.scopeLabel : activeGame?.scopeLabel ?? input.scopeLabel,
+    scopeType: currentGameScope?.scopeType ?? input.scopeType,
+    scopeKey: currentGameScope?.scopeKey ?? input.scopeKey,
+    scopeLabel: currentGameScope?.scopeLabel ?? input.scopeLabel,
     counterKey: DEFAULT_DEATH_COUNTER_KEY,
     counterLabel: DEFAULT_DEATH_COUNTER_LABEL,
   });


### PR DESCRIPTION
## What changed

- Removed the separate admin panel for selecting an active death-counter game.
- Death counter commands now resolve their game scope from the admin-configured current stream game.
- Hid the `current_stream_game` technical record from the public counters page.
- Moved the current game's counter group to the top of `/contadores` and marked it as `contador atual`.

## Why

The current stream game should only represent the active channel series on the page, while death counters should always be tied to that admin-defined current game instead of a separate active-game setting.

## Validation

- `npm test -- src/lib/db/repository.test.ts`
- `npm run lint` (passes with the existing `aria-pressed` warning in `src/components/admin-dashboard-tabs.tsx`)