### PR TITLE
[codex] Fix spending history dark mode

### DIFF
--- a/src/components/pipetz-spending-history-card.tsx
+++ b/src/components/pipetz-spending-history-card.tsx
@@ -25,7 +25,7 @@ export function PipetzSpendingHistoryCard({
           </p>
         </div>
 
-        <div className="overflow-hidden rounded-[var(--radius)] border-[3px] border-[var(--color-ink)] bg-white">
+        <div className="overflow-hidden rounded-[var(--radius)] border-[3px] border-[var(--color-ink)] bg-[var(--surface-card)]">
           {visibleEntries.length > 0 ? (
             <ul className="divide-y-[3px] divide-[var(--color-ink)]">
               {visibleEntries.map((entry) => (


### PR DESCRIPTION
## Summary

- Replaces the fixed white background on the Pipetz spending history list with the themed `--surface-card` token.
- Keeps the light-mode appearance the same while allowing the card surface to become dark in dark mode.

## Root cause

The history list container used `bg-white`, so dark mode updated the text colors but left the panel bright, making the component look washed out and inconsistent.

## Validation

- `npm run lint` passed with one existing warning in `src/components/admin-dashboard-tabs.tsx` about `aria-pressed` on `role="tab"`.
- `npm run build` passed.