### PR TITLE
[codex] Implementar recompensas da live e aposta da casa

### DIFF
--- a/docs/streamerbot-live-rewards.md
+++ b/docs/streamerbot-live-rewards.md
@@ -1,0 +1,34 @@
+# Recompensas da live pelo Streamer.bot
+
+Esta integração usa `POST /api/internal/streamerbot/events` com HMAC, como os demais eventos do Streamer.bot.
+
+## Inscrição no canal
+
+- Trigger no Streamer.bot: `YouTube > General > New Subscriber`.
+- Observação da documentação oficial: esse trigger depende da integração do StreamElements configurada no Streamer.bot.
+- Payload esperado pelo app:
+  - `eventType`: `channel_subscription`
+  - `viewerExternalId`: ID do canal do YouTube da pessoa inscrita
+  - `youtubeDisplayName`: nome visível, quando disponível
+  - `youtubeHandle`: handle, quando disponível
+  - `occurredAt`: data em ISO
+  - `payload.broadcastId`: opcional
+- Regra de pagamento: 2000 pipetz uma única vez por viewer. Se o Streamer.bot reenviar o evento, o `eventId` evita duplicidade; se outro evento chegar para o mesmo viewer, o app ignora porque já existe ledger `channel_subscription`.
+
+## Metas de likes
+
+- Trigger no Streamer.bot: `YouTube > Broadcast > Statistics Updated`.
+- A variável `likeCount` é usada para comparar com as metas cadastradas no admin.
+- Payload esperado pelo app:
+  - `eventType`: `like_count_update`
+  - `balance` ou `payload.likeCount`: número atual de likes
+  - `payload.broadcastId`: ID da live, usado para garantir que cada meta pague só uma vez por live
+  - `payload.isLive`: `true` quando o evento veio da live monitorada
+  - `occurredAt`: data em ISO
+- Critério de presença: viewers com ledger `presence_tick` nos últimos 5 minutos antes do evento de likes. Esse critério acompanha o comportamento do trigger `YouTube > General > Present Viewers`, que no YouTube funciona como rastreador de atividade do chat e usa 5 minutos como padrão.
+
+Fontes da configuração Streamer.bot:
+
+- https://docs.streamer.bot/api/triggers/youtube/general/new-subscriber
+- https://docs.streamer.bot/api/triggers/youtube/broadcast/statistics-updated
+- https://docs.streamer.bot/api/triggers/youtube/general/present-viewers

--- a/docs/streamerbot-live-rewards.md
+++ b/docs/streamerbot-live-rewards.md
@@ -25,7 +25,7 @@ Esta integração usa `POST /api/internal/streamerbot/events` com HMAC, como os 
   - `payload.broadcastId`: ID da live, usado para garantir que cada meta pague só uma vez por live
   - `payload.isLive`: `true` quando o evento veio da live monitorada
   - `occurredAt`: data em ISO
-- Critério de presença: viewers com ledger `presence_tick` nos últimos 5 minutos antes do evento de likes. Esse critério acompanha o comportamento do trigger `YouTube > General > Present Viewers`, que no YouTube funciona como rastreador de atividade do chat e usa 5 minutos como padrão.
+- Critério de presença: viewers com ledger `presence_tick` na mesma `broadcastId` do evento de likes, desde o início da live até o momento em que a meta bateu.
 
 Fontes da configuração Streamer.bot:
 

--- a/drizzle/0014_real_millenium_guard.sql
+++ b/drizzle/0014_real_millenium_guard.sql
@@ -1,0 +1,26 @@
+ALTER TABLE "bet_entries" ADD COLUMN "is_house_entry" boolean DEFAULT false NOT NULL;
+--> statement-breakpoint
+CREATE TABLE "live_like_goals" (
+	"id" varchar(64) PRIMARY KEY NOT NULL,
+	"label" varchar(255),
+	"target_like_count" integer NOT NULL,
+	"reward_amount" integer NOT NULL,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "live_like_goal_rewards" (
+	"id" varchar(64) PRIMARY KEY NOT NULL,
+	"goal_id" varchar(64) NOT NULL,
+	"broadcast_id" varchar(128) NOT NULL,
+	"like_count" integer NOT NULL,
+	"reward_amount" integer NOT NULL,
+	"rewarded_viewer_count" integer NOT NULL,
+	"total_amount" integer NOT NULL,
+	"paid_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "live_like_goal_rewards" ADD CONSTRAINT "live_like_goal_rewards_goal_id_live_like_goals_id_fk" FOREIGN KEY ("goal_id") REFERENCES "public"."live_like_goals"("id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "live_like_goal_rewards_goal_broadcast_idx" ON "live_like_goal_rewards" USING btree ("goal_id","broadcast_id");

--- a/drizzle/meta/0014_snapshot.json
+++ b/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,2536 @@
+{
+  "id": "c76be4ef-6b7e-41f3-9e59-dc861ddc7b90",
+  "prevId": "584c489d-a7d1-46a4-b8a3-8c1a2a0f287a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.bet_entries": {
+      "name": "bet_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bet_id": {
+          "name": "bet_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_house_entry": {
+          "name": "is_house_entry",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payout_amount": {
+          "name": "payout_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refunded_at": {
+          "name": "refunded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bet_entries_bet_viewer_idx": {
+          "name": "bet_entries_bet_viewer_idx",
+          "columns": [
+            {
+              "expression": "bet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "viewer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bet_entries_bet_id_bets_id_fk": {
+          "name": "bet_entries_bet_id_bets_id_fk",
+          "tableFrom": "bet_entries",
+          "tableTo": "bets",
+          "columnsFrom": [
+            "bet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bet_entries_option_id_bet_options_id_fk": {
+          "name": "bet_entries_option_id_bet_options_id_fk",
+          "tableFrom": "bet_entries",
+          "tableTo": "bet_options",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bet_entries_viewer_id_users_id_fk": {
+          "name": "bet_entries_viewer_id_users_id_fk",
+          "tableFrom": "bet_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bet_options": {
+      "name": "bet_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bet_id": {
+          "name": "bet_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pool_amount": {
+          "name": "pool_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bet_options_bet_id_bets_id_fk": {
+          "name": "bet_options_bet_id_bets_id_fk",
+          "tableFrom": "bet_options",
+          "tableTo": "bets",
+          "columnsFrom": [
+            "bet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bets": {
+      "name": "bets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closes_at": {
+          "name": "closes_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "winning_option_id": {
+          "name": "winning_option_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bridge_clients": {
+      "name": "bridge_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "machine_key": {
+          "name": "machine_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bridge_clients_machine_key_idx": {
+          "name": "bridge_clients_machine_key_idx",
+          "columns": [
+            {
+              "expression": "machine_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_items": {
+      "name": "catalog_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "global_cooldown_seconds": {
+          "name": "global_cooldown_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "viewer_cooldown_seconds": {
+          "name": "viewer_cooldown_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_image_url": {
+          "name": "preview_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accent_color": {
+          "name": "accent_color",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#b4ff39'"
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "streamerbot_action_ref": {
+          "name": "streamerbot_action_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "streamerbot_args_template": {
+          "name": "streamerbot_args_template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "catalog_items_slug_idx": {
+          "name": "catalog_items_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.creator_suggestion_boosts": {
+      "name": "creator_suggestion_boosts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "suggestion_id": {
+          "name": "suggestion_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "creator_suggestion_boosts_suggestion_id_creator_suggestions_id_fk": {
+          "name": "creator_suggestion_boosts_suggestion_id_creator_suggestions_id_fk",
+          "tableFrom": "creator_suggestion_boosts",
+          "tableTo": "creator_suggestions",
+          "columnsFrom": [
+            "suggestion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "creator_suggestion_boosts_viewer_id_users_id_fk": {
+          "name": "creator_suggestion_boosts_viewer_id_users_id_fk",
+          "tableFrom": "creator_suggestion_boosts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.creator_suggestions": {
+      "name": "creator_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_url": {
+          "name": "channel_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_votes": {
+          "name": "total_votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "creator_suggestions_viewer_id_users_id_fk": {
+          "name": "creator_suggestions_viewer_id_users_id_fk",
+          "tableFrom": "creator_suggestions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_suggestion_boosts": {
+      "name": "game_suggestion_boosts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "suggestion_id": {
+          "name": "suggestion_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_suggestion_boosts_suggestion_id_game_suggestions_id_fk": {
+          "name": "game_suggestion_boosts_suggestion_id_game_suggestions_id_fk",
+          "tableFrom": "game_suggestion_boosts",
+          "tableTo": "game_suggestions",
+          "columnsFrom": [
+            "suggestion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_suggestion_boosts_viewer_id_users_id_fk": {
+          "name": "game_suggestion_boosts_viewer_id_users_id_fk",
+          "tableFrom": "game_suggestion_boosts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_suggestions": {
+      "name": "game_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "igdb_id": {
+          "name": "igdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_name": {
+          "name": "canonical_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platforms": {
+          "name": "platforms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_votes": {
+          "name": "total_votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_suggestions_viewer_id_users_id_fk": {
+          "name": "game_suggestions_viewer_id_users_id_fk",
+          "tableFrom": "game_suggestions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_account_viewers": {
+      "name": "google_account_viewers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_account_id": {
+          "name": "google_account_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "google_account_viewers_account_viewer_idx": {
+          "name": "google_account_viewers_account_viewer_idx",
+          "columns": [
+            {
+              "expression": "google_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "viewer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "google_account_viewers_viewer_id_idx": {
+          "name": "google_account_viewers_viewer_id_idx",
+          "columns": [
+            {
+              "expression": "viewer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_account_viewers_google_account_id_google_accounts_id_fk": {
+          "name": "google_account_viewers_google_account_id_google_accounts_id_fk",
+          "tableFrom": "google_account_viewers",
+          "tableTo": "google_accounts",
+          "columnsFrom": [
+            "google_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "google_account_viewers_viewer_id_users_id_fk": {
+          "name": "google_account_viewers_viewer_id_users_id_fk",
+          "tableFrom": "google_account_viewers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_accounts": {
+      "name": "google_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_user_id": {
+          "name": "google_user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_viewer_id": {
+          "name": "active_viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cross_account_protection_state": {
+          "name": "cross_account_protection_state",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ok'"
+        },
+        "cross_account_protection_event": {
+          "name": "cross_account_protection_event",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cross_account_protection_reason": {
+          "name": "cross_account_protection_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cross_account_protection_updated_at": {
+          "name": "cross_account_protection_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sessions_revoked_at": {
+          "name": "sessions_revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "google_accounts_google_user_id_idx": {
+          "name": "google_accounts_google_user_id_idx",
+          "columns": [
+            {
+              "expression": "google_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "google_accounts_email_idx": {
+          "name": "google_accounts_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_accounts_active_viewer_id_users_id_fk": {
+          "name": "google_accounts_active_viewer_id_users_id_fk",
+          "tableFrom": "google_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "active_viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_risc_deliveries": {
+      "name": "google_risc_deliveries",
+      "schema": "",
+      "columns": {
+        "jti": {
+          "name": "jti",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_types": {
+          "name": "event_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_account_count": {
+          "name": "matched_account_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.live_like_goal_rewards": {
+      "name": "live_like_goal_rewards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "broadcast_id": {
+          "name": "broadcast_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reward_amount": {
+          "name": "reward_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rewarded_viewer_count": {
+          "name": "rewarded_viewer_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "live_like_goal_rewards_goal_broadcast_idx": {
+          "name": "live_like_goal_rewards_goal_broadcast_idx",
+          "columns": [
+            {
+              "expression": "goal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "broadcast_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "live_like_goal_rewards_goal_id_live_like_goals_id_fk": {
+          "name": "live_like_goal_rewards_goal_id_live_like_goals_id_fk",
+          "tableFrom": "live_like_goal_rewards",
+          "tableTo": "live_like_goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.live_like_goals": {
+      "name": "live_like_goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_like_count": {
+          "name": "target_like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reward_amount": {
+          "name": "reward_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.obs_overlay_control": {
+      "name": "obs_overlay_control",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumed_at": {
+          "name": "resumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.point_ledger": {
+      "name": "point_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "point_ledger_external_event_idx": {
+          "name": "point_ledger_external_event_idx",
+          "columns": [
+            {
+              "expression": "external_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "point_ledger_viewer_id_users_id_fk": {
+          "name": "point_ledger_viewer_id_users_id_fk",
+          "tableFrom": "point_ledger",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_recommendations": {
+      "name": "product_recommendations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "href": {
+          "name": "href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "store_label": {
+          "name": "store_label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_kind": {
+          "name": "link_kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "product_recommendations_slug_idx": {
+          "name": "product_recommendations_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_overlay_queue": {
+      "name": "quote_overlay_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_number": {
+          "name": "quote_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_body": {
+          "name": "quote_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_display_name": {
+          "name": "created_by_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_youtube_handle": {
+          "name": "created_by_youtube_handle",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_viewer_id": {
+          "name": "requested_by_viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_display_name": {
+          "name": "requested_by_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_youtube_handle": {
+          "name": "requested_by_youtube_handle",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'streamerbot_chat'"
+        },
+        "cost": {
+          "name": "cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_duration_seconds": {
+          "name": "display_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quote_overlay_queue_requested_by_viewer_id_users_id_fk": {
+          "name": "quote_overlay_queue_requested_by_viewer_id_users_id_fk",
+          "tableFrom": "quote_overlay_queue",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_overlay_state": {
+      "name": "quote_overlay_state",
+      "schema": "",
+      "columns": {
+        "slot": {
+          "name": "slot",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "overlay_id": {
+          "name": "overlay_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_number": {
+          "name": "quote_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_body": {
+          "name": "quote_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_display_name": {
+          "name": "created_by_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_youtube_handle": {
+          "name": "created_by_youtube_handle",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_viewer_id": {
+          "name": "requested_by_viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_display_name": {
+          "name": "requested_by_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_youtube_handle": {
+          "name": "requested_by_youtube_handle",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'streamerbot_chat'"
+        },
+        "cost": {
+          "name": "cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quote_overlay_state_requested_by_viewer_id_users_id_fk": {
+          "name": "quote_overlay_state_requested_by_viewer_id_users_id_fk",
+          "tableFrom": "quote_overlay_state",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quotes": {
+      "name": "quotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_number": {
+          "name": "quote_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_viewer_id": {
+          "name": "created_by_viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_display_name": {
+          "name": "created_by_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_youtube_handle": {
+          "name": "created_by_youtube_handle",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'streamerbot_chat'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quotes_quote_number_idx": {
+          "name": "quotes_quote_number_idx",
+          "columns": [
+            {
+              "expression": "quote_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quotes_created_by_viewer_id_users_id_fk": {
+          "name": "quotes_created_by_viewer_id_users_id_fk",
+          "tableFrom": "quotes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.redemptions": {
+      "name": "redemptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_item_id": {
+          "name": "catalog_item_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_at_purchase": {
+          "name": "cost_at_purchase",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_source": {
+          "name": "request_source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'web'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bridge_attempt_count": {
+          "name": "bridge_attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claimed_by_bridge_id": {
+          "name": "claimed_by_bridge_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "redemptions_viewer_id_users_id_fk": {
+          "name": "redemptions_viewer_id_users_id_fk",
+          "tableFrom": "redemptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "redemptions_catalog_item_id_catalog_items_id_fk": {
+          "name": "redemptions_catalog_item_id_catalog_items_id_fk",
+          "tableFrom": "redemptions",
+          "tableTo": "catalog_items",
+          "columnsFrom": [
+            "catalog_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.streamerbot_counters": {
+      "name": "streamerbot_counters",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_reset_at": {
+          "name": "last_reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.streamerbot_event_log": {
+      "name": "streamerbot_event_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_external_id": {
+          "name": "viewer_external_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature_valid": {
+          "name": "signature_valid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "streamerbot_event_id_idx": {
+          "name": "streamerbot_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_user_id": {
+          "name": "google_user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_channel_id": {
+          "name": "youtube_channel_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "youtube_display_name": {
+          "name": "youtube_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "youtube_handle": {
+          "name": "youtube_handle",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_linked": {
+          "name": "is_linked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "exclude_from_ranking": {
+          "name": "exclude_from_ranking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_youtube_channel_id_idx": {
+          "name": "users_youtube_channel_id_idx",
+          "columns": [
+            {
+              "expression": "youtube_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.video_suggestion_boosts": {
+      "name": "video_suggestion_boosts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "suggestion_id": {
+          "name": "suggestion_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "video_suggestion_boosts_suggestion_id_video_suggestions_id_fk": {
+          "name": "video_suggestion_boosts_suggestion_id_video_suggestions_id_fk",
+          "tableFrom": "video_suggestion_boosts",
+          "tableTo": "video_suggestions",
+          "columnsFrom": [
+            "suggestion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "video_suggestion_boosts_viewer_id_users_id_fk": {
+          "name": "video_suggestion_boosts_viewer_id_users_id_fk",
+          "tableFrom": "video_suggestion_boosts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.video_suggestions": {
+      "name": "video_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "youtube_video_id": {
+          "name": "youtube_video_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_name": {
+          "name": "creator_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_votes": {
+          "name": "total_votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "video_suggestions_viewer_id_users_id_fk": {
+          "name": "video_suggestions_viewer_id_users_id_fk",
+          "tableFrom": "video_suggestions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.viewer_balances": {
+      "name": "viewer_balances",
+      "schema": "",
+      "columns": {
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "current_balance": {
+          "name": "current_balance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lifetime_earned": {
+          "name": "lifetime_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lifetime_spent": {
+          "name": "lifetime_spent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "viewer_balances_viewer_id_users_id_fk": {
+          "name": "viewer_balances_viewer_id_users_id_fk",
+          "tableFrom": "viewer_balances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.viewer_links": {
+      "name": "viewer_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_account_id": {
+          "name": "google_account_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_code": {
+          "name": "link_code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "viewer_links_google_account_id_idx": {
+          "name": "viewer_links_google_account_id_idx",
+          "columns": [
+            {
+              "expression": "google_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "viewer_links_code_idx": {
+          "name": "viewer_links_code_idx",
+          "columns": [
+            {
+              "expression": "link_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "viewer_links_google_account_id_google_accounts_id_fk": {
+          "name": "viewer_links_google_account_id_google_accounts_id_fk",
+          "tableFrom": "viewer_links",
+          "tableTo": "google_accounts",
+          "columnsFrom": [
+            "google_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1779318000000,
       "tag": "0013_ludylops_product_recommendations",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1779461229179,
+      "tag": "0014_real_millenium_guard",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -6,6 +6,7 @@ import { AdminGameSuggestionsPanel } from "@/components/admin-game-suggestions-p
 import { AdminVideoSuggestionsPanel } from "@/components/admin-video-suggestions-panel";
 import { AdminPipetzPricingPanel } from "@/components/admin-pipetz-pricing-panel";
 import { AdminPipetzAirdropPanel } from "@/components/admin-pipetz-airdrop-panel";
+import { AdminLiveLikeGoalsPanel } from "@/components/admin-live-like-goals-panel";
 import { AdminRecommendationsPanel } from "@/components/admin-recommendations-panel";
 import { AdminViewerLinksPanel } from "@/components/admin-viewer-links-panel";
 import { RedemptionGrid } from "@/components/redemption-grid";
@@ -23,6 +24,7 @@ import {
   listAdminVideoSuggestions,
   listAdminProductRecommendations,
   listAdminBets,
+  listAdminLiveLikeGoals,
   listAdminRedemptions,
 } from "@/lib/db/repository";
 import { getStreamerbotLivestreamStatus } from "@/lib/streamerbot/live-status";
@@ -39,7 +41,7 @@ const statusColorMap: Record<string, string> = {
 
 export default async function AdminPage() {
   await requireAdminSession();
-  const [catalog, leaderboard, bridge, liveStatus, currentGame, redemptions, bets, suggestions, videoSuggestions, recommendations, viewers, obsOverlayStatus, pricing] = await Promise.all([
+  const [catalog, leaderboard, bridge, liveStatus, currentGame, redemptions, bets, likeGoals, suggestions, videoSuggestions, recommendations, viewers, obsOverlayStatus, pricing] = await Promise.all([
     getCatalog(),
     getLeaderboard(),
     getBridgeStatus(),
@@ -47,6 +49,7 @@ export default async function AdminPage() {
     getCurrentGame(),
     listAdminRedemptions(),
     listAdminBets(),
+    listAdminLiveLikeGoals(),
     listAdminGameSuggestions(),
     listAdminVideoSuggestions(),
     listAdminProductRecommendations(),
@@ -105,6 +108,7 @@ export default async function AdminPage() {
                   <LiveStatusPanel bridge={bridge} initialStatus={liveStatus} />
                   <AdminCurrentGamePanel initialGame={currentGame} />
                   <AdminPipetzPricingPanel initialPricing={pricing} />
+                  <AdminLiveLikeGoalsPanel initialGoals={likeGoals} />
                 </div>
                 <AdminObsOverlaysPanel initialStatus={obsOverlayStatus} />
               </div>

--- a/src/app/api/admin/live-like-goals/[id]/route.ts
+++ b/src/app/api/admin/live-like-goals/[id]/route.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+
+import { fail, isTrustedAppMutationRequest, ok, requireAdminApiSession } from "@/lib/api";
+import { deleteLiveLikeGoal, updateLiveLikeGoal } from "@/lib/db/repository";
+import { liveLikeGoalSchema } from "@/lib/streamerbot/schemas";
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!isTrustedAppMutationRequest(request)) {
+    return fail("Forbidden", 403);
+  }
+
+  const session = await requireAdminApiSession();
+  if (!session) {
+    return fail("Forbidden", 403);
+  }
+
+  const { id } = await params;
+  try {
+    const payload = liveLikeGoalSchema.parse(await request.json());
+    return ok(await updateLiveLikeGoal(id, payload));
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return fail("Dados inválidos para a meta de likes.", 400);
+    }
+    return fail(error instanceof Error ? error.message : "Falha ao atualizar meta de likes.", 400);
+  }
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!isTrustedAppMutationRequest(request)) {
+    return fail("Forbidden", 403);
+  }
+
+  const session = await requireAdminApiSession();
+  if (!session) {
+    return fail("Forbidden", 403);
+  }
+
+  const { id } = await params;
+  try {
+    return ok(await deleteLiveLikeGoal(id));
+  } catch (error) {
+    return fail(error instanceof Error ? error.message : "Falha ao remover meta de likes.", 400);
+  }
+}

--- a/src/app/api/admin/live-like-goals/route.ts
+++ b/src/app/api/admin/live-like-goals/route.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+import { fail, isTrustedAppMutationRequest, ok, requireAdminApiSession } from "@/lib/api";
+import { createLiveLikeGoal, listAdminLiveLikeGoals } from "@/lib/db/repository";
+import { liveLikeGoalSchema } from "@/lib/streamerbot/schemas";
+
+export async function GET() {
+  const session = await requireAdminApiSession();
+  if (!session) {
+    return fail("Forbidden", 403);
+  }
+
+  return ok(await listAdminLiveLikeGoals());
+}
+
+export async function POST(request: Request) {
+  if (!isTrustedAppMutationRequest(request)) {
+    return fail("Forbidden", 403);
+  }
+
+  const session = await requireAdminApiSession();
+  if (!session) {
+    return fail("Forbidden", 403);
+  }
+
+  try {
+    const payload = liveLikeGoalSchema.parse(await request.json());
+    return ok(await createLiveLikeGoal(payload), { status: 201 });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return fail("Dados inválidos para a meta de likes.", 400);
+    }
+    return fail(error instanceof Error ? error.message : "Falha ao salvar meta de likes.", 400);
+  }
+}

--- a/src/components/admin-live-like-goals-panel.tsx
+++ b/src/components/admin-live-like-goals-panel.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { LiveLikeGoalAdminRecord } from "@/lib/types";
+import { formatDateTime, formatPipetz } from "@/lib/utils";
+
+export function AdminLiveLikeGoalsPanel({
+  initialGoals,
+}: {
+  initialGoals: LiveLikeGoalAdminRecord[];
+}) {
+  const router = useRouter();
+  const [label, setLabel] = useState("");
+  const [targetLikeCount, setTargetLikeCount] = useState("30");
+  const [rewardAmount, setRewardAmount] = useState("100");
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const parsedTarget = Number.parseInt(targetLikeCount, 10);
+  const parsedReward = Number.parseInt(rewardAmount, 10);
+  const canSubmit = Number.isInteger(parsedTarget) && parsedTarget > 0 && Number.isInteger(parsedReward) && parsedReward > 0;
+
+  function submitGoal() {
+    if (!canSubmit) {
+      setFeedback("Informe likes e recompensa válidos.");
+      return;
+    }
+
+    setFeedback(null);
+    startTransition(async () => {
+      const response = await fetch("/api/admin/live-like-goals", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          label: label.trim() || undefined,
+          targetLikeCount: parsedTarget,
+          rewardAmount: parsedReward,
+          isActive: true,
+        }),
+      });
+      const payload = (await response.json()) as { ok?: boolean; error?: string };
+      if (!response.ok || !payload.ok) {
+        setFeedback(payload.error ?? "Falha ao salvar meta de likes.");
+        return;
+      }
+
+      setLabel("");
+      setTargetLikeCount("30");
+      setRewardAmount("100");
+      setFeedback("Meta de likes salva.");
+      router.refresh();
+    });
+  }
+
+  function deleteGoal(goalId: string) {
+    setFeedback(null);
+    startTransition(async () => {
+      const response = await fetch(`/api/admin/live-like-goals/${goalId}`, {
+        method: "DELETE",
+      });
+      const payload = (await response.json()) as { ok?: boolean; error?: string };
+      if (!response.ok || !payload.ok) {
+        setFeedback(payload.error ?? "Falha ao remover meta de likes.");
+        return;
+      }
+      setFeedback("Meta de likes removida.");
+      router.refresh();
+    });
+  }
+
+  function toggleGoal(goal: LiveLikeGoalAdminRecord) {
+    setFeedback(null);
+    startTransition(async () => {
+      const response = await fetch(`/api/admin/live-like-goals/${goal.id}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          label: goal.label ?? undefined,
+          targetLikeCount: goal.targetLikeCount,
+          rewardAmount: goal.rewardAmount,
+          isActive: !goal.isActive,
+        }),
+      });
+      const payload = (await response.json()) as { ok?: boolean; error?: string };
+      if (!response.ok || !payload.ok) {
+        setFeedback(payload.error ?? "Falha ao atualizar meta de likes.");
+        return;
+      }
+      router.refresh();
+    });
+  }
+
+  return (
+    <section className="panel surface-section p-6">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
+            Metas de likes
+          </p>
+          <h2 className="mt-2 text-3xl uppercase" style={{ fontFamily: "var(--font-display)" }}>
+            Recompensas da live
+          </h2>
+        </div>
+        {feedback ? <div className="retro-label neutral-chip max-w-sm">{feedback}</div> : null}
+      </div>
+
+      <div className="mt-6 grid gap-4 lg:grid-cols-[1fr_150px_170px_auto]">
+        <label className="grid gap-2">
+          <span className="text-sm font-black uppercase tracking-[0.14em]">Nome</span>
+          <Input value={label} onChange={(event) => setLabel(event.target.value)} placeholder="Ex.: Meta 30 likes" />
+        </label>
+        <label className="grid gap-2">
+          <span className="text-sm font-black uppercase tracking-[0.14em]">Likes</span>
+          <Input type="number" min={1} value={targetLikeCount} onChange={(event) => setTargetLikeCount(event.target.value)} />
+        </label>
+        <label className="grid gap-2">
+          <span className="text-sm font-black uppercase tracking-[0.14em]">Pipetz</span>
+          <Input type="number" min={1} value={rewardAmount} onChange={(event) => setRewardAmount(event.target.value)} />
+        </label>
+        <Button type="button" onClick={submitGoal} disabled={isPending || !canSubmit} variant="success" className="self-end">
+          Salvar
+        </Button>
+      </div>
+
+      <div className="mt-6 grid gap-3">
+        {initialGoals.length === 0 ? (
+          <p className="card-flat bg-[var(--color-paper)] p-4 text-sm font-bold text-[var(--color-ink-soft)]">
+            Nenhuma meta cadastrada.
+          </p>
+        ) : null}
+        {initialGoals.map((goal) => (
+          <article key={goal.id} className="card-flat grid gap-3 bg-[var(--color-paper)] p-4 lg:grid-cols-[1fr_auto]">
+            <div>
+              <div className="flex flex-wrap items-center gap-2">
+                <h3 className="text-lg font-black uppercase">{goal.label || `${goal.targetLikeCount} likes`}</h3>
+                <span className="badge-brutal bg-[var(--color-mint)] px-2 py-1 text-[10px] text-[var(--color-accent-ink)]">
+                  {goal.isActive ? "ativa" : "pausada"}
+                </span>
+              </div>
+              <p className="mt-1 text-sm font-bold text-[var(--color-ink-soft)]">
+                Ao bater {goal.targetLikeCount} likes, cada viewer presente recebe {formatPipetz(goal.rewardAmount)} pipetz.
+              </p>
+              <p className="mt-1 text-xs font-bold text-[var(--color-ink-soft)]">
+                Presença: viewers com registro de presença nos últimos 5 minutos.
+              </p>
+              {goal.lastReward ? (
+                <p className="mt-2 text-xs font-bold text-[var(--color-ink-soft)]">
+                  Último pagamento: {formatDateTime(goal.lastReward.paidAt)} para {goal.lastReward.rewardedViewerCount} viewers.
+                </p>
+              ) : null}
+            </div>
+            <div className="flex flex-wrap items-center gap-2 self-start">
+              <Button type="button" variant="neutral" size="sm" onClick={() => toggleGoal(goal)} disabled={isPending}>
+                {goal.isActive ? "Pausar" : "Ativar"}
+              </Button>
+              <Button type="button" variant="danger" size="sm" onClick={() => deleteGoal(goal.id)} disabled={isPending}>
+                Remover
+              </Button>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/admin-live-like-goals-panel.tsx
+++ b/src/components/admin-live-like-goals-panel.tsx
@@ -145,7 +145,7 @@ export function AdminLiveLikeGoalsPanel({
                 Ao bater {goal.targetLikeCount} likes, cada viewer presente recebe {formatPipetz(goal.rewardAmount)} pipetz.
               </p>
               <p className="mt-1 text-xs font-bold text-[var(--color-ink-soft)]">
-                Presença: viewers com registro de presença nos últimos 5 minutos.
+                Viewer presente: desde o início da live.
               </p>
               {goal.lastReward ? (
                 <p className="mt-2 text-xs font-bold text-[var(--color-ink-soft)]">

--- a/src/lib/bets/service.test.ts
+++ b/src/lib/bets/service.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  calculateHouseBetEntries,
   calculateBetPayouts,
   evaluateBetLifecycleAction,
   evaluateBetPlacement,
@@ -153,6 +154,46 @@ describe("calculateBetPayouts", () => {
       { entryId: "entry-a", viewerId: "viewer-a", payoutAmount: 75 },
       { entryId: "entry-b", viewerId: "viewer-b", payoutAmount: 225 },
     ]);
+  });
+});
+
+describe("calculateHouseBetEntries", () => {
+  it("creates a house entry for each empty option using the sum of the other pools", () => {
+    expect(
+      calculateHouseBetEntries({
+        options: [
+          { id: "a", betId: "bet-1", label: "A", sortOrder: 0, poolAmount: 100 },
+          { id: "b", betId: "bet-1", label: "B", sortOrder: 1, poolAmount: 0 },
+          { id: "c", betId: "bet-1", label: "C", sortOrder: 2, poolAmount: 50 },
+        ],
+        existingEntries: [],
+      }),
+    ).toEqual([{ optionId: "b", amount: 150 }]);
+  });
+
+  it("does not duplicate an existing house entry", () => {
+    expect(
+      calculateHouseBetEntries({
+        options: [
+          { id: "a", betId: "bet-1", label: "A", sortOrder: 0, poolAmount: 100 },
+          { id: "b", betId: "bet-1", label: "B", sortOrder: 1, poolAmount: 0 },
+        ],
+        existingEntries: [
+          {
+            id: "house-entry",
+            betId: "bet-1",
+            optionId: "b",
+            viewerId: "house_b",
+            amount: 100,
+            isHouseEntry: true,
+            payoutAmount: null,
+            settledAt: null,
+            refundedAt: null,
+            createdAt: new Date("2026-03-31T10:00:00.000Z").toISOString(),
+          },
+        ],
+      }),
+    ).toEqual([]);
   });
 });
 

--- a/src/lib/bets/service.ts
+++ b/src/lib/bets/service.ts
@@ -175,5 +175,26 @@ export function shouldRefundBetOnResolve(input: {
   entries: BetEntryRecord[];
   winningOptionId: string;
 }) {
-  return !input.entries.some((entry) => entry.optionId === input.winningOptionId);
+  return !input.entries.some((entry) => entry.optionId === input.winningOptionId && !entry.isHouseEntry);
+}
+
+export function calculateHouseBetEntries(input: {
+  options: BetOptionRecord[];
+  existingEntries: BetEntryRecord[];
+}) {
+  return input.options
+    .filter((option) => option.poolAmount === 0)
+    .filter(
+      (option) =>
+        !input.existingEntries.some(
+          (entry) => entry.optionId === option.id && entry.isHouseEntry,
+        ),
+    )
+    .map((option) => ({
+      optionId: option.id,
+      amount: input.options
+        .filter((candidate) => candidate.id !== option.id)
+        .reduce((sum, candidate) => sum + candidate.poolAmount, 0),
+    }))
+    .filter((entry) => entry.amount > 0);
 }

--- a/src/lib/db/repository.test.ts
+++ b/src/lib/db/repository.test.ts
@@ -67,6 +67,7 @@ import {
   cancelBet,
   createBet,
   createGameSuggestion,
+  createLiveLikeGoal,
   createVideoSuggestion,
   createProductRecommendationFromInput,
   deleteProductRecommendation,
@@ -3188,6 +3189,76 @@ describe("ingestStreamerbotEvent", () => {
         isLive: true,
         reason: "present_viewers",
         source: "streamerbot",
+      },
+    });
+  });
+
+  it("rewards viewers present since the beginning of the same live like goal broadcast", async () => {
+    getDbMock.mockReturnValue(null);
+
+    const goal = await createLiveLikeGoal({
+      label: "Meta 30 likes",
+      targetLikeCount: 30,
+      rewardAmount: 100,
+      isActive: true,
+    });
+    const before = await getViewerDashboard("viewer_lia");
+    const balanceBeforePresence = before?.balance.currentBalance ?? 0;
+
+    await ingestStreamerbotEvent({
+      eventId: "presence-like-goal-start",
+      eventType: "presence_tick",
+      viewerExternalId: "yt_lia",
+      youtubeDisplayName: "Lia Pixel",
+      amount: 5,
+      occurredAt: "2026-04-01T12:00:00.000Z",
+      payload: {
+        broadcastId: "live-like-goal-1",
+        isLive: true,
+        reason: "present_viewers",
+      },
+    });
+
+    const afterPresence = await getViewerDashboard("viewer_lia");
+    const balanceAfterPresence = afterPresence?.balance.currentBalance ?? 0;
+    const result = await ingestStreamerbotEvent({
+      eventId: "likes-goal-start",
+      eventType: "like_count_update",
+      amount: 0,
+      occurredAt: "2026-04-01T12:30:00.000Z",
+      payload: {
+        broadcastId: "live-like-goal-1",
+        isLive: true,
+        likeCount: 30,
+      },
+    });
+    const afterReward = await getViewerDashboard("viewer_lia");
+    const balanceAfterReward = afterReward?.balance.currentBalance ?? 0;
+
+    expect(result).toMatchObject({
+      mode: "demo",
+      likeGoalsPaid: 1,
+      rewardedViewerCount: 1,
+    });
+    expect(balanceAfterPresence).toBe(balanceBeforePresence + 5);
+    expect(balanceAfterReward).toBe(balanceAfterPresence + 100);
+    const store = (globalThis as typeof globalThis & {
+      __lojaDemoStore?: {
+        ledger: Array<{
+          kind: string;
+          amount: number;
+          metadata: Record<string, unknown>;
+        }>;
+      };
+    }).__lojaDemoStore;
+    const rewardLedger = store?.ledger.find((entry) => entry.kind === "like_goal_reward");
+    expect(rewardLedger).toMatchObject({
+      kind: "like_goal_reward",
+      amount: goal.rewardAmount,
+      metadata: {
+        goalId: goal.id,
+        broadcastId: "live-like-goal-1",
+        presenceCriterion: "presence_tick desde o início da live",
       },
     });
   });

--- a/src/lib/db/repository.ts
+++ b/src/lib/db/repository.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { and, desc, eq, gte, inArray, lt, sql } from "drizzle-orm";
 
 import {
+  calculateHouseBetEntries,
   calculateBetPayouts,
   evaluateBetLifecycleAction,
   evaluateBetPlacement,
@@ -22,6 +23,8 @@ import {
   googleAccounts,
   googleAccountViewers,
   googleRiscDeliveries,
+  liveLikeGoalRewards,
+  liveLikeGoals,
   obsOverlayControl,
   pointLedger,
   quoteOverlayQueue,
@@ -92,6 +95,9 @@ import {
   GoogleAccountViewerRecord,
   GoogleRiscDeliveryRecord,
   LedgerEntryRecord,
+  LiveLikeGoalAdminRecord,
+  LiveLikeGoalRecord,
+  LiveLikeGoalRewardRecord,
   ObsOverlayAdminStatusRecord,
   ObsOverlayControlRecord,
   PipetzPricingRecord,
@@ -148,6 +154,8 @@ const DEFAULT_PIPETZ_PRICING: PipetzPricingRecord = {
   updatedAt: null,
   updatedBy: null,
 };
+const CHANNEL_SUBSCRIPTION_REWARD_AMOUNT = 2000;
+const LIKE_GOAL_PRESENCE_WINDOW_MS = 5 * 60 * 1000;
 
 type StreamerbotCounterCommandAction = "increment" | "decrement" | "get" | "reset";
 type StreamerbotCounterScopeType = "global" | "game";
@@ -287,6 +295,8 @@ type DemoStore = {
   bets: BetRecord[];
   betOptions: BetOptionRecord[];
   betEntries: BetEntryRecord[];
+  liveLikeGoals: LiveLikeGoalRecord[];
+  liveLikeGoalRewards: LiveLikeGoalRewardRecord[];
   gameSuggestions: GameSuggestionRecord[];
   gameSuggestionBoosts: GameSuggestionBoostRecord[];
   creatorSuggestions: CreatorSuggestionRecord[];
@@ -321,6 +331,8 @@ function getDemoStore(): DemoStore {
       bets: structuredClone(demoBetRecords),
       betOptions: structuredClone(demoBetOptions),
       betEntries: structuredClone(demoBetEntries),
+      liveLikeGoals: [],
+      liveLikeGoalRewards: [],
       gameSuggestions: structuredClone(demoGameSuggestions),
       gameSuggestionBoosts: structuredClone(demoGameSuggestionBoosts),
       creatorSuggestions: structuredClone(demoCreatorSuggestions),
@@ -1365,6 +1377,25 @@ function getDemoViewerByYoutubeChannelId(store: DemoStore, youtubeChannelId: str
   return store.viewers.find((entry) => entry.youtubeChannelId === youtubeChannelId) ?? null;
 }
 
+function buildHouseViewerId(optionId: string) {
+  return `house_${optionId}`.slice(0, 64);
+}
+
+function buildHouseViewerForOption(option: BetOptionRecord): ViewerRecord {
+  return {
+    id: buildHouseViewerId(option.id),
+    googleUserId: null,
+    email: null,
+    youtubeChannelId: `house:${option.id}`.slice(0, 128),
+    youtubeDisplayName: "Casa Pipetz",
+    youtubeHandle: null,
+    avatarUrl: null,
+    isLinked: false,
+    excludeFromRanking: true,
+    createdAt: new Date().toISOString(),
+  };
+}
+
 function getDemoGoogleAccountViewerLinks(store: DemoStore, googleAccountId: string) {
   return store.googleAccountViewers.filter((entry) => entry.googleAccountId === googleAccountId);
 }
@@ -1418,11 +1449,69 @@ function serializeBetEntry(row: typeof betEntries.$inferSelect): BetEntryRecord 
     optionId: row.optionId,
     viewerId: row.viewerId,
     amount: row.amount,
+    isHouseEntry: row.isHouseEntry,
     payoutAmount: row.payoutAmount,
     settledAt: row.settledAt?.toISOString() ?? null,
     refundedAt: row.refundedAt?.toISOString() ?? null,
     createdAt: row.createdAt.toISOString(),
   };
+}
+
+function serializeLiveLikeGoal(row: typeof liveLikeGoals.$inferSelect): LiveLikeGoalRecord {
+  return {
+    id: row.id,
+    label: row.label,
+    targetLikeCount: row.targetLikeCount,
+    rewardAmount: row.rewardAmount,
+    isActive: row.isActive,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+function serializeLiveLikeGoalReward(
+  row: typeof liveLikeGoalRewards.$inferSelect,
+): LiveLikeGoalRewardRecord {
+  return {
+    id: row.id,
+    goalId: row.goalId,
+    broadcastId: row.broadcastId,
+    likeCount: row.likeCount,
+    rewardAmount: row.rewardAmount,
+    rewardedViewerCount: row.rewardedViewerCount,
+    totalAmount: row.totalAmount,
+    paidAt: row.paidAt.toISOString(),
+  };
+}
+
+function buildLiveLikeGoalAdminRecord(
+  goal: LiveLikeGoalRecord,
+  rewards: LiveLikeGoalRewardRecord[],
+): LiveLikeGoalAdminRecord {
+  return {
+    ...goal,
+    lastReward:
+      rewards
+        .filter((reward) => reward.goalId === goal.id)
+        .sort((a, b) => b.paidAt.localeCompare(a.paidAt))[0] ?? null,
+  };
+}
+
+function readNumberFromPayload(payload: Record<string, unknown>, key: string) {
+  const value = payload[key];
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function readStringFromPayload(payload: Record<string, unknown>, key: string) {
+  const value = payload[key];
+  return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
 function buildViewerPosition(
@@ -6141,6 +6230,7 @@ async function placeBetForViewer(input: {
     optionId: input.optionId,
     viewerId: dashboard.viewer.id,
     amount: input.amount,
+    isHouseEntry: false,
     payoutAmount: null,
     settledAt: null,
     refundedAt: null,
@@ -6243,6 +6333,7 @@ async function placeBetForViewer(input: {
           optionId: input.optionId,
           viewerId: dashboard.viewer.id,
           amount: input.amount,
+          isHouseEntry: false,
           payoutAmount: null,
           settledAt: null,
           refundedAt: null,
@@ -6850,12 +6941,40 @@ export async function lockBet(betId: string) {
     if (!transition.canTransition) {
       throw new Error(transition.reason);
     }
+    const options = store.betOptions.filter((option) => option.betId === betId);
+    const existingEntries = store.betEntries.filter((entry) => entry.betId === betId);
+    const houseEntries = calculateHouseBetEntries({ options, existingEntries });
+    for (const houseEntry of houseEntries) {
+      const option = options.find((entry) => entry.id === houseEntry.optionId);
+      if (!option) {
+        continue;
+      }
+      const houseViewer = buildHouseViewerForOption(option);
+      if (!store.viewers.some((viewer) => viewer.id === houseViewer.id)) {
+        store.viewers.push(houseViewer);
+      }
+      getBalance(store, houseViewer.id);
+      option.poolAmount += houseEntry.amount;
+      store.betEntries.unshift({
+        id: randomUUID(),
+        betId,
+        optionId: option.id,
+        viewerId: houseViewer.id,
+        amount: houseEntry.amount,
+        isHouseEntry: true,
+        payoutAmount: null,
+        settledAt: null,
+        refundedAt: null,
+        createdAt: new Date().toISOString(),
+      });
+    }
     bet.status = "locked";
     bet.lockedAt = new Date().toISOString();
     return buildBetWithOptions({
       bet,
-      options: store.betOptions.filter((option) => option.betId === betId),
+      options,
       viewerEntry: null,
+      entries: store.betEntries.filter((entry) => entry.betId === betId),
     });
   }
 
@@ -6869,20 +6988,93 @@ export async function lockBet(betId: string) {
     throw new Error(transition.reason);
   }
   const lockedAt = new Date();
+  let optionRows: Array<typeof betOptions.$inferSelect> = [];
+  let entryRows: Array<typeof betEntries.$inferSelect> = [];
 
-  await db
-    .update(bets)
-    .set({
-      status: "locked",
-      lockedAt,
-    })
-    .where(eq(bets.id, betId));
+  await db.transaction(async (tx) => {
+    optionRows = await tx.select().from(betOptions).where(eq(betOptions.betId, betId));
+    entryRows = await tx.select().from(betEntries).where(eq(betEntries.betId, betId));
+    const serializedOptions = optionRows.map(serializeBetOption);
+    const houseEntries = calculateHouseBetEntries({
+      options: serializedOptions,
+      existingEntries: entryRows.map(serializeBetEntry),
+    });
 
-  const optionRows = await db.select().from(betOptions).where(eq(betOptions.betId, betId));
+    for (const houseEntry of houseEntries) {
+      const option = serializedOptions.find((entry) => entry.id === houseEntry.optionId);
+      if (!option) {
+        continue;
+      }
+      const houseViewer = buildHouseViewerForOption(option);
+      await tx
+        .insert(users)
+        .values({
+          id: houseViewer.id,
+          googleUserId: null,
+          email: null,
+          youtubeChannelId: houseViewer.youtubeChannelId,
+          youtubeDisplayName: houseViewer.youtubeDisplayName,
+          youtubeHandle: null,
+          avatarUrl: null,
+          isLinked: false,
+          excludeFromRanking: true,
+          createdAt: new Date(houseViewer.createdAt),
+        })
+        .onConflictDoNothing();
+      await tx
+        .insert(viewerBalances)
+        .values({
+          viewerId: houseViewer.id,
+          currentBalance: 0,
+          lifetimeEarned: 0,
+          lifetimeSpent: 0,
+          lastSyncedAt: new Date(),
+        })
+        .onConflictDoNothing();
+      const [insertedEntry] = await tx
+        .insert(betEntries)
+        .values({
+          id: randomUUID(),
+          betId,
+          optionId: option.id,
+          viewerId: houseViewer.id,
+          amount: houseEntry.amount,
+          isHouseEntry: true,
+          payoutAmount: null,
+          settledAt: null,
+          refundedAt: null,
+          createdAt: lockedAt,
+        })
+        .onConflictDoNothing({
+          target: [betEntries.betId, betEntries.viewerId],
+        })
+        .returning();
+
+      if (insertedEntry) {
+        await tx
+          .update(betOptions)
+          .set({ poolAmount: sql`${betOptions.poolAmount} + ${houseEntry.amount}` })
+          .where(eq(betOptions.id, option.id));
+      }
+    }
+
+    await tx
+      .update(bets)
+      .set({
+        status: "locked",
+        lockedAt,
+      })
+      .where(eq(bets.id, betId));
+
+    optionRows = await tx.select().from(betOptions).where(eq(betOptions.betId, betId));
+    entryRows = await tx.select().from(betEntries).where(eq(betEntries.betId, betId));
+  });
+
   return buildBetWithOptions({
     bet: { ...currentBet, status: "locked", lockedAt: lockedAt.toISOString() },
     options: optionRows.map(serializeBetOption),
     viewerEntry: null,
+    entries: entryRows.map(serializeBetEntry),
   });
 }
 
@@ -7635,6 +7827,162 @@ export async function listAdminRedemptions() {
   }));
 }
 
+export async function listAdminLiveLikeGoals(): Promise<LiveLikeGoalAdminRecord[]> {
+  const db = getDb();
+  if (isDemoMode || !db) {
+    const store = getDemoStore();
+    return store.liveLikeGoals
+      .map((goal) => buildLiveLikeGoalAdminRecord(goal, store.liveLikeGoalRewards))
+      .sort((a, b) => a.targetLikeCount - b.targetLikeCount);
+  }
+
+  const [goalRows, rewardRows] = await Promise.all([
+    db.select().from(liveLikeGoals).orderBy(liveLikeGoals.targetLikeCount),
+    db.select().from(liveLikeGoalRewards).orderBy(desc(liveLikeGoalRewards.paidAt)),
+  ]);
+  const rewards = rewardRows.map(serializeLiveLikeGoalReward);
+  return goalRows.map((goal) => buildLiveLikeGoalAdminRecord(serializeLiveLikeGoal(goal), rewards));
+}
+
+export async function createLiveLikeGoal(input: {
+  label?: string | null;
+  targetLikeCount: number;
+  rewardAmount: number;
+  isActive?: boolean;
+}) {
+  const now = new Date().toISOString();
+  const goal: LiveLikeGoalRecord = {
+    id: randomUUID(),
+    label: input.label?.trim() || null,
+    targetLikeCount: input.targetLikeCount,
+    rewardAmount: input.rewardAmount,
+    isActive: input.isActive ?? true,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  const db = getDb();
+  if (isDemoMode || !db) {
+    getDemoStore().liveLikeGoals.push(goal);
+    return goal;
+  }
+
+  await db.insert(liveLikeGoals).values({
+    id: goal.id,
+    label: goal.label,
+    targetLikeCount: goal.targetLikeCount,
+    rewardAmount: goal.rewardAmount,
+    isActive: goal.isActive,
+    createdAt: new Date(goal.createdAt),
+    updatedAt: new Date(goal.updatedAt),
+  });
+  return goal;
+}
+
+export async function updateLiveLikeGoal(
+  goalId: string,
+  input: {
+    label?: string | null;
+    targetLikeCount: number;
+    rewardAmount: number;
+    isActive?: boolean;
+  },
+) {
+  const updatedAt = new Date().toISOString();
+  const db = getDb();
+  if (isDemoMode || !db) {
+    const goal = getDemoStore().liveLikeGoals.find((entry) => entry.id === goalId);
+    if (!goal) {
+      throw new Error("like_goal_not_found");
+    }
+    goal.label = input.label?.trim() || null;
+    goal.targetLikeCount = input.targetLikeCount;
+    goal.rewardAmount = input.rewardAmount;
+    goal.isActive = input.isActive ?? true;
+    goal.updatedAt = updatedAt;
+    return goal;
+  }
+
+  const [updated] = await db
+    .update(liveLikeGoals)
+    .set({
+      label: input.label?.trim() || null,
+      targetLikeCount: input.targetLikeCount,
+      rewardAmount: input.rewardAmount,
+      isActive: input.isActive ?? true,
+      updatedAt: new Date(updatedAt),
+    })
+    .where(eq(liveLikeGoals.id, goalId))
+    .returning();
+  if (!updated) {
+    throw new Error("like_goal_not_found");
+  }
+  return serializeLiveLikeGoal(updated);
+}
+
+export async function deleteLiveLikeGoal(goalId: string) {
+  const db = getDb();
+  if (isDemoMode || !db) {
+    const store = getDemoStore();
+    const index = store.liveLikeGoals.findIndex((entry) => entry.id === goalId);
+    if (index < 0) {
+      throw new Error("like_goal_not_found");
+    }
+    const [deleted] = store.liveLikeGoals.splice(index, 1);
+    store.liveLikeGoalRewards = store.liveLikeGoalRewards.filter((entry) => entry.goalId !== goalId);
+    return deleted;
+  }
+
+  await db.delete(liveLikeGoalRewards).where(eq(liveLikeGoalRewards.goalId, goalId));
+  const [deleted] = await db.delete(liveLikeGoals).where(eq(liveLikeGoals.id, goalId)).returning();
+  if (!deleted) {
+    throw new Error("like_goal_not_found");
+  }
+  return serializeLiveLikeGoal(deleted);
+}
+
+function getDemoPresentViewerIds(store: DemoStore, occurredAt: string) {
+  const cutoff = new Date(occurredAt).getTime() - LIKE_GOAL_PRESENCE_WINDOW_MS;
+  const present = store.ledger
+    .filter(
+      (entry) =>
+        entry.kind === "presence_tick" &&
+        new Date(entry.createdAt).getTime() >= cutoff &&
+        new Date(entry.createdAt).getTime() <= new Date(occurredAt).getTime(),
+    )
+    .map((entry) => entry.viewerId);
+
+  return [...new Set(present)].filter((viewerId) => {
+    const viewer = store.viewers.find((entry) => entry.id === viewerId);
+    return viewer && !viewer.excludeFromRanking;
+  });
+}
+
+async function getDatabasePresentViewerIds(occurredAt: string) {
+  const db = getDb();
+  if (!db) {
+    return [];
+  }
+  const occurred = new Date(occurredAt);
+  const cutoff = new Date(occurred.getTime() - LIKE_GOAL_PRESENCE_WINDOW_MS);
+  const rows = await db
+    .select({
+      viewerId: pointLedger.viewerId,
+      excludeFromRanking: users.excludeFromRanking,
+    })
+    .from(pointLedger)
+    .innerJoin(users, eq(pointLedger.viewerId, users.id))
+    .where(
+      and(
+        eq(pointLedger.kind, "presence_tick"),
+        gte(pointLedger.createdAt, cutoff),
+        lt(pointLedger.createdAt, occurred),
+        eq(users.excludeFromRanking, false),
+      ),
+    );
+  return [...new Set(rows.map((entry) => entry.viewerId))];
+}
+
 export async function adjustViewerBalance({
   viewerId,
   amount,
@@ -7727,7 +8075,7 @@ export async function getBridgeStatus() {
 
 export async function ingestStreamerbotEvent(input: {
   eventId: string;
-  eventType: "presence_tick" | "chat_bonus" | "manual_adjustment";
+  eventType: "presence_tick" | "chat_bonus" | "manual_adjustment" | "channel_subscription" | "like_count_update";
   viewerExternalId?: string;
   youtubeDisplayName?: string;
   youtubeHandle?: string;
@@ -7753,8 +8101,70 @@ export async function ingestStreamerbotEvent(input: {
       };
     }
 
+    if (input.eventType === "like_count_update") {
+      const likeCount = readNumberFromPayload(input.payload, "likeCount") ?? input.balance ?? 0;
+      const broadcastId = readStringFromPayload(input.payload, "broadcastId") ?? "demo_live";
+      const eligibleGoals = store.liveLikeGoals.filter(
+        (goal) =>
+          goal.isActive &&
+          goal.targetLikeCount <= likeCount &&
+          !store.liveLikeGoalRewards.some(
+            (reward) => reward.goalId === goal.id && reward.broadcastId === broadcastId,
+          ),
+      );
+      const presentViewerIds = getDemoPresentViewerIds(store, input.occurredAt);
+      for (const goal of eligibleGoals) {
+        for (const viewerId of presentViewerIds) {
+          const balance = getBalance(store, viewerId);
+          balance.currentBalance += goal.rewardAmount;
+          balance.lifetimeEarned += goal.rewardAmount;
+          balance.lastSyncedAt = new Date().toISOString();
+          createLedgerEntry(store, {
+            viewerId,
+            kind: "like_goal_reward",
+            amount: goal.rewardAmount,
+            source: "like_goal_reward",
+            externalEventId: `${input.eventId}:${goal.id}:${viewerId}`,
+            metadata: {
+              goalId: goal.id,
+              broadcastId,
+              likeCount,
+              targetLikeCount: goal.targetLikeCount,
+              presenceCriterion: "presence_tick nos últimos 5 minutos",
+            },
+            createdAt: input.occurredAt,
+          });
+        }
+        store.liveLikeGoalRewards.unshift({
+          id: randomUUID(),
+          goalId: goal.id,
+          broadcastId,
+          likeCount,
+          rewardAmount: goal.rewardAmount,
+          rewardedViewerCount: presentViewerIds.length,
+          totalAmount: presentViewerIds.length * goal.rewardAmount,
+          paidAt: input.occurredAt,
+        });
+      }
+      return {
+        mode: "demo" as const,
+        deduped: false,
+        eventLogInserted: false,
+        viewerCreated: false,
+        balanceUpdated: eligibleGoals.length > 0 && presentViewerIds.length > 0,
+        ledgerInserted: eligibleGoals.length > 0 && presentViewerIds.length > 0,
+        linkMatched: false,
+        likeGoalsPaid: eligibleGoals.length,
+        rewardedViewerCount: presentViewerIds.length,
+      };
+    }
+
     const viewer = store.viewers.find((entry) => entry.youtubeChannelId === input.viewerExternalId);
-    if (!viewer || typeof input.amount !== "number") {
+    const eventAmount =
+      input.eventType === "channel_subscription"
+        ? CHANNEL_SUBSCRIPTION_REWARD_AMOUNT
+        : input.amount;
+    if (!viewer || typeof eventAmount !== "number") {
       return {
         mode: "demo" as const,
         deduped: false,
@@ -7775,20 +8185,45 @@ export async function ingestStreamerbotEvent(input: {
     }
 
     const creditedViewer = await resolveUnifiedViewerForLinkedChannel(viewer);
+    if (
+      input.eventType === "channel_subscription" &&
+      store.ledger.some(
+        (entry) => entry.viewerId === creditedViewer.id && entry.kind === "channel_subscription",
+      )
+    ) {
+      return {
+        mode: "demo" as const,
+        deduped: false,
+        eventLogInserted: false,
+        viewerCreated: false,
+        balanceUpdated: false,
+        ledgerInserted: false,
+        linkMatched: false,
+        viewerId: creditedViewer.id,
+        ignoredReason: "subscription_already_rewarded",
+      };
+    }
     const balance = getBalance(store, creditedViewer.id);
-    balance.currentBalance += input.amount;
-    if (input.amount > 0) {
-      balance.lifetimeEarned += input.amount;
+    balance.currentBalance += eventAmount;
+    if (eventAmount > 0) {
+      balance.lifetimeEarned += eventAmount;
     } else {
-      balance.lifetimeSpent += Math.abs(input.amount);
+      balance.lifetimeSpent += Math.abs(eventAmount);
     }
     balance.lastSyncedAt = new Date().toISOString();
 
     createLedgerEntry(store, {
       viewerId: creditedViewer.id,
-      kind: input.eventType === "presence_tick" ? "presence_tick" : input.eventType === "chat_bonus" ? "chat_bonus" : "manual_adjustment",
-      amount: input.amount,
-      source: "streamerbot",
+      kind:
+        input.eventType === "presence_tick"
+          ? "presence_tick"
+          : input.eventType === "chat_bonus"
+            ? "chat_bonus"
+            : input.eventType === "channel_subscription"
+              ? "channel_subscription"
+              : "manual_adjustment",
+      amount: eventAmount,
+      source: input.eventType === "channel_subscription" ? "channel_subscription" : "streamerbot",
       externalEventId: input.eventId,
       metadata: input.payload,
       createdAt: input.occurredAt,
@@ -7853,7 +8288,90 @@ export async function ingestStreamerbotEvent(input: {
     signatureValid: true,
   });
 
-  if (typeof input.amount === "number" && input.viewerExternalId) {
+  if (input.eventType === "like_count_update") {
+    const likeCount = readNumberFromPayload(input.payload, "likeCount") ?? input.balance ?? 0;
+    const broadcastId = readStringFromPayload(input.payload, "broadcastId") ?? "current_live";
+    const [goalRows, rewardRows, presentViewerIds] = await Promise.all([
+      db.select().from(liveLikeGoals).where(eq(liveLikeGoals.isActive, true)),
+      db.select().from(liveLikeGoalRewards).where(eq(liveLikeGoalRewards.broadcastId, broadcastId)),
+      getDatabasePresentViewerIds(input.occurredAt),
+    ]);
+    const paidGoalIds = new Set(rewardRows.map((entry) => entry.goalId));
+    const eligibleGoals = goalRows
+      .map(serializeLiveLikeGoal)
+      .filter((goal) => goal.targetLikeCount <= likeCount && !paidGoalIds.has(goal.id));
+
+    await db.transaction(async (tx) => {
+      for (const goal of eligibleGoals) {
+        const [reward] = await tx
+          .insert(liveLikeGoalRewards)
+          .values({
+            id: randomUUID(),
+            goalId: goal.id,
+            broadcastId,
+            likeCount,
+            rewardAmount: goal.rewardAmount,
+            rewardedViewerCount: presentViewerIds.length,
+            totalAmount: presentViewerIds.length * goal.rewardAmount,
+            paidAt: new Date(input.occurredAt),
+          })
+          .onConflictDoNothing({
+            target: [liveLikeGoalRewards.goalId, liveLikeGoalRewards.broadcastId],
+          })
+          .returning();
+
+        if (!reward) {
+          continue;
+        }
+
+        for (const viewerId of presentViewerIds) {
+          await tx
+            .update(viewerBalances)
+            .set({
+              currentBalance: sql`${viewerBalances.currentBalance} + ${goal.rewardAmount}`,
+              lifetimeEarned: sql`${viewerBalances.lifetimeEarned} + ${goal.rewardAmount}`,
+              lastSyncedAt: new Date(),
+            })
+            .where(eq(viewerBalances.viewerId, viewerId));
+          await tx.insert(pointLedger).values({
+            id: randomUUID(),
+            viewerId,
+            kind: "like_goal_reward",
+            amount: goal.rewardAmount,
+            source: "like_goal_reward",
+            externalEventId: `${input.eventId}:${goal.id}:${viewerId}`.slice(0, 128),
+            metadata: {
+              goalId: goal.id,
+              broadcastId,
+              likeCount,
+              targetLikeCount: goal.targetLikeCount,
+              presenceCriterion: "presence_tick nos últimos 5 minutos",
+            },
+            createdAt: new Date(input.occurredAt),
+          });
+        }
+      }
+    });
+
+    return {
+      mode: "database" as const,
+      deduped: false,
+      eventLogInserted: true,
+      viewerCreated: false,
+      balanceUpdated: eligibleGoals.length > 0 && presentViewerIds.length > 0,
+      ledgerInserted: eligibleGoals.length > 0 && presentViewerIds.length > 0,
+      linkMatched: false,
+      likeGoalsPaid: eligibleGoals.length,
+      rewardedViewerCount: presentViewerIds.length,
+    };
+  }
+
+  const eventAmount =
+    input.eventType === "channel_subscription"
+      ? CHANNEL_SUBSCRIPTION_REWARD_AMOUNT
+      : input.amount;
+
+  if (typeof eventAmount === "number" && input.viewerExternalId) {
     let viewerCreated = false;
     let [viewer] = await db
       .select()
@@ -7902,18 +8420,43 @@ export async function ingestStreamerbotEvent(input: {
 
     const serializedViewer = serializeViewer(viewer);
     const creditedViewer = await resolveUnifiedViewerForLinkedChannel(serializedViewer);
+    if (input.eventType === "channel_subscription") {
+      const [existingSubscriptionReward] = await db
+        .select()
+        .from(pointLedger)
+        .where(
+          and(
+            eq(pointLedger.viewerId, creditedViewer.id),
+            eq(pointLedger.kind, "channel_subscription"),
+          ),
+        )
+        .limit(1);
+      if (existingSubscriptionReward) {
+        return {
+          mode: "database" as const,
+          deduped: false,
+          eventLogInserted: true,
+          viewerCreated,
+          balanceUpdated: false,
+          ledgerInserted: false,
+          linkMatched: false,
+          viewerId: creditedViewer.id,
+          ignoredReason: "subscription_already_rewarded",
+        };
+      }
+    }
 
     await db
       .update(viewerBalances)
       .set({
-        currentBalance: sql`${viewerBalances.currentBalance} + ${input.amount}`,
+        currentBalance: sql`${viewerBalances.currentBalance} + ${eventAmount}`,
         lifetimeEarned:
-          input.amount > 0
-            ? sql`${viewerBalances.lifetimeEarned} + ${input.amount}`
+          eventAmount > 0
+            ? sql`${viewerBalances.lifetimeEarned} + ${eventAmount}`
             : viewerBalances.lifetimeEarned,
         lifetimeSpent:
-          input.amount < 0
-            ? sql`${viewerBalances.lifetimeSpent} + ${Math.abs(input.amount)}`
+          eventAmount < 0
+            ? sql`${viewerBalances.lifetimeSpent} + ${Math.abs(eventAmount)}`
             : viewerBalances.lifetimeSpent,
         lastSyncedAt: new Date(),
       })
@@ -7927,9 +8470,11 @@ export async function ingestStreamerbotEvent(input: {
           ? "presence_tick"
           : input.eventType === "chat_bonus"
             ? "chat_bonus"
-            : "manual_adjustment",
-      amount: input.amount,
-      source: "streamerbot",
+            : input.eventType === "channel_subscription"
+              ? "channel_subscription"
+              : "manual_adjustment",
+      amount: eventAmount,
+      source: input.eventType === "channel_subscription" ? "channel_subscription" : "streamerbot",
       externalEventId: input.eventId,
       metadata: input.payload,
       createdAt: new Date(input.occurredAt),

--- a/src/lib/db/repository.ts
+++ b/src/lib/db/repository.ts
@@ -155,7 +155,7 @@ const DEFAULT_PIPETZ_PRICING: PipetzPricingRecord = {
   updatedBy: null,
 };
 const CHANNEL_SUBSCRIPTION_REWARD_AMOUNT = 2000;
-const LIKE_GOAL_PRESENCE_WINDOW_MS = 5 * 60 * 1000;
+const LIKE_GOAL_PRESENCE_CRITERION = "presence_tick desde o início da live";
 
 type StreamerbotCounterCommandAction = "increment" | "decrement" | "get" | "reset";
 type StreamerbotCounterScopeType = "global" | "game";
@@ -7941,14 +7941,14 @@ export async function deleteLiveLikeGoal(goalId: string) {
   return serializeLiveLikeGoal(deleted);
 }
 
-function getDemoPresentViewerIds(store: DemoStore, occurredAt: string) {
-  const cutoff = new Date(occurredAt).getTime() - LIKE_GOAL_PRESENCE_WINDOW_MS;
+function getDemoPresentViewerIds(store: DemoStore, occurredAt: string, broadcastId: string) {
+  const occurredTime = new Date(occurredAt).getTime();
   const present = store.ledger
     .filter(
       (entry) =>
         entry.kind === "presence_tick" &&
-        new Date(entry.createdAt).getTime() >= cutoff &&
-        new Date(entry.createdAt).getTime() <= new Date(occurredAt).getTime(),
+        readStringFromPayload(entry.metadata, "broadcastId") === broadcastId &&
+        new Date(entry.createdAt).getTime() <= occurredTime,
     )
     .map((entry) => entry.viewerId);
 
@@ -7958,13 +7958,12 @@ function getDemoPresentViewerIds(store: DemoStore, occurredAt: string) {
   });
 }
 
-async function getDatabasePresentViewerIds(occurredAt: string) {
+async function getDatabasePresentViewerIds(occurredAt: string, broadcastId: string) {
   const db = getDb();
   if (!db) {
     return [];
   }
   const occurred = new Date(occurredAt);
-  const cutoff = new Date(occurred.getTime() - LIKE_GOAL_PRESENCE_WINDOW_MS);
   const rows = await db
     .select({
       viewerId: pointLedger.viewerId,
@@ -7975,7 +7974,7 @@ async function getDatabasePresentViewerIds(occurredAt: string) {
     .where(
       and(
         eq(pointLedger.kind, "presence_tick"),
-        gte(pointLedger.createdAt, cutoff),
+        sql`${pointLedger.metadata}->>'broadcastId' = ${broadcastId}`,
         lt(pointLedger.createdAt, occurred),
         eq(users.excludeFromRanking, false),
       ),
@@ -8112,7 +8111,7 @@ export async function ingestStreamerbotEvent(input: {
             (reward) => reward.goalId === goal.id && reward.broadcastId === broadcastId,
           ),
       );
-      const presentViewerIds = getDemoPresentViewerIds(store, input.occurredAt);
+      const presentViewerIds = getDemoPresentViewerIds(store, input.occurredAt, broadcastId);
       for (const goal of eligibleGoals) {
         for (const viewerId of presentViewerIds) {
           const balance = getBalance(store, viewerId);
@@ -8130,7 +8129,7 @@ export async function ingestStreamerbotEvent(input: {
               broadcastId,
               likeCount,
               targetLikeCount: goal.targetLikeCount,
-              presenceCriterion: "presence_tick nos últimos 5 minutos",
+              presenceCriterion: LIKE_GOAL_PRESENCE_CRITERION,
             },
             createdAt: input.occurredAt,
           });
@@ -8294,7 +8293,7 @@ export async function ingestStreamerbotEvent(input: {
     const [goalRows, rewardRows, presentViewerIds] = await Promise.all([
       db.select().from(liveLikeGoals).where(eq(liveLikeGoals.isActive, true)),
       db.select().from(liveLikeGoalRewards).where(eq(liveLikeGoalRewards.broadcastId, broadcastId)),
-      getDatabasePresentViewerIds(input.occurredAt),
+      getDatabasePresentViewerIds(input.occurredAt, broadcastId),
     ]);
     const paidGoalIds = new Set(rewardRows.map((entry) => entry.goalId));
     const eligibleGoals = goalRows
@@ -8345,7 +8344,7 @@ export async function ingestStreamerbotEvent(input: {
               broadcastId,
               likeCount,
               targetLikeCount: goal.targetLikeCount,
-              presenceCriterion: "presence_tick nos últimos 5 minutos",
+              presenceCriterion: LIKE_GOAL_PRESENCE_CRITERION,
             },
             createdAt: new Date(input.occurredAt),
           });

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -182,6 +182,7 @@ export const betEntries = pgTable(
       .references(() => users.id)
       .notNull(),
     amount: integer("amount").notNull(),
+    isHouseEntry: boolean("is_house_entry").default(false).notNull(),
     payoutAmount: integer("payout_amount"),
     settledAt: timestamp("settled_at", { withTimezone: true }),
     refundedAt: timestamp("refunded_at", { withTimezone: true }),
@@ -189,6 +190,38 @@ export const betEntries = pgTable(
   },
   (table) => ({
     betViewerIdx: uniqueIndex("bet_entries_bet_viewer_idx").on(table.betId, table.viewerId),
+  }),
+);
+
+export const liveLikeGoals = pgTable("live_like_goals", {
+  id: varchar("id", { length: 64 }).primaryKey(),
+  label: varchar("label", { length: 255 }),
+  targetLikeCount: integer("target_like_count").notNull(),
+  rewardAmount: integer("reward_amount").notNull(),
+  isActive: boolean("is_active").default(true).notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+export const liveLikeGoalRewards = pgTable(
+  "live_like_goal_rewards",
+  {
+    id: varchar("id", { length: 64 }).primaryKey(),
+    goalId: varchar("goal_id", { length: 64 })
+      .references(() => liveLikeGoals.id)
+      .notNull(),
+    broadcastId: varchar("broadcast_id", { length: 128 }).notNull(),
+    likeCount: integer("like_count").notNull(),
+    rewardAmount: integer("reward_amount").notNull(),
+    rewardedViewerCount: integer("rewarded_viewer_count").notNull(),
+    totalAmount: integer("total_amount").notNull(),
+    paidAt: timestamp("paid_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => ({
+    goalBroadcastIdx: uniqueIndex("live_like_goal_rewards_goal_broadcast_idx").on(
+      table.goalId,
+      table.broadcastId,
+    ),
   }),
 );
 

--- a/src/lib/demo-data.ts
+++ b/src/lib/demo-data.ts
@@ -373,6 +373,7 @@ export const demoBetEntries: BetEntryRecord[] = [
     optionId: "opt-2b",
     viewerId: "viewer_ana",
     amount: 400,
+    isHouseEntry: false,
     payoutAmount: 683,
     settledAt: new Date(now.getTime() - 23 * 60 * 60 * 1000).toISOString(),
     refundedAt: null,

--- a/src/lib/streamerbot/live-status.ts
+++ b/src/lib/streamerbot/live-status.ts
@@ -12,6 +12,7 @@ import type {
 const LIVE_REQUIRED_EVENT_TYPES: StreamerbotEventType[] = [
   "presence_tick",
   "chat_bonus",
+  "like_count_update",
 ];
 const LIVE_STATUS_CACHE_TTL_MS = 15_000;
 const LIVE_STATUS_REQUEST_TIMEOUT_MS = 5_000;

--- a/src/lib/streamerbot/schemas.ts
+++ b/src/lib/streamerbot/schemas.ts
@@ -205,7 +205,13 @@ export const adminAirdropSchema = z.object({
 
 export const streamerbotEventSchema = z.object({
   eventId: z.string().min(3),
-  eventType: z.enum(["presence_tick", "chat_bonus", "manual_adjustment"]),
+  eventType: z.enum([
+    "presence_tick",
+    "chat_bonus",
+    "manual_adjustment",
+    "channel_subscription",
+    "like_count_update",
+  ]),
   viewerExternalId: z.string().min(1).optional(),
   youtubeDisplayName: z.string().min(1).optional(),
   youtubeHandle: z.string().min(1).optional(),
@@ -213,6 +219,13 @@ export const streamerbotEventSchema = z.object({
   balance: z.number().int().optional(),
   occurredAt: z.string().datetime(),
   payload: z.record(z.string(), z.unknown()).default({}),
+});
+
+export const liveLikeGoalSchema = z.object({
+  label: z.string().trim().max(255).optional(),
+  targetLikeCount: z.number().int().min(1).max(1_000_000),
+  rewardAmount: z.number().int().min(1).max(100_000),
+  isActive: z.boolean().default(true),
 });
 
 export const bridgeHeartbeatSchema = z.object({

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -8,6 +8,8 @@ export type CatalogItemType =
 export type LedgerKind =
   | "presence_tick"
   | "chat_bonus"
+  | "channel_subscription"
+  | "like_goal_reward"
   | "admin_airdrop"
   | "manual_adjustment"
   | "redemption_debit"
@@ -40,7 +42,9 @@ export type RedemptionStatus =
 export type StreamerbotEventType =
   | "presence_tick"
   | "chat_bonus"
-  | "manual_adjustment";
+  | "manual_adjustment"
+  | "channel_subscription"
+  | "like_count_update";
 
 export type GameSuggestionStatus =
   | "open"
@@ -393,10 +397,36 @@ export interface BetEntryRecord {
   optionId: string;
   viewerId: string;
   amount: number;
+  isHouseEntry?: boolean;
   payoutAmount: number | null;
   settledAt: string | null;
   refundedAt: string | null;
   createdAt: string;
+}
+
+export interface LiveLikeGoalRecord {
+  id: string;
+  label: string | null;
+  targetLikeCount: number;
+  rewardAmount: number;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface LiveLikeGoalRewardRecord {
+  id: string;
+  goalId: string;
+  broadcastId: string;
+  likeCount: number;
+  rewardAmount: number;
+  rewardedViewerCount: number;
+  totalAmount: number;
+  paidAt: string;
+}
+
+export interface LiveLikeGoalAdminRecord extends LiveLikeGoalRecord {
+  lastReward: LiveLikeGoalRewardRecord | null;
 }
 
 export interface BetViewerPositionRecord {

--- a/streamerbot/channel-subscription-reward.cs
+++ b/streamerbot/channel-subscription-reward.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+
+public class CPHInline
+{
+    private static readonly HttpClient Http = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+
+    public bool Execute()
+    {
+        string appBaseUrl = ReadRequiredGlobal("lojaneon.appBaseUrl");
+        string sharedSecret = ReadRequiredGlobal("lojaneon.streamerbotSharedSecret");
+        string viewerExternalId = FirstArg("userId", "targetUserId", "user");
+        string youtubeDisplayName = FirstArg("user", "userName", "displayName");
+        string youtubeHandle = FirstArg("userName", "user");
+        string broadcastId = FirstArg("broadcastId");
+
+        if (string.IsNullOrWhiteSpace(appBaseUrl) || string.IsNullOrWhiteSpace(sharedSecret) || string.IsNullOrWhiteSpace(viewerExternalId))
+        {
+            CPH.LogWarn("[Loja Pipetz] New Subscriber sem app, segredo ou viewerExternalId.");
+            return false;
+        }
+
+        string timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString();
+        string occurredAt = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
+        string eventId = string.Format("subscription-{0}-{1}", viewerExternalId, timestamp);
+        string body = BuildBody(eventId, viewerExternalId, youtubeDisplayName, youtubeHandle, occurredAt, broadcastId);
+
+        return PostSigned(appBaseUrl, sharedSecret, timestamp, body);
+    }
+
+    private bool PostSigned(string appBaseUrl, string sharedSecret, string timestamp, string body)
+    {
+        using (var request = new HttpRequestMessage(HttpMethod.Post, string.Format("{0}/api/internal/streamerbot/events", appBaseUrl.TrimEnd('/'))))
+        {
+            request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+            request.Headers.Add("x-timestamp", timestamp);
+            request.Headers.Add("x-signature", BuildSignature(sharedSecret, timestamp, body));
+            HttpResponseMessage response = Http.SendAsync(request).GetAwaiter().GetResult();
+            string responseBody = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            CPH.LogInfo(string.Format("[Loja Pipetz] channel_subscription status={0} body={1}", (int)response.StatusCode, responseBody));
+            return response.IsSuccessStatusCode;
+        }
+    }
+
+    private string ReadRequiredGlobal(string variableName)
+    {
+        try { return CPH.GetGlobalVar<string>(variableName, true) ?? string.Empty; }
+        catch { return string.Empty; }
+    }
+
+    private string FirstArg(params string[] names)
+    {
+        foreach (string name in names)
+        {
+            if (args != null && args.ContainsKey(name) && args[name] != null)
+            {
+                string value = args[name].ToString().Trim();
+                if (!string.IsNullOrWhiteSpace(value)) return value;
+            }
+            if (CPH.TryGetArg(name, out string typed) && !string.IsNullOrWhiteSpace(typed)) return typed.Trim();
+        }
+        return string.Empty;
+    }
+
+    private static string BuildBody(string eventId, string viewerExternalId, string youtubeDisplayName, string youtubeHandle, string occurredAt, string broadcastId)
+    {
+        var builder = new StringBuilder();
+        builder.Append("{");
+        builder.AppendFormat("\"eventId\":\"{0}\"", Escape(eventId));
+        builder.Append(",\"eventType\":\"channel_subscription\"");
+        builder.AppendFormat(",\"viewerExternalId\":\"{0}\"", Escape(viewerExternalId));
+        if (!string.IsNullOrWhiteSpace(youtubeDisplayName)) builder.AppendFormat(",\"youtubeDisplayName\":\"{0}\"", Escape(youtubeDisplayName));
+        if (!string.IsNullOrWhiteSpace(youtubeHandle)) builder.AppendFormat(",\"youtubeHandle\":\"{0}\"", Escape(youtubeHandle));
+        builder.AppendFormat(",\"occurredAt\":\"{0}\"", occurredAt);
+        builder.Append(",\"payload\":{\"source\":\"streamerbot\"");
+        if (!string.IsNullOrWhiteSpace(broadcastId)) builder.AppendFormat(",\"broadcastId\":\"{0}\"", Escape(broadcastId));
+        builder.Append("}}");
+        return builder.ToString();
+    }
+
+    private static string BuildSignature(string secret, string timestamp, string body)
+    {
+        using (var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret)))
+        {
+            byte[] hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(string.Format("{0}.{1}", timestamp, body)));
+            return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+        }
+    }
+
+    private static string Escape(string value)
+    {
+        return (value ?? string.Empty).Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\r", "\\r").Replace("\n", "\\n").Replace("\t", "\\t");
+    }
+}

--- a/streamerbot/like-count-update.cs
+++ b/streamerbot/like-count-update.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+
+public class CPHInline
+{
+    private static readonly HttpClient Http = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+
+    public bool Execute()
+    {
+        string appBaseUrl = ReadRequiredGlobal("lojaneon.appBaseUrl");
+        string sharedSecret = ReadRequiredGlobal("lojaneon.streamerbotSharedSecret");
+        int likeCount = ReadIntArg("likeCount");
+        string broadcastId = FirstArg("broadcastId");
+        bool isLive = ReadBoolArg("isLive");
+
+        if (string.IsNullOrWhiteSpace(appBaseUrl) || string.IsNullOrWhiteSpace(sharedSecret) || likeCount <= 0)
+        {
+            CPH.LogWarn("[Loja Pipetz] Statistics Updated sem app, segredo ou likeCount.");
+            return false;
+        }
+
+        string timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString();
+        string occurredAt = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
+        string eventId = string.Format("likes-{0}-{1}", string.IsNullOrWhiteSpace(broadcastId) ? "live" : broadcastId, timestamp);
+        string body = BuildBody(eventId, likeCount, occurredAt, broadcastId, isLive);
+
+        using (var request = new HttpRequestMessage(HttpMethod.Post, string.Format("{0}/api/internal/streamerbot/events", appBaseUrl.TrimEnd('/'))))
+        {
+            request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+            request.Headers.Add("x-timestamp", timestamp);
+            request.Headers.Add("x-signature", BuildSignature(sharedSecret, timestamp, body));
+            HttpResponseMessage response = Http.SendAsync(request).GetAwaiter().GetResult();
+            string responseBody = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            CPH.LogInfo(string.Format("[Loja Pipetz] like_count_update status={0} body={1}", (int)response.StatusCode, responseBody));
+            return response.IsSuccessStatusCode;
+        }
+    }
+
+    private string ReadRequiredGlobal(string variableName)
+    {
+        try { return CPH.GetGlobalVar<string>(variableName, true) ?? string.Empty; }
+        catch { return string.Empty; }
+    }
+
+    private int ReadIntArg(string argName)
+    {
+        if (CPH.TryGetArg(argName, out int typedValue)) return typedValue;
+        if (CPH.TryGetArg(argName, out string rawValue) && int.TryParse(rawValue, out int parsed)) return parsed;
+        return 0;
+    }
+
+    private bool ReadBoolArg(string argName)
+    {
+        if (CPH.TryGetArg(argName, out bool typedValue)) return typedValue;
+        if (CPH.TryGetArg(argName, out string rawValue)) return string.Equals(rawValue, "true", StringComparison.OrdinalIgnoreCase) || rawValue == "1";
+        return false;
+    }
+
+    private string FirstArg(params string[] names)
+    {
+        foreach (string name in names)
+        {
+            if (args != null && args.ContainsKey(name) && args[name] != null)
+            {
+                string value = args[name].ToString().Trim();
+                if (!string.IsNullOrWhiteSpace(value)) return value;
+            }
+            if (CPH.TryGetArg(name, out string typed) && !string.IsNullOrWhiteSpace(typed)) return typed.Trim();
+        }
+        return string.Empty;
+    }
+
+    private static string BuildBody(string eventId, int likeCount, string occurredAt, string broadcastId, bool isLive)
+    {
+        var builder = new StringBuilder();
+        builder.Append("{");
+        builder.AppendFormat("\"eventId\":\"{0}\"", Escape(eventId));
+        builder.Append(",\"eventType\":\"like_count_update\"");
+        builder.AppendFormat(",\"balance\":{0}", likeCount);
+        builder.AppendFormat(",\"occurredAt\":\"{0}\"", occurredAt);
+        builder.Append(",\"payload\":{");
+        builder.Append("\"source\":\"streamerbot\"");
+        builder.AppendFormat(",\"likeCount\":{0}", likeCount);
+        builder.AppendFormat(",\"isLive\":{0}", isLive ? "true" : "false");
+        if (!string.IsNullOrWhiteSpace(broadcastId)) builder.AppendFormat(",\"broadcastId\":\"{0}\"", Escape(broadcastId));
+        builder.Append("}}");
+        return builder.ToString();
+    }
+
+    private static string BuildSignature(string secret, string timestamp, string body)
+    {
+        using (var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret)))
+        {
+            byte[] hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(string.Format("{0}.{1}", timestamp, body)));
+            return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+        }
+    }
+
+    private static string Escape(string value)
+    {
+        return (value ?? string.Empty).Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\r", "\\r").Replace("\n", "\\n").Replace("\t", "\\t");
+    }
+}


### PR DESCRIPTION
## Resumo

- adiciona aposta automática da casa ao travar apostas com opções zeradas
- adiciona eventos Streamer.bot para inscrição no canal e atualização de likes
- adiciona metas de likes no admin, ledger de recompensas e histórico por live
- inclui migration, documentação e scripts C# para configurar os triggers no Streamer.bot

## Impacto

Apostas travadas passam a equilibrar opções sem pool com uma entrada identificada como aposta da casa. Inscrições recebem 2000 pipetz uma única vez por viewer, e metas de likes pagam viewers presentes uma vez por meta e por `broadcastId`.

## Validação

- `npx tsc --noEmit`
- `npm test`
- `npm run lint` (passa com warning existente em `admin-dashboard-tabs.tsx`)
- `npm run build`

Closes #98
Closes #107