### PR TITLE
[codex] Criar overlay de meta de likes

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ Mais detalhes ficam em `bridge/README.md`.
 - `/contadores`: contadores públicos.
 - `/privacy`: política de privacidade.
 - `/admin`: operação da live.
+- `/obs/likes`: browser source para a meta de likes no OBS.
 - `/obs/quotes`: browser source para quotes no OBS.
+- `/obs/bets`: browser source para apostas abertas no OBS.
 
 ## Setup local
 

--- a/docs/streamerbot-live-rewards.md
+++ b/docs/streamerbot-live-rewards.md
@@ -27,6 +27,13 @@ Esta integração usa `POST /api/internal/streamerbot/events` com HMAC, como os 
   - `occurredAt`: data em ISO
 - Critério de presença: viewers com ledger `presence_tick` na mesma `broadcastId` do evento de likes, desde o início da live até o momento em que a meta bateu.
 
+### Overlay da meta de likes
+
+- Abra `/obs/likes` como Browser Source no OBS ou em ferramenta equivalente.
+- Use `/obs/likes?demo=1` para testar o visual sem depender de eventos reais.
+- O overlay lê a meta ativa cadastrada no admin e o último `like_count_update` aceito pela API.
+- Para atualizar o progresso ao vivo, mantenha o script `streamerbot/like-count-update.cs` em uma action ligada ao trigger `YouTube > Broadcast > Statistics Updated`.
+
 Fontes da configuração Streamer.bot:
 
 - https://docs.streamer.bot/api/triggers/youtube/general/new-subscriber

--- a/src/app/api/obs/likes/current/route.ts
+++ b/src/app/api/obs/likes/current/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+
+import { getLiveLikeGoalOverlayState } from "@/lib/db/repository";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const state = await getLiveLikeGoalOverlayState();
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: state,
+    },
+    {
+      headers: {
+        "Cache-Control": "no-store, max-age=0, must-revalidate",
+      },
+    },
+  );
+}

--- a/src/app/obs/likes/page.tsx
+++ b/src/app/obs/likes/page.tsx
@@ -1,0 +1,5 @@
+import { ObsLikeGoalOverlay } from "@/components/obs-like-goal-overlay";
+
+export default function ObsLikesPage() {
+  return <ObsLikeGoalOverlay />;
+}

--- a/src/components/admin-obs-overlays-panel.tsx
+++ b/src/components/admin-obs-overlays-panel.tsx
@@ -26,6 +26,14 @@ const overlays = [
     apiHref: "/api/obs/quotes/current",
   },
   {
+    id: "likes",
+    name: "Meta de likes no OBS",
+    description: "Overlay da meta ativa de likes, com contador, progresso e recompensa exibidos ao vivo.",
+    liveHref: "/obs/likes",
+    demoHref: "/obs/likes?demo=1",
+    apiHref: "/api/obs/likes/current",
+  },
+  {
     id: "bets",
     name: "Apostas no OBS",
     description: "Overlay da aposta aberta, com pool, opções e distribuição dos votos atualizados automaticamente.",

--- a/src/components/obs-like-goal-overlay.tsx
+++ b/src/components/obs-like-goal-overlay.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import type { LiveLikeGoalOverlayStateRecord } from "@/lib/types";
+import { formatPipetz } from "@/lib/utils";
+
+const DEMO_UPDATED_AT = "2026-06-01T21:00:00.000Z";
+
+const DEMO_STATE: LiveLikeGoalOverlayStateRecord = {
+  currentLikeCount: 42,
+  updatedAt: DEMO_UPDATED_AT,
+  broadcastId: "demo-live",
+  goal: {
+    id: "demo-like-goal",
+    label: "Meta 50 likes",
+    targetLikeCount: 50,
+    rewardAmount: 150,
+    isActive: true,
+    createdAt: DEMO_UPDATED_AT,
+    updatedAt: DEMO_UPDATED_AT,
+  },
+  progressPercent: 84,
+  remainingLikes: 8,
+  isGoalReached: false,
+};
+
+function formatNumber(value: number) {
+  return new Intl.NumberFormat("pt-BR").format(value);
+}
+
+export function ObsLikeGoalOverlay() {
+  const searchParams = useSearchParams();
+  const isDemo = searchParams.get("demo") === "1";
+  const [liveState, setLiveState] = useState<LiveLikeGoalOverlayStateRecord | null>(null);
+
+  useEffect(() => {
+    if (isDemo) {
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    async function loadState() {
+      try {
+        const response = await fetch("/api/obs/likes/current", {
+          cache: "no-store",
+        });
+
+        if (!response.ok) {
+          return;
+        }
+
+        const payload = (await response.json()) as {
+          ok: boolean;
+          data: LiveLikeGoalOverlayStateRecord;
+        };
+
+        if (!cancelled) {
+          setLiveState(payload.data);
+        }
+      } catch {
+        if (!cancelled) {
+          setLiveState(null);
+        }
+      }
+    }
+
+    void loadState();
+    const interval = window.setInterval(() => {
+      void loadState();
+    }, 1000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [isDemo]);
+
+  const state = isDemo ? DEMO_STATE : liveState;
+  const goal = state?.goal ?? null;
+  const currentLikeCount = state?.currentLikeCount ?? 0;
+  const progressPercent = state?.progressPercent ?? 0;
+
+  return (
+    <div className="pointer-events-none flex min-h-screen items-end justify-center p-6 sm:justify-end sm:p-10 lg:p-14">
+      <section
+        className="min-w-0 overflow-hidden border-[4px] border-black bg-[#fff6db] text-black shadow-[12px_12px_0_#000]"
+        style={{ width: "min(1040px, 92vw)" }}
+        aria-live="polite"
+      >
+        <div className="p-4 sm:p-5">
+          {!state ? (
+            <div className="border-[3px] border-black bg-white p-5 text-2xl font-black uppercase">
+              Carregando meta de likes.
+            </div>
+          ) : goal ? (
+            <div className="grid gap-4 lg:grid-cols-[minmax(180px,0.55fr)_minmax(360px,1fr)_auto] lg:items-center">
+              <p className="min-w-0 break-words text-2xl font-black uppercase sm:text-3xl">
+                {goal.label || `${formatNumber(goal.targetLikeCount)} likes`}
+              </p>
+
+              <div className="border-[4px] border-black bg-white">
+                <div className="relative h-12 overflow-hidden">
+                  <div
+                    className="h-full bg-[#ff66b3] transition-[width] duration-500"
+                    style={{ width: `${progressPercent}%` }}
+                  />
+                  <div className="absolute inset-0 flex items-center justify-start px-4 text-lg font-black uppercase sm:justify-end">
+                    {formatNumber(currentLikeCount)}/{formatNumber(goal.targetLikeCount)}
+                  </div>
+                </div>
+              </div>
+
+              <span className="block w-full max-w-full break-words border-[3px] border-black bg-[#41d1ff] px-3 py-1 text-xs font-black uppercase sm:w-auto sm:text-base">
+                {formatPipetz(goal.rewardAmount)} pipetz pra cada presente
+              </span>
+            </div>
+          ) : (
+            <div className="border-[3px] border-black bg-white p-5 text-2xl font-black uppercase">
+              Configure uma meta ativa no admin.
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/lib/db/repository.test.ts
+++ b/src/lib/db/repository.test.ts
@@ -78,6 +78,7 @@ import {
   ensureViewerFromSession,
   getViewerDashboard,
   getActiveQuoteOverlay,
+  getLiveLikeGoalOverlayState,
   getObsOverlayAdminStatus,
   getSessionViewerState,
   getViewerLinkCodeState,
@@ -3358,6 +3359,77 @@ describe("ingestStreamerbotEvent", () => {
         goalId: goal.id,
         broadcastId: "live-like-goal-1",
         presenceCriterion: "presence_tick desde o início da live",
+      },
+    });
+  });
+
+  it("returns the initial like goal overlay state from the first active goal", async () => {
+    getDbMock.mockReturnValue(null);
+
+    const goal = await createLiveLikeGoal({
+      label: "Meta 50 likes",
+      targetLikeCount: 50,
+      rewardAmount: 150,
+      isActive: true,
+    });
+
+    const state = await getLiveLikeGoalOverlayState();
+
+    expect(state).toMatchObject({
+      currentLikeCount: 0,
+      updatedAt: null,
+      broadcastId: null,
+      progressPercent: 0,
+      remainingLikes: 50,
+      isGoalReached: false,
+      goal: {
+        id: goal.id,
+        label: "Meta 50 likes",
+        targetLikeCount: 50,
+      },
+    });
+  });
+
+  it("updates the like goal overlay state from the latest like count event", async () => {
+    getDbMock.mockReturnValue(null);
+
+    await createLiveLikeGoal({
+      label: "Meta 30 likes",
+      targetLikeCount: 30,
+      rewardAmount: 100,
+      isActive: true,
+    });
+    const nextGoal = await createLiveLikeGoal({
+      label: "Meta 50 likes",
+      targetLikeCount: 50,
+      rewardAmount: 150,
+      isActive: true,
+    });
+
+    await ingestStreamerbotEvent({
+      eventId: "likes-overlay-1",
+      eventType: "like_count_update",
+      balance: 42,
+      occurredAt: "2026-04-01T12:30:00.000Z",
+      payload: {
+        broadcastId: "live-like-overlay",
+        isLive: true,
+      },
+    });
+
+    const state = await getLiveLikeGoalOverlayState();
+
+    expect(state).toMatchObject({
+      currentLikeCount: 42,
+      updatedAt: "2026-04-01T12:30:00.000Z",
+      broadcastId: "live-like-overlay",
+      progressPercent: 84,
+      remainingLikes: 8,
+      isGoalReached: false,
+      goal: {
+        id: nextGoal.id,
+        label: "Meta 50 likes",
+        targetLikeCount: 50,
       },
     });
   });

--- a/src/lib/db/repository.ts
+++ b/src/lib/db/repository.ts
@@ -97,6 +97,7 @@ import {
   LedgerEntryRecord,
   LiveLikeGoalAdminRecord,
   LiveLikeGoalRecord,
+  LiveLikeGoalOverlayStateRecord,
   LiveLikeGoalRewardRecord,
   ObsOverlayAdminStatusRecord,
   ObsOverlayControlRecord,
@@ -107,6 +108,7 @@ import {
   QuoteRecord,
   ProductRecommendationRecord,
   RedemptionRecord,
+  StreamerbotEventType,
   StreamerbotCounterRecord,
   StreamerbotCounterSummaryRecord,
   VideoSuggestionBoostRecord,
@@ -400,6 +402,15 @@ type DemoStore = {
   productRecommendations: ProductRecommendationRecord[];
   bridgeClients: BridgeClientRecord[];
   streamerbotCounters: StreamerbotCounterRecord[];
+  streamerbotEvents: DemoStreamerbotEventLogRecord[];
+};
+
+type DemoStreamerbotEventLogRecord = {
+  eventId: string;
+  eventType: StreamerbotEventType;
+  balance: number | null;
+  payload: Record<string, unknown>;
+  occurredAt: string;
 };
 
 declare global {
@@ -436,6 +447,7 @@ function getDemoStore(): DemoStore {
       productRecommendations: structuredClone(demoProductRecommendations),
       bridgeClients: structuredClone(demoBridgeClients),
       streamerbotCounters: [],
+      streamerbotEvents: [],
     };
   }
 
@@ -1606,6 +1618,71 @@ function readNumberFromPayload(payload: Record<string, unknown>, key: string) {
 function readStringFromPayload(payload: Record<string, unknown>, key: string) {
   const value = payload[key];
   return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return value as Record<string, unknown>;
+}
+
+function readLikeCountFromStreamerbotEvent(input: {
+  balance?: number | null;
+  payload: Record<string, unknown>;
+}) {
+  const likeCount =
+    readNumberFromPayload(input.payload, "likeCount") ??
+    readNumberFromPayload(input.payload, "balance") ??
+    input.balance ??
+    0;
+
+  return Math.max(0, Math.floor(likeCount));
+}
+
+function buildStreamerbotEventLogPayload(input: {
+  eventType: StreamerbotEventType;
+  balance?: number;
+  payload: Record<string, unknown>;
+}) {
+  if (input.eventType !== "like_count_update") {
+    return input.payload;
+  }
+
+  return {
+    ...input.payload,
+    likeCount: readLikeCountFromStreamerbotEvent(input),
+  };
+}
+
+function buildLiveLikeGoalOverlayState(
+  goals: LiveLikeGoalRecord[],
+  latestEvent: {
+    balance?: number | null;
+    occurredAt: string;
+    payload: Record<string, unknown>;
+  } | null,
+): LiveLikeGoalOverlayStateRecord {
+  const currentLikeCount = latestEvent ? readLikeCountFromStreamerbotEvent(latestEvent) : 0;
+  const activeGoals = goals
+    .filter((goal) => goal.isActive)
+    .sort((left, right) => left.targetLikeCount - right.targetLikeCount);
+  const goal =
+    activeGoals.find((entry) => entry.targetLikeCount > currentLikeCount) ??
+    activeGoals[activeGoals.length - 1] ??
+    null;
+
+  return {
+    currentLikeCount,
+    updatedAt: latestEvent?.occurredAt ?? null,
+    broadcastId: latestEvent ? readStringFromPayload(latestEvent.payload, "broadcastId") : null,
+    goal,
+    progressPercent: goal
+      ? Math.min(100, Math.round((currentLikeCount / goal.targetLikeCount) * 100))
+      : 0,
+    remainingLikes: goal ? Math.max(goal.targetLikeCount - currentLikeCount, 0) : null,
+    isGoalReached: goal ? currentLikeCount >= goal.targetLikeCount : false,
+  };
 }
 
 function buildViewerPosition(
@@ -7966,6 +8043,38 @@ export async function listAdminLiveLikeGoals(): Promise<LiveLikeGoalAdminRecord[
   return goalRows.map((goal) => buildLiveLikeGoalAdminRecord(serializeLiveLikeGoal(goal), rewards));
 }
 
+export async function getLiveLikeGoalOverlayState(): Promise<LiveLikeGoalOverlayStateRecord> {
+  const db = getDb();
+  if (isDemoMode || !db) {
+    const store = getDemoStore();
+    const latestEvent =
+      store.streamerbotEvents
+        .filter((entry) => entry.eventType === "like_count_update")
+        .sort((left, right) => new Date(right.occurredAt).getTime() - new Date(left.occurredAt).getTime())[0] ??
+      null;
+
+    return buildLiveLikeGoalOverlayState(store.liveLikeGoals, latestEvent);
+  }
+
+  const [goalRows, latestEventRows] = await Promise.all([
+    db.select().from(liveLikeGoals).where(eq(liveLikeGoals.isActive, true)).orderBy(liveLikeGoals.targetLikeCount),
+    db
+      .select()
+      .from(streamerbotEventLog)
+      .where(eq(streamerbotEventLog.eventType, "like_count_update"))
+      .orderBy(desc(streamerbotEventLog.occurredAt))
+      .limit(1),
+  ]);
+  const latestEvent = latestEventRows[0]
+    ? {
+        occurredAt: latestEventRows[0].occurredAt.toISOString(),
+        payload: asRecord(latestEventRows[0].payload),
+      }
+    : null;
+
+  return buildLiveLikeGoalOverlayState(goalRows.map(serializeLiveLikeGoal), latestEvent);
+}
+
 export async function createLiveLikeGoal(input: {
   label?: string | null;
   targetLikeCount: number;
@@ -8209,8 +8318,12 @@ export async function ingestStreamerbotEvent(input: {
   const db = getDb();
   if (isDemoMode || !db) {
     const store = getDemoStore();
+    const eventLogPayload = buildStreamerbotEventLogPayload(input);
 
-    if (store.ledger.some((entry) => entry.externalEventId === input.eventId)) {
+    if (
+      store.streamerbotEvents.some((entry) => entry.eventId === input.eventId) ||
+      store.ledger.some((entry) => entry.externalEventId === input.eventId)
+    ) {
       return {
         mode: "demo" as const,
         deduped: true,
@@ -8222,9 +8335,20 @@ export async function ingestStreamerbotEvent(input: {
       };
     }
 
+    store.streamerbotEvents.unshift({
+      eventId: input.eventId,
+      eventType: input.eventType,
+      balance: input.balance ?? null,
+      payload: eventLogPayload,
+      occurredAt: input.occurredAt,
+    });
+
     if (input.eventType === "like_count_update") {
-      const likeCount = readNumberFromPayload(input.payload, "likeCount") ?? input.balance ?? 0;
-      const broadcastId = readStringFromPayload(input.payload, "broadcastId") ?? "demo_live";
+      const likeCount = readLikeCountFromStreamerbotEvent({
+        balance: input.balance,
+        payload: eventLogPayload,
+      });
+      const broadcastId = readStringFromPayload(eventLogPayload, "broadcastId") ?? "demo_live";
       const eligibleGoals = store.liveLikeGoals.filter(
         (goal) =>
           goal.isActive &&
@@ -8399,19 +8523,24 @@ export async function ingestStreamerbotEvent(input: {
     };
   }
 
+  const eventLogPayload = buildStreamerbotEventLogPayload(input);
+
   await db.insert(streamerbotEventLog).values({
     id: randomUUID(),
     eventId: input.eventId,
     eventType: input.eventType,
     viewerExternalId: input.viewerExternalId ?? null,
-    payload: input.payload,
+    payload: eventLogPayload,
     occurredAt: new Date(input.occurredAt),
     signatureValid: true,
   });
 
   if (input.eventType === "like_count_update") {
-    const likeCount = readNumberFromPayload(input.payload, "likeCount") ?? input.balance ?? 0;
-    const broadcastId = readStringFromPayload(input.payload, "broadcastId") ?? "current_live";
+    const likeCount = readLikeCountFromStreamerbotEvent({
+      balance: input.balance,
+      payload: eventLogPayload,
+    });
+    const broadcastId = readStringFromPayload(eventLogPayload, "broadcastId") ?? "current_live";
     const [goalRows, rewardRows, presentViewerIds] = await Promise.all([
       db.select().from(liveLikeGoals).where(eq(liveLikeGoals.isActive, true)),
       db.select().from(liveLikeGoalRewards).where(eq(liveLikeGoalRewards.broadcastId, broadcastId)),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -441,6 +441,16 @@ export interface LiveLikeGoalAdminRecord extends LiveLikeGoalRecord {
   lastReward: LiveLikeGoalRewardRecord | null;
 }
 
+export interface LiveLikeGoalOverlayStateRecord {
+  currentLikeCount: number;
+  updatedAt: string | null;
+  broadcastId: string | null;
+  goal: LiveLikeGoalRecord | null;
+  progressPercent: number;
+  remainingLikes: number | null;
+  isGoalReached: boolean;
+}
+
 export interface BetViewerPositionRecord {
   amount: number;
   optionId: string;


### PR DESCRIPTION
## O que mudou

- Adiciona o overlay OBS `/obs/likes` e o modo demo `/obs/likes?demo=1`.
- Adiciona o feed JSON `/api/obs/likes/current` para a meta ativa de likes.
- Usa o último evento `like_count_update` aceito para calcular o progresso da meta.
- Lista o novo overlay no painel admin de browser sources.
- Documenta a configuração necessária para OBS e Streamer.bot.

## Impacto

O OBS pode usar uma browser source fixa para mostrar a meta de likes da live, com barra de progresso, contador `likes/meta` e recompensa por pessoa presente.

## Validação

- `npm test -- src/lib/db/repository.test.ts`
- `npm run lint` (passa com warning preexistente em `src/components/admin-dashboard-tabs.tsx`)
- `npm run build`
- Verificação visual do overlay em desktop/mobile durante a implementação

Closes #109