### PR TITLE
[codex] Add Twitch-style live wheel

### DIFF
--- a/docs/twitch-wheel.md
+++ b/docs/twitch-wheel.md
@@ -1,0 +1,63 @@
+# Roleta estilo Twitch
+
+## Rotas
+
+- Admin: `/admin`, aba `Operação`, painel `Roleta da live`.
+- Overlay para OBS: `/obs/wheel`.
+- Demo visual do overlay: `/obs/wheel?demo=1`.
+- Feed JSON do overlay: `GET /api/obs/wheel/current`.
+- Giro assinado pelo Streamer.bot: `POST /api/internal/streamerbot/wheel`.
+
+## Configuração no app
+
+No painel admin, cadastre as opções da roleta. Cada opção tem:
+
+- nome exibido no overlay;
+- peso do sorteio, em que valores maiores aumentam a chance;
+- cor do segmento;
+- estado ativo ou pausado.
+
+O app salva a configuração em `streamerbot_counters`, na chave `twitch_wheel_config`, então não é necessário alterar código para trocar prêmios.
+
+## OBS
+
+Adicione um `Browser Source` apontando para `/obs/wheel`.
+
+Sugestão de cena:
+
+- largura: `1920`;
+- altura: `1080`;
+- CSS customizado: deixe vazio, a página já remove a moldura normal do app para rotas `/obs/*`.
+
+O resultado é decidido no servidor antes da animação. O overlay apenas anima até a opção escolhida e mantém o resultado visível pelo tempo configurado.
+
+## Streamer.bot
+
+Crie uma action ou comando no Streamer.bot que faça `POST` para:
+
+```text
+{lojaneon.appBaseUrl}/api/internal/streamerbot/wheel
+```
+
+Use o mesmo padrão HMAC das outras integrações do projeto:
+
+- header `x-timestamp` com Unix time em milissegundos;
+- header `x-signature` com HMAC SHA-256 de `<timestamp>.<body_json>`;
+- segredo global `lojaneon.streamerbotSharedSecret`, equivalente a `STREAMERBOT_SHARED_SECRET` no app.
+
+Corpo mínimo:
+
+```json
+{
+  "requestedBy": "chat",
+  "source": "streamerbot_chat"
+}
+```
+
+Se o comando for acionado por viewer, envie `requestedBy` com o nome do viewer ou do moderador. O endpoint responde com `replyMessage`, `result` e a configuração atual da roleta.
+
+Consulte a documentação oficial atual do Streamer.bot antes de recriar a action:
+
+- Execute C# Code: https://docs.streamer.bot/api/sub-actions/core/csharp/execute-csharp-code/
+- Arguments & Variables: https://docs.streamer.bot/api/csharp/guide/variables
+- SendYouTubeMessageToLatestMonitored: https://docs.streamer.bot/api/csharp/methods/youtube/chat/send-youtube-message-to-latest-monitored

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -7,6 +7,7 @@ import { AdminVideoSuggestionsPanel } from "@/components/admin-video-suggestions
 import { AdminPipetzPricingPanel } from "@/components/admin-pipetz-pricing-panel";
 import { AdminPipetzAirdropPanel } from "@/components/admin-pipetz-airdrop-panel";
 import { AdminLiveLikeGoalsPanel } from "@/components/admin-live-like-goals-panel";
+import { AdminWheelPanel } from "@/components/admin-wheel-panel";
 import { AdminRecommendationsPanel } from "@/components/admin-recommendations-panel";
 import { AdminViewerLinksPanel } from "@/components/admin-viewer-links-panel";
 import { RedemptionGrid } from "@/components/redemption-grid";
@@ -30,6 +31,7 @@ import {
 import { getStreamerbotLivestreamStatus } from "@/lib/streamerbot/live-status";
 import { getCurrentGame } from "@/lib/current-game";
 import { formatDateTime, formatPipetz } from "@/lib/utils";
+import { getWheelConfig } from "@/lib/wheel";
 
 const statusColorMap: Record<string, string> = {
   queued: "var(--color-lavender)",
@@ -41,7 +43,7 @@ const statusColorMap: Record<string, string> = {
 
 export default async function AdminPage() {
   await requireAdminSession();
-  const [catalog, leaderboard, bridge, liveStatus, currentGame, redemptions, bets, likeGoals, suggestions, videoSuggestions, recommendations, viewers, obsOverlayStatus, pricing] = await Promise.all([
+  const [catalog, leaderboard, bridge, liveStatus, currentGame, redemptions, bets, likeGoals, suggestions, videoSuggestions, recommendations, viewers, obsOverlayStatus, pricing, wheelConfig] = await Promise.all([
     getCatalog(),
     getLeaderboard(),
     getBridgeStatus(),
@@ -56,6 +58,7 @@ export default async function AdminPage() {
     listAdminViewerDirectory(),
     getObsOverlayAdminStatus(),
     getPipetzPricing(),
+    getWheelConfig(),
   ]);
 
   return (
@@ -106,6 +109,7 @@ export default async function AdminPage() {
               <div className="grid gap-6 xl:grid-cols-[0.95fr_1.05fr]">
                 <div className="space-y-6">
                   <LiveStatusPanel bridge={bridge} initialStatus={liveStatus} />
+                  <AdminWheelPanel initialConfig={wheelConfig} />
                   <AdminCurrentGamePanel initialGame={currentGame} />
                   <AdminPipetzPricingPanel initialPricing={pricing} />
                   <AdminLiveLikeGoalsPanel initialGoals={likeGoals} />

--- a/src/app/api/admin/wheel/route.ts
+++ b/src/app/api/admin/wheel/route.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+import { fail, isTrustedAppMutationRequest, ok, requireAdminApiSession } from "@/lib/api";
+import { wheelConfigSchema } from "@/lib/streamerbot/schemas";
+import { getWheelConfig, updateWheelConfig } from "@/lib/wheel";
+
+export async function GET() {
+  const session = await requireAdminApiSession();
+  if (!session) {
+    return fail("Forbidden", 403);
+  }
+
+  return ok(await getWheelConfig());
+}
+
+export async function PUT(request: Request) {
+  if (!isTrustedAppMutationRequest(request)) {
+    return fail("Forbidden", 403);
+  }
+
+  const session = await requireAdminApiSession();
+  if (!session) {
+    return fail("Forbidden", 403);
+  }
+
+  try {
+    const payload = wheelConfigSchema.parse(await request.json());
+    const updatedBy = session.user?.email?.toLowerCase() ?? null;
+    return ok(await updateWheelConfig({ ...payload, updatedBy }));
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return fail("Dados inválidos para a roleta.", 400);
+    }
+    return fail(error instanceof Error ? error.message : "Falha ao salvar roleta.", 400);
+  }
+}

--- a/src/app/api/admin/wheel/spin/route.ts
+++ b/src/app/api/admin/wheel/spin/route.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+import { fail, isTrustedAppMutationRequest, ok, requireAdminApiSession } from "@/lib/api";
+import { wheelSpinRequestSchema } from "@/lib/streamerbot/schemas";
+import { triggerWheelSpin } from "@/lib/wheel";
+
+export async function POST(request: Request) {
+  if (!isTrustedAppMutationRequest(request)) {
+    return fail("Forbidden", 403);
+  }
+
+  const session = await requireAdminApiSession();
+  if (!session) {
+    return fail("Forbidden", 403);
+  }
+
+  try {
+    const parsed = wheelSpinRequestSchema.parse(await request.json().catch(() => ({})));
+    return ok(await triggerWheelSpin(parsed));
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return fail("Dados inválidos para o giro da roleta.", 400);
+    }
+    return fail(error instanceof Error ? error.message : "Falha ao girar roleta.", 400);
+  }
+}

--- a/src/app/api/internal/streamerbot/wheel/route.ts
+++ b/src/app/api/internal/streamerbot/wheel/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+
+import { ok } from "@/lib/api";
+import { env } from "@/lib/env";
+import { wheelSpinRequestSchema } from "@/lib/streamerbot/schemas";
+import { verifySignedRequest } from "@/lib/streamerbot/security";
+import { triggerWheelSpin } from "@/lib/wheel";
+
+export async function POST(request: Request) {
+  const raw = await request.text();
+  const timestamp = request.headers.get("x-timestamp");
+  const signature = request.headers.get("x-signature");
+
+  const valid = verifySignedRequest({
+    body: raw,
+    timestamp,
+    signature,
+    secret: env.STREAMERBOT_SHARED_SECRET,
+  });
+  if (!valid) {
+    console.warn("[streamerbot/wheel] Invalid signature.", {
+      hasSecret: Boolean(env.STREAMERBOT_SHARED_SECRET),
+      hasTimestamp: Boolean(timestamp),
+      hasSignature: Boolean(signature),
+    });
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "Invalid signature.",
+        replyMessage: "Assinatura inválida no comando da roleta.",
+      },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const payload = wheelSpinRequestSchema.parse(JSON.parse(raw || "{}"));
+    const config = await triggerWheelSpin({ ...payload, source: payload.source ?? "streamerbot_chat" });
+    const result = config.lastSpin;
+
+    console.info("[streamerbot/wheel] Triggered wheel spin.", {
+      requestedBy: payload.requestedBy,
+      result: result?.label,
+      spinId: result?.spinId,
+    });
+
+    return ok({
+      config,
+      result,
+      replyMessage: result ? `Roleta girando: ${result.label}.` : "Roleta girando.",
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Falha ao girar roleta.";
+    console.error("[streamerbot/wheel] Failed to process payload.", error);
+    return NextResponse.json(
+      {
+        ok: false,
+        error: message,
+        replyMessage: "Não consegui girar a roleta agora.",
+      },
+      { status: 400 },
+    );
+  }
+}

--- a/src/app/api/obs/wheel/current/route.ts
+++ b/src/app/api/obs/wheel/current/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+
+import { getWheelConfig } from "@/lib/wheel";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const config = await getWheelConfig();
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: config,
+    },
+    {
+      headers: {
+        "Cache-Control": "no-store, max-age=0, must-revalidate",
+      },
+    },
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
 import { Archivo_Black, IBM_Plex_Mono, DM_Sans, Geist } from "next/font/google";
+import Script from "next/script";
 
 import { auth } from "@/auth";
 import { AppChrome } from "@/components/app-chrome";
@@ -82,7 +83,9 @@ export default async function RootLayout({
       style={initialTheme ? { colorScheme: initialTheme } : undefined}
     >
       <body className="min-h-full text-[var(--color-ink)]" style={{ fontFamily: "var(--font-body), var(--font-display), sans-serif" }}>
-        <script id="pipetz-theme" dangerouslySetInnerHTML={{ __html: themeScript }} />
+        <Script id="pipetz-theme" strategy="beforeInteractive">
+          {themeScript}
+        </Script>
         <Providers>
           <AppChrome
             session={session}

--- a/src/app/obs/wheel/page.tsx
+++ b/src/app/obs/wheel/page.tsx
@@ -1,0 +1,5 @@
+import { ObsWheelOverlay } from "@/components/obs-wheel-overlay";
+
+export default function ObsWheelPage() {
+  return <ObsWheelOverlay />;
+}

--- a/src/components/admin-obs-overlays-panel.tsx
+++ b/src/components/admin-obs-overlays-panel.tsx
@@ -41,6 +41,14 @@ const overlays = [
     demoHref: "/obs/bets?demo=1",
     apiHref: "/api/obs/bets/current",
   },
+  {
+    id: "wheel",
+    name: "Roleta no OBS",
+    description: "Overlay da roleta da live, com animação visual e resultado final mantido na tela.",
+    liveHref: "/obs/wheel",
+    demoHref: "/obs/wheel?demo=1",
+    apiHref: "/api/obs/wheel/current",
+  },
 ];
 
 export function AdminObsOverlaysPanel({

--- a/src/components/admin-wheel-panel.tsx
+++ b/src/components/admin-wheel-panel.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { Plus, Save, Trash2, Play } from "lucide-react";
+import { useState, useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { WheelConfigRecord, WheelOptionRecord } from "@/lib/types";
+import { formatDateTime } from "@/lib/utils";
+
+const palette = ["#ff66b3", "#41d1ff", "#00beae", "#ffe066", "#b4ff39", "#d7b7ff"];
+
+function buildOption(index: number): WheelOptionRecord {
+  return {
+    id: `opcao_${index + 1}`,
+    label: "",
+    weight: 1,
+    color: palette[index % palette.length],
+    isActive: true,
+    sortOrder: index,
+  };
+}
+
+export function AdminWheelPanel({ initialConfig }: { initialConfig: WheelConfigRecord }) {
+  const router = useRouter();
+  const [title, setTitle] = useState(initialConfig.title);
+  const [spinDurationMs, setSpinDurationMs] = useState(String(initialConfig.spinDurationMs));
+  const [resultHoldSeconds, setResultHoldSeconds] = useState(String(initialConfig.resultHoldSeconds));
+  const [options, setOptions] = useState<WheelOptionRecord[]>(initialConfig.options);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const activeCount = options.filter((option) => option.isActive && option.label.trim()).length;
+  const canSave = title.trim().length > 0 && activeCount >= 2;
+
+  function updateOption(optionId: string, patch: Partial<WheelOptionRecord>) {
+    setOptions((current) =>
+      current.map((option) => (option.id === optionId ? { ...option, ...patch } : option)),
+    );
+  }
+
+  function addOption() {
+    setOptions((current) => [...current, buildOption(current.length)]);
+  }
+
+  function removeOption(optionId: string) {
+    setOptions((current) =>
+      current.filter((option) => option.id !== optionId).map((option, index) => ({ ...option, sortOrder: index })),
+    );
+  }
+
+  function saveConfig() {
+    if (!canSave) {
+      setFeedback("Cadastre pelo menos duas opções ativas.");
+      return;
+    }
+
+    setFeedback(null);
+    startTransition(async () => {
+      const response = await fetch("/api/admin/wheel", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          title: title.trim(),
+          spinDurationMs: Number.parseInt(spinDurationMs, 10),
+          resultHoldSeconds: Number.parseInt(resultHoldSeconds, 10),
+          options: options
+            .map((option, index) => ({ ...option, label: option.label.trim(), sortOrder: index }))
+            .filter((option) => option.label),
+        }),
+      });
+      const payload = (await response.json()) as { ok?: boolean; error?: string; data?: WheelConfigRecord };
+      if (!response.ok || !payload.ok || !payload.data) {
+        setFeedback(payload.error ?? "Falha ao salvar roleta.");
+        return;
+      }
+
+      setTitle(payload.data.title);
+      setSpinDurationMs(String(payload.data.spinDurationMs));
+      setResultHoldSeconds(String(payload.data.resultHoldSeconds));
+      setOptions(payload.data.options);
+      setFeedback("Roleta salva.");
+      router.refresh();
+    });
+  }
+
+  function spinWheel() {
+    setFeedback(null);
+    startTransition(async () => {
+      const response = await fetch("/api/admin/wheel/spin", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ source: "admin", requestedBy: "admin" }),
+      });
+      const payload = (await response.json()) as { ok?: boolean; error?: string; data?: WheelConfigRecord };
+      if (!response.ok || !payload.ok || !payload.data?.lastSpin) {
+        setFeedback(payload.error ?? "Falha ao girar roleta.");
+        return;
+      }
+
+      setFeedback(`Resultado: ${payload.data.lastSpin.label}.`);
+      router.refresh();
+    });
+  }
+
+  return (
+    <section className="panel surface-section p-6">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
+            Roleta da live
+          </p>
+          <h2 className="mt-2 text-3xl uppercase" style={{ fontFamily: "var(--font-display)" }}>
+            Prêmios do chat
+          </h2>
+        </div>
+        {feedback ? <div className="retro-label neutral-chip max-w-sm">{feedback}</div> : null}
+      </div>
+
+      <div className="mt-6 grid gap-4 lg:grid-cols-[1fr_180px_180px]">
+        <label className="grid gap-2">
+          <span className="text-sm font-black uppercase tracking-[0.14em]">Título</span>
+          <Input value={title} onChange={(event) => setTitle(event.target.value)} />
+        </label>
+        <label className="grid gap-2">
+          <span className="text-sm font-black uppercase tracking-[0.14em]">Animação</span>
+          <Input
+            type="number"
+            min={2500}
+            max={12000}
+            value={spinDurationMs}
+            onChange={(event) => setSpinDurationMs(event.target.value)}
+          />
+        </label>
+        <label className="grid gap-2">
+          <span className="text-sm font-black uppercase tracking-[0.14em]">Visível por</span>
+          <Input
+            type="number"
+            min={5}
+            max={120}
+            value={resultHoldSeconds}
+            onChange={(event) => setResultHoldSeconds(event.target.value)}
+          />
+        </label>
+      </div>
+
+      <div className="mt-6 grid gap-3">
+        {options.map((option, index) => (
+          <article
+            key={option.id}
+            className="card-flat grid gap-3 bg-[var(--color-paper)] p-4 lg:grid-cols-[44px_1fr_110px_110px_auto]"
+          >
+            <button
+              type="button"
+              className="h-11 w-11 border-[3px] border-[var(--color-ink)]"
+              style={{ backgroundColor: option.color }}
+              title="Cor da opção"
+              onClick={() => updateOption(option.id, { color: palette[(palette.indexOf(option.color) + 1) % palette.length] ?? palette[0] })}
+            />
+            <Input
+              value={option.label}
+              placeholder={`Opção ${index + 1}`}
+              onChange={(event) => updateOption(option.id, { label: event.target.value })}
+            />
+            <Input
+              type="number"
+              min={1}
+              max={100}
+              value={option.weight}
+              onChange={(event) => updateOption(option.id, { weight: Number.parseInt(event.target.value, 10) || 1 })}
+            />
+            <label className="flex min-h-11 items-center gap-2 text-sm font-black uppercase">
+              <input
+                type="checkbox"
+                checked={option.isActive}
+                onChange={(event) => updateOption(option.id, { isActive: event.target.checked })}
+              />
+              Ativa
+            </label>
+            <Button
+              type="button"
+              variant="danger"
+              size="icon"
+              onClick={() => removeOption(option.id)}
+              disabled={isPending || options.length <= 2}
+              title="Remover opção"
+            >
+              <Trash2 aria-hidden="true" />
+            </Button>
+          </article>
+        ))}
+      </div>
+
+      <div className="mt-5 flex flex-wrap items-center gap-3">
+        <Button type="button" variant="neutral" onClick={addOption} disabled={isPending || options.length >= 24}>
+          <Plus aria-hidden="true" />
+          Adicionar
+        </Button>
+        <Button type="button" variant="success" onClick={saveConfig} disabled={isPending || !canSave}>
+          <Save aria-hidden="true" />
+          Salvar
+        </Button>
+        <Button type="button" variant="accent" onClick={spinWheel} disabled={isPending || activeCount < 2}>
+          <Play aria-hidden="true" />
+          Girar agora
+        </Button>
+        <Link href="/obs/wheel" className="btn-brutal ink-button px-5 py-2.5 text-sm">
+          Abrir overlay
+        </Link>
+        <Link href="/obs/wheel?demo=1" className="btn-brutal bg-[var(--color-paper)] px-5 py-2.5 text-sm">
+          Abrir demo
+        </Link>
+      </div>
+
+      <div className="mt-4 grid gap-1 text-sm font-bold text-[var(--color-ink-soft)]">
+        <p>URL do OBS: /obs/wheel</p>
+        <p>Feed JSON: /api/obs/wheel/current</p>
+        {initialConfig.lastSpin ? <p>Último resultado: {initialConfig.lastSpin.label} em {formatDateTime(initialConfig.lastSpin.startedAt)}</p> : null}
+      </div>
+    </section>
+  );
+}

--- a/src/components/obs-wheel-overlay.tsx
+++ b/src/components/obs-wheel-overlay.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+
+import type { WheelConfigRecord, WheelSpinRecord } from "@/lib/types";
+
+const DEMO_CONFIG: WheelConfigRecord = {
+  title: "Roleta da live",
+  spinDurationMs: 5200,
+  resultHoldSeconds: 30,
+  updatedAt: null,
+  updatedBy: null,
+  lastSpin: {
+    spinId: "demo-spin",
+    optionId: "demo-2",
+    label: "Desafio do chat",
+    color: "#00beae",
+    requestedBy: "chat",
+    source: "demo",
+    startedAt: new Date().toISOString(),
+    spinDurationMs: 5200,
+    resultVisibleUntil: new Date(Date.now() + 60_000).toISOString(),
+  },
+  options: [
+    { id: "demo-1", label: "Bônus de pipetz", weight: 1, color: "#ff66b3", isActive: true, sortOrder: 0 },
+    { id: "demo-2", label: "Desafio do chat", weight: 1, color: "#00beae", isActive: true, sortOrder: 1 },
+    { id: "demo-3", label: "Escolhe um jogo", weight: 1, color: "#41d1ff", isActive: true, sortOrder: 2 },
+    { id: "demo-4", label: "Tenta de novo", weight: 1, color: "#ffe066", isActive: true, sortOrder: 3 },
+  ],
+};
+
+function buildGradient(options: WheelConfigRecord["options"]) {
+  const active = options.filter((option) => option.isActive);
+  const total = active.reduce((sum, option) => sum + option.weight, 0);
+  let cursor = 0;
+  return active
+    .map((option) => {
+      const start = cursor;
+      cursor += (option.weight / total) * 360;
+      return `${option.color} ${start}deg ${cursor}deg`;
+    })
+    .join(", ");
+}
+
+function getOptionCenter(options: WheelConfigRecord["options"], optionId: string) {
+  const active = options.filter((option) => option.isActive);
+  const total = active.reduce((sum, option) => sum + option.weight, 0);
+  let cursor = 0;
+  for (const option of active) {
+    const size = (option.weight / total) * 360;
+    if (option.id === optionId) {
+      return cursor + size / 2;
+    }
+    cursor += size;
+  }
+  return 0;
+}
+
+function isSpinVisible(spin: WheelSpinRecord | null) {
+  return spin ? new Date(spin.resultVisibleUntil).getTime() > Date.now() : false;
+}
+
+export function ObsWheelOverlay() {
+  const searchParams = useSearchParams();
+  const isDemo = searchParams.get("demo") === "1";
+  const [config, setConfig] = useState<WheelConfigRecord | null>(isDemo ? DEMO_CONFIG : null);
+  const [rotation, setRotation] = useState(0);
+  const [lastSpinId, setLastSpinId] = useState<string | null>(null);
+  const spin = config?.lastSpin ?? null;
+  const visibleSpin = isSpinVisible(spin) ? spin : null;
+  const activeOptions = useMemo(() => config?.options.filter((option) => option.isActive) ?? [], [config]);
+  const gradient = useMemo(() => buildGradient(activeOptions), [activeOptions]);
+
+  useEffect(() => {
+    if (isDemo) {
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    async function loadWheel() {
+      try {
+        const response = await fetch("/api/obs/wheel/current", { cache: "no-store" });
+        if (!response.ok) {
+          return;
+        }
+        const payload = (await response.json()) as { ok: boolean; data: WheelConfigRecord };
+        if (!cancelled) {
+          setConfig(payload.data);
+        }
+      } catch {
+        if (!cancelled) {
+          setConfig(null);
+        }
+      }
+    }
+
+    void loadWheel();
+    const interval = window.setInterval(() => {
+      void loadWheel();
+    }, 1000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [isDemo]);
+
+  useEffect(() => {
+    if (!spin || !config || spin.spinId === lastSpinId) {
+      return;
+    }
+
+    const center = getOptionCenter(config.options, spin.optionId);
+    const timeout = window.setTimeout(() => {
+      setRotation((current) => Math.ceil(current / 360) * 360 + 2160 - center);
+      setLastSpinId(spin.spinId);
+    }, 0);
+
+    return () => window.clearTimeout(timeout);
+  }, [config, lastSpinId, spin]);
+
+  if (!config || activeOptions.length < 2) {
+    return null;
+  }
+
+  return (
+    <div className="pointer-events-none flex min-h-screen items-center justify-center p-6 text-black">
+      <section className="grid w-full max-w-[1120px] items-center gap-8 lg:grid-cols-[620px_1fr]" aria-live="polite">
+        <div className="relative aspect-square w-full">
+          <div className="absolute left-1/2 top-[-18px] z-20 h-0 w-0 -translate-x-1/2 border-x-[28px] border-t-[56px] border-x-transparent border-t-black" />
+          <div
+            className="absolute inset-0 rounded-full border-[8px] border-black shadow-[16px_16px_0_#000]"
+            style={{
+              background: `conic-gradient(${gradient})`,
+              transform: `rotate(${rotation}deg)`,
+              transition: `transform ${spin?.spinDurationMs ?? config.spinDurationMs}ms cubic-bezier(.12,.82,.16,1)`,
+            }}
+          >
+            <div className="absolute inset-[13%] rounded-full border-[6px] border-black bg-[#fff6db]" />
+            <div className="absolute inset-[39%] rounded-full border-[5px] border-black bg-white" />
+          </div>
+        </div>
+
+        <div className="border-[5px] border-black bg-[#fff6db] p-7 shadow-[12px_12px_0_#000]">
+          <p className="text-xs font-black uppercase tracking-[0.28em]">{config.title}</p>
+          <h1
+            className="mt-3 text-5xl font-black uppercase leading-none lg:text-6xl"
+            style={{ fontFamily: "var(--font-display)" }}
+          >
+            {visibleSpin ? visibleSpin.label : "Pronta para girar"}
+          </h1>
+          <p className="mt-4 border-[3px] border-black px-4 py-2 text-sm font-black uppercase tracking-[0.18em]" style={{ backgroundColor: visibleSpin?.color ?? "#41d1ff" }}>
+            {visibleSpin ? "Resultado final" : `${activeOptions.length} opções ativas`}
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/lib/streamerbot/schemas.ts
+++ b/src/lib/streamerbot/schemas.ts
@@ -228,7 +228,28 @@ export const liveLikeGoalSchema = z.object({
   isActive: z.boolean().default(true),
 });
 
-export const bridgeHeartbeatSchema = z.object({
+const wheelColorSchema = z
+  .string()
+  .trim()
+  .regex(/^#[0-9a-fA-F]{6}$/);
+export const wheelOptionSchema = z.object({
+  id: z.string().trim().min(1).max(64).optional(),
+  label: z.string().trim().min(1).max(80),
+  weight: z.number().int().min(1).max(100).default(1),
+  color: wheelColorSchema.default("#41d1ff"),
+  isActive: z.boolean().default(true),
+  sortOrder: z.number().int().min(0).max(999).default(0),
+});
+export const wheelConfigSchema = z.object({
+  title: z.string().trim().min(1).max(80).default("Roleta da live"),
+  spinDurationMs: z.number().int().min(2500).max(12000).default(5200),
+  resultHoldSeconds: z.number().int().min(5).max(120).default(30),
+  options: z.array(wheelOptionSchema).min(2).max(24),
+});
+export const wheelSpinRequestSchema = z.object({
+  requestedBy: z.string().trim().min(1).max(255).optional(),
+  source: z.string().trim().min(1).max(64).default("web"),
+});export const bridgeHeartbeatSchema = z.object({
   bridgeId: z.string().min(1),
   machineKey: z.string().min(1),
   label: z.string().min(1),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -327,7 +327,34 @@ export interface PipetzPricingRecord {
   updatedBy: string | null;
 }
 
-export interface StreamerbotCounterRecord {
+export interface WheelOptionRecord {
+  id: string;
+  label: string;
+  weight: number;
+  color: string;
+  isActive: boolean;
+  sortOrder: number;
+}
+export interface WheelSpinRecord {
+  spinId: string;
+  optionId: string;
+  label: string;
+  color: string;
+  requestedBy: string | null;
+  source: string;
+  startedAt: string;
+  spinDurationMs: number;
+  resultVisibleUntil: string;
+}
+export interface WheelConfigRecord {
+  title: string;
+  spinDurationMs: number;
+  resultHoldSeconds: number;
+  options: WheelOptionRecord[];
+  updatedAt: string | null;
+  updatedBy: string | null;
+  lastSpin: WheelSpinRecord | null;
+}export interface StreamerbotCounterRecord {
   key: string;
   scopeType: string;
   scopeKey: string;

--- a/src/lib/wheel.ts
+++ b/src/lib/wheel.ts
@@ -1,0 +1,327 @@
+import { randomInt, randomUUID } from "node:crypto";
+
+import { eq } from "drizzle-orm";
+
+import { getDb } from "@/lib/db/client";
+import { streamerbotCounters } from "@/lib/db/schema";
+import { isDemoMode } from "@/lib/env";
+import type { WheelConfigRecord, WheelOptionRecord, WheelSpinRecord } from "@/lib/types";
+import { slugify } from "@/lib/utils";
+
+const WHEEL_CONFIG_KEY = "twitch_wheel_config";
+const WHEEL_SETTING_SCOPE_TYPE = "setting";
+const WHEEL_SETTING_SCOPE_KEY = "twitch_wheel";
+const WHEEL_DEFAULT_COLORS = ["#ff66b3", "#41d1ff", "#00beae", "#ffe066", "#b4ff39", "#d7b7ff"];
+
+const DEFAULT_WHEEL_CONFIG: WheelConfigRecord = {
+  title: "Roleta da live",
+  spinDurationMs: 5200,
+  resultHoldSeconds: 30,
+  updatedAt: null,
+  updatedBy: null,
+  lastSpin: null,
+  options: [
+    { id: "pipetz_bonus", label: "Bônus de pipetz", weight: 1, color: "#ff66b3", isActive: true, sortOrder: 0 },
+    { id: "escolhe_jogo", label: "Escolhe um jogo", weight: 1, color: "#41d1ff", isActive: true, sortOrder: 1 },
+    { id: "desafio_chat", label: "Desafio do chat", weight: 1, color: "#00beae", isActive: true, sortOrder: 2 },
+    { id: "tenta_de_novo", label: "Tenta de novo", weight: 1, color: "#ffe066", isActive: true, sortOrder: 3 },
+  ],
+};
+
+declare global {
+  var __pipetzWheelConfig: WheelConfigRecord | undefined;
+}
+
+function isMissingStreamerbotCountersTableError(error: unknown) {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const maybePostgresError = error as Error & {
+    code?: string;
+    cause?: { code?: string; message?: string };
+  };
+  const message = `${error.message} ${maybePostgresError.cause?.message ?? ""}`;
+
+  return (
+    maybePostgresError.code === "42P01" ||
+    maybePostgresError.cause?.code === "42P01" ||
+    message.includes('relation "streamerbot_counters" does not exist')
+  );
+}
+
+function sanitizeWheelColor(value: unknown, fallback: string) {
+  return typeof value === "string" && /^#[0-9a-fA-F]{6}$/.test(value) ? value : fallback;
+}
+
+function normalizeWheelOptions(value: unknown): WheelOptionRecord[] {
+  const rawOptions = Array.isArray(value) ? value : DEFAULT_WHEEL_CONFIG.options;
+  return rawOptions
+    .map((entry, index) => {
+      const option = entry as Record<string, unknown>;
+      const label = typeof option.label === "string" ? option.label.trim() : "";
+      if (!label) {
+        return null;
+      }
+
+      const rawId = typeof option.id === "string" ? option.id.trim() : "";
+      const id = rawId || slugify(label) || `option_${index + 1}`;
+      const weight =
+        typeof option.weight === "number" && Number.isFinite(option.weight)
+          ? Math.max(1, Math.min(100, Math.trunc(option.weight)))
+          : 1;
+      const sortOrder =
+        typeof option.sortOrder === "number" && Number.isFinite(option.sortOrder)
+          ? Math.max(0, Math.min(999, Math.trunc(option.sortOrder)))
+          : index;
+
+      return {
+        id: id.slice(0, 64),
+        label: label.slice(0, 80),
+        weight,
+        color: sanitizeWheelColor(option.color, WHEEL_DEFAULT_COLORS[index % WHEEL_DEFAULT_COLORS.length]),
+        isActive: option.isActive !== false,
+        sortOrder,
+      } satisfies WheelOptionRecord;
+    })
+    .filter((entry): entry is WheelOptionRecord => Boolean(entry))
+    .slice(0, 24)
+    .sort((left, right) => {
+      if (left.sortOrder !== right.sortOrder) {
+        return left.sortOrder - right.sortOrder;
+      }
+      return left.label.localeCompare(right.label, "pt-BR");
+    });
+}
+
+function normalizeWheelSpin(value: unknown): WheelSpinRecord | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const spin = value as Record<string, unknown>;
+  if (
+    typeof spin.spinId !== "string" ||
+    typeof spin.optionId !== "string" ||
+    typeof spin.label !== "string" ||
+    typeof spin.color !== "string" ||
+    typeof spin.source !== "string" ||
+    typeof spin.startedAt !== "string" ||
+    typeof spin.spinDurationMs !== "number" ||
+    typeof spin.resultVisibleUntil !== "string"
+  ) {
+    return null;
+  }
+
+  return {
+    spinId: spin.spinId,
+    optionId: spin.optionId,
+    label: spin.label,
+    color: sanitizeWheelColor(spin.color, "#41d1ff"),
+    requestedBy: typeof spin.requestedBy === "string" ? spin.requestedBy : null,
+    source: spin.source,
+    startedAt: spin.startedAt,
+    spinDurationMs: spin.spinDurationMs,
+    resultVisibleUntil: spin.resultVisibleUntil,
+  };
+}
+
+function serializeWheelConfigRow(row: typeof streamerbotCounters.$inferSelect | null): WheelConfigRecord {
+  if (!row) {
+    return structuredClone(DEFAULT_WHEEL_CONFIG);
+  }
+
+  const metadata = row.metadata as Record<string, unknown>;
+  return {
+    title:
+      typeof metadata.title === "string" && metadata.title.trim()
+        ? metadata.title.trim().slice(0, 80)
+        : DEFAULT_WHEEL_CONFIG.title,
+    spinDurationMs:
+      typeof metadata.spinDurationMs === "number" && Number.isFinite(metadata.spinDurationMs)
+        ? Math.max(2500, Math.min(12000, Math.trunc(metadata.spinDurationMs)))
+        : DEFAULT_WHEEL_CONFIG.spinDurationMs,
+    resultHoldSeconds:
+      typeof metadata.resultHoldSeconds === "number" && Number.isFinite(metadata.resultHoldSeconds)
+        ? Math.max(5, Math.min(120, Math.trunc(metadata.resultHoldSeconds)))
+        : DEFAULT_WHEEL_CONFIG.resultHoldSeconds,
+    options: normalizeWheelOptions(metadata.options),
+    updatedAt: row.updatedAt.toISOString(),
+    updatedBy: typeof metadata.updatedBy === "string" ? metadata.updatedBy : null,
+    lastSpin: normalizeWheelSpin(metadata.lastSpin),
+  };
+}
+
+function getDemoWheelConfig() {
+  globalThis.__pipetzWheelConfig ??= structuredClone(DEFAULT_WHEEL_CONFIG);
+  return globalThis.__pipetzWheelConfig;
+}
+
+export async function getWheelConfig(): Promise<WheelConfigRecord> {
+  const db = getDb();
+  if (isDemoMode || !db) {
+    return structuredClone(getDemoWheelConfig());
+  }
+
+  try {
+    const [row] = await db
+      .select()
+      .from(streamerbotCounters)
+      .where(eq(streamerbotCounters.key, WHEEL_CONFIG_KEY))
+      .limit(1);
+    return serializeWheelConfigRow(row ?? null);
+  } catch (error) {
+    if (isMissingStreamerbotCountersTableError(error)) {
+      return structuredClone(DEFAULT_WHEEL_CONFIG);
+    }
+    throw error;
+  }
+}
+
+export async function updateWheelConfig(input: {
+  title: string;
+  spinDurationMs: number;
+  resultHoldSeconds: number;
+  options: unknown;
+  updatedBy: string | null;
+}): Promise<WheelConfigRecord> {
+  const current = await getWheelConfig();
+  const updatedAt = new Date();
+  const metadata = {
+    title: input.title,
+    spinDurationMs: input.spinDurationMs,
+    resultHoldSeconds: input.resultHoldSeconds,
+    options: normalizeWheelOptions(input.options),
+    lastSpin: current.lastSpin,
+    updatedBy: input.updatedBy,
+    scopeType: WHEEL_SETTING_SCOPE_TYPE,
+    scopeKey: WHEEL_SETTING_SCOPE_KEY,
+  };
+
+  if (metadata.options.filter((option) => option.isActive).length < 2) {
+    throw new Error("A roleta precisa ter pelo menos duas opções ativas.");
+  }
+
+  const db = getDb();
+  if (isDemoMode || !db) {
+    globalThis.__pipetzWheelConfig = {
+      title: metadata.title,
+      spinDurationMs: metadata.spinDurationMs,
+      resultHoldSeconds: metadata.resultHoldSeconds,
+      options: metadata.options,
+      updatedAt: updatedAt.toISOString(),
+      updatedBy: input.updatedBy,
+      lastSpin: current.lastSpin,
+    };
+    return getWheelConfig();
+  }
+
+  await db
+    .insert(streamerbotCounters)
+    .values({
+      key: WHEEL_CONFIG_KEY,
+      value: metadata.options.length,
+      lastResetAt: null,
+      updatedAt,
+      metadata,
+    })
+    .onConflictDoUpdate({
+      target: streamerbotCounters.key,
+      set: { value: metadata.options.length, updatedAt, metadata },
+    });
+
+  return getWheelConfig();
+}
+
+function pickWheelOption(options: WheelOptionRecord[]) {
+  const active = options.filter((option) => option.isActive);
+  const totalWeight = active.reduce((sum, option) => sum + option.weight, 0);
+  let ticket = randomInt(1, totalWeight + 1);
+  for (const option of active) {
+    ticket -= option.weight;
+    if (ticket <= 0) {
+      return option;
+    }
+  }
+  return active[active.length - 1];
+}
+
+export async function triggerWheelSpin(input: {
+  requestedBy?: string | null;
+  source?: string | null;
+}): Promise<WheelConfigRecord> {
+  const current = await getWheelConfig();
+  const activeOptions = current.options.filter((option) => option.isActive);
+  if (activeOptions.length < 2) {
+    throw new Error("A roleta precisa ter pelo menos duas opções ativas.");
+  }
+
+  const selected = pickWheelOption(current.options);
+  const startedAt = new Date();
+  const lastSpin: WheelSpinRecord = {
+    spinId: randomUUID(),
+    optionId: selected.id,
+    label: selected.label,
+    color: selected.color,
+    requestedBy: input.requestedBy?.trim() || null,
+    source: input.source?.trim() || "web",
+    startedAt: startedAt.toISOString(),
+    spinDurationMs: current.spinDurationMs,
+    resultVisibleUntil: new Date(startedAt.getTime() + current.spinDurationMs + current.resultHoldSeconds * 1000).toISOString(),
+  };
+
+  return updateWheelConfig({
+    title: current.title,
+    spinDurationMs: current.spinDurationMs,
+    resultHoldSeconds: current.resultHoldSeconds,
+    options: current.options,
+    updatedBy: current.updatedBy,
+  }).then(async () => {
+    const next = await getWheelConfig();
+    next.lastSpin = lastSpin;
+
+    const db = getDb();
+    if (isDemoMode || !db) {
+      globalThis.__pipetzWheelConfig = next;
+      return getWheelConfig();
+    }
+
+    await db
+      .insert(streamerbotCounters)
+      .values({
+        key: WHEEL_CONFIG_KEY,
+        value: next.options.length,
+        lastResetAt: null,
+        updatedAt: startedAt,
+        metadata: {
+          title: next.title,
+          spinDurationMs: next.spinDurationMs,
+          resultHoldSeconds: next.resultHoldSeconds,
+          options: next.options,
+          lastSpin,
+          updatedBy: next.updatedBy,
+          scopeType: WHEEL_SETTING_SCOPE_TYPE,
+          scopeKey: WHEEL_SETTING_SCOPE_KEY,
+        },
+      })
+      .onConflictDoUpdate({
+        target: streamerbotCounters.key,
+        set: {
+          value: next.options.length,
+          updatedAt: startedAt,
+          metadata: {
+            title: next.title,
+            spinDurationMs: next.spinDurationMs,
+            resultHoldSeconds: next.resultHoldSeconds,
+            options: next.options,
+            lastSpin,
+            updatedBy: next.updatedBy,
+            scopeType: WHEEL_SETTING_SCOPE_TYPE,
+            scopeKey: WHEEL_SETTING_SCOPE_KEY,
+          },
+        },
+      });
+
+    return getWheelConfig();
+  });
+}


### PR DESCRIPTION
## Summary

- Adds a configurable Twitch-style wheel for live prizes, stored in the existing Streamer.bot counter/settings storage.
- Adds admin controls to configure options, weights, colors, duration, and to trigger a spin.
- Adds OBS routes and signed Streamer.bot trigger endpoint for the wheel overlay.
- Replaces the root theme inline script with `next/script` to satisfy Next.js 16 script rendering rules.
- Documents OBS and Streamer.bot setup for the wheel.

Closes #110

## Validation

- npm run lint
- npm test
- npm run build