### PR TITLE
Improve HLTB enrichment and live reward updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,14 @@ IGDB_CLIENT_SECRET=
 PS_PLUS_SYNC_SECRET=
 ```
 
+Checklist de deploy para Google OAuth:
+
+- Em `APP_URL` e `NEXT_PUBLIC_APP_URL`, use as URLs públicas finais do deploy, sem barra no fim.
+- No Google Cloud Console, em **Authorized redirect URIs**, cadastre uma callback para cada domínio público usado pelo app, no formato `https://seu-dominio/api/auth/callback/google`.
+- Para este projeto, o domínio principal deve ter `https://ludylops.live/api/auth/callback/google`; se o deploy da Vercel também for usado para login, cadastre também a URL equivalente de `*.vercel.app`.
+- Depois do deploy, confira `GET /api/health/public`: `data.auth.googleOAuthConfigured` deve ser `true` e `data.auth.googleOAuthCallbackUrls` mostra as callbacks esperadas.
+- Rode `npm run smoke:auth -- https://seu-dominio` para validar `/api/auth/providers` e o início do login antes de divulgar o deploy.
+
 Para Google Cross-Account Protection (RISC), configure também:
 
 ```env

--- a/docs/howlongtobeat.md
+++ b/docs/howlongtobeat.md
@@ -4,18 +4,36 @@ A página pública de jogos da comunidade exibe o tempo médio para zerar quando
 
 ## Fonte dos dados
 
-A aplicação usa o pacote `howlongtobeat`, um wrapper não oficial do site HowLongToBeat. Não há chave de API nem variável de ambiente obrigatória para essa integração.
+A aplicação consulta o próprio site HowLongToBeat em modo best-effort:
+
+1. Baixa a home do HowLongToBeat e lê os scripts referenciados no HTML.
+2. Procura dinamicamente qual endpoint `/api/...` está sendo usado pela busca do site, com fallback para `/api/s`.
+3. Chama `${searchPath}/init?t=...` para obter token e campos temporários.
+4. Envia `POST` para o endpoint descoberto com `searchType: "games"`, `modifier: "hide_dlc"` e os termos do jogo.
+
+Não há chave de API nem variável de ambiente obrigatória para essa integração.
 
 Como a fonte é baseada em busca no site, a integração trata os dados como complementares:
 
 - se houver uma correspondência confiável, o card mostra o tempo de história principal;
 - se não houver correspondência confiável, o card mostra `Sem dado confiável`;
+- DLCs são evitadas no payload e candidatos fracos são descartados pelo score;
 - falhas da fonte externa não impedem a exibição das sugestões.
 
 ## Cache
 
 Os dados são persistidos em `game_suggestions` pelas colunas `hltb_*`.
 
-O cache é atualizado quando uma sugestão é criada ou quando o admin corrige o cadastro IGDB do jogo. A listagem pública também tenta atualizar, de forma limitada, até três sugestões com cache vazio ou vencido por chamada. O cache vence depois de 30 dias.
+O cache é atualizado quando uma sugestão é criada ou quando o admin corrige o cadastro IGDB do jogo. A listagem pública também tenta atualizar, de forma limitada, até oito sugestões com cache vazio ou vencido por chamada. O cache vence depois de 30 dias.
 
-O cache também registra buscas sem correspondência confiável, evitando consultas repetidas a cada renderização.
+Buscas sem correspondência confiável são marcadas por apenas 15 minutos. Assim, falhas temporárias do site ou do deploy anterior não prendem a sugestão em estado vazio por 30 dias, e a listagem consegue avançar para outros jogos no lote seguinte.
+
+## Backfill
+
+Para preencher jogos antigos sem depender da listagem pública, rode:
+
+```bash
+npm run backfill:hltb -- --limit=100
+```
+
+Use `--dry-run` para simular e `--all-statuses` para incluir sugestões fora de `open` e `accepted`.

--- a/docs/streamerbot-live-rewards.md
+++ b/docs/streamerbot-live-rewards.md
@@ -26,6 +26,8 @@ Esta integração usa `POST /api/internal/streamerbot/events` com HMAC, como os 
   - `payload.isLive`: `true` quando o evento veio da live monitorada
   - `occurredAt`: data em ISO
 - Critério de presença: viewers com ledger `presence_tick` na mesma `broadcastId` do evento de likes, desde o início da live até o momento em que a meta bateu.
+- Overlay do OBS: use `/obs/likes` como browser source. Para testar o visual sem live, use `/obs/likes?demo=1`.
+- Feed do overlay: `/api/obs/live-like-goals/current`, atualizado pelo último `like_count_update` recebido.
 
 ### Overlay da meta de likes
 

--- a/drizzle/0017_featured_rosadiariogamer.sql
+++ b/drizzle/0017_featured_rosadiariogamer.sql
@@ -1,0 +1,89 @@
+INSERT INTO "users" (
+  "id",
+  "google_user_id",
+  "email",
+  "youtube_channel_id",
+  "youtube_display_name",
+  "youtube_handle",
+  "avatar_url",
+  "is_linked",
+  "exclude_from_ranking",
+  "created_at"
+)
+VALUES (
+  'viewer_ludylops_featured',
+  NULL,
+  NULL,
+  'system:ludylops-featured-creators',
+  'Ludylops',
+  NULL,
+  NULL,
+  false,
+  true,
+  now()
+)
+ON CONFLICT ("id") DO UPDATE SET
+  "youtube_display_name" = EXCLUDED."youtube_display_name",
+  "exclude_from_ranking" = true;
+--> statement-breakpoint
+UPDATE "creator_suggestions"
+SET
+  "viewer_id" = 'viewer_ludylops_featured',
+  "slug" = 'rosadiariogamer',
+  "name" = 'Rosa Diário Gamer',
+  "channel_url" = 'https://www.youtube.com/@rosadiariogamer',
+  "platform" = 'youtube',
+  "category" = 'games',
+  "reason" = 'Canal de games com energia próxima, presença de comunidade e um jeito gostoso de acompanhar gameplay.',
+  "status" = 'featured',
+  "total_votes" = GREATEST("total_votes", 1210),
+  "updated_at" = now()
+WHERE "id" = 'cs-featured-rosadiariogamer'
+   OR lower("slug") = 'rosadiariogamer'
+   OR lower("name") = 'rosa diário gamer'
+   OR lower("channel_url") LIKE '%@rosadiariogamer%';
+--> statement-breakpoint
+INSERT INTO "creator_suggestions" (
+  "id",
+  "viewer_id",
+  "slug",
+  "name",
+  "channel_url",
+  "platform",
+  "category",
+  "reason",
+  "status",
+  "total_votes",
+  "created_at",
+  "updated_at"
+)
+SELECT
+  'cs-featured-rosadiariogamer',
+  'viewer_ludylops_featured',
+  'rosadiariogamer',
+  'Rosa Diário Gamer',
+  'https://www.youtube.com/@rosadiariogamer',
+  'youtube',
+  'games',
+  'Canal de games com energia próxima, presença de comunidade e um jeito gostoso de acompanhar gameplay.',
+  'featured',
+  1210,
+  now(),
+  now()
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "creator_suggestions"
+  WHERE "id" = 'cs-featured-rosadiariogamer'
+     OR lower("slug") = 'rosadiariogamer'
+     OR lower("name") = 'rosa diário gamer'
+     OR lower("channel_url") LIKE '%@rosadiariogamer%'
+);
+--> statement-breakpoint
+UPDATE "creator_suggestions"
+SET
+  "status" = 'featured',
+  "total_votes" = GREATEST("total_votes", 1300),
+  "updated_at" = now()
+WHERE lower("name") = 'desce a letra'
+   OR lower("slug") IN ('desce-a-letra', 'descealetra')
+   OR lower("channel_url") LIKE '%desce%letra%';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1780502400000,
       "tag": "0016_ps_plus_deluxe_catalog",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1780425600000,
+      "tag": "0017_featured_rosadiariogamer",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.1",
         "framer-motion": "^12.38.0",
-        "howlongtobeat": "^1.8.0",
         "lucide-react": "^1.7.0",
         "next": "16.2.1",
         "next-auth": "^5.0.0-beta.30",
@@ -5047,12 +5046,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -5077,43 +5070,6 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
-        "https-proxy-agent": "^5.0.1",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
-    "node_modules/axios/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/axios/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -5188,12 +5144,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "license": "ISC"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -5386,69 +5336,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/cheerio": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
-      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
-      "license": "MIT",
-      "dependencies": {
-        "cheerio-select": "^2.1.0",
-        "dom-serializer": "^2.0.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.2.2",
-        "encoding-sniffer": "^0.2.1",
-        "htmlparser2": "^10.1.0",
-        "parse5": "^7.3.0",
-        "parse5-htmlparser2-tree-adapter": "^7.1.0",
-        "parse5-parser-stream": "^7.1.2",
-        "undici": "^7.19.0",
-        "whatwg-mimetype": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=20.18.1"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
-      }
-    },
-    "node_modules/cheerio-select": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
-      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-select": "^5.1.0",
-        "css-what": "^6.1.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/cheerio/node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/cheerio/node_modules/whatwg-mimetype": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
@@ -5608,18 +5495,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -5739,22 +5614,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/css-select": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
-      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
     "node_modules/css-tree": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
@@ -5767,18 +5626,6 @@
       },
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
-    "node_modules/css-what": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
-      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/cssesc": {
@@ -6014,15 +5861,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -6062,73 +5900,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/dom-serializer/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dotenv": {
@@ -6343,31 +6114,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/encoding-sniffer": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
-      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "^0.6.3",
-        "whatwg-encoding": "^3.1.1"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
-      }
-    },
-    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
@@ -6386,6 +6132,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -6551,6 +6298,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7290,6 +7038,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-uri": {
@@ -7456,26 +7205,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -7490,43 +7219,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/formdata-polyfill": {
@@ -7935,6 +7627,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -7990,18 +7683,6 @@
         "node": ">=16.9.0"
       }
     },
-    "node_modules/howlongtobeat": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/howlongtobeat/-/howlongtobeat-1.8.0.tgz",
-      "integrity": "sha512-OFjqjXT5c6hz86q9zUl0zW0uUnDMj73dMTf5yISNy9lL2sw1NDF0HZAQIvf7kgNBxTtdhuBHItz3OQSjTz+mRw==",
-      "license": "WTFPL",
-      "dependencies": {
-        "axios": "^0.22",
-        "cheerio": "^1.0.0-rc.12",
-        "fast-levenshtein": "^2.0.6",
-        "user-agents": "^1.0.580"
-      }
-    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -8021,37 +7702,6 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/htmlparser2": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
-      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.2.2",
-        "entities": "^7.0.1"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/entities": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -9969,18 +9619,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/nth-check": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
-    },
     "node_modules/oauth4webapi": {
       "version": "3.8.5",
       "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.5.tgz",
@@ -10351,55 +9989,6 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
-    "node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
-      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
-      "license": "MIT",
-      "dependencies": {
-        "domhandler": "^5.0.3",
-        "parse5": "^7.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5-parser-stream": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
-      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
-      "license": "MIT",
-      "dependencies": {
-        "parse5": "^7.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5-parser-stream/node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -10703,15 +10292,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/punycode": {
@@ -12813,6 +12393,7 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
       "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -12945,15 +12526,6 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/user-agents": {
-      "version": "1.1.675",
-      "resolved": "https://registry.npmjs.org/user-agents/-/user-agents-1.1.675.tgz",
-      "integrity": "sha512-ZQnegGfKf083joYjEZuLgjJtpDHW5IhOXWCw/25yx82ZvctDcYp/PQsWNShH4Dq00SuDYaPm0qndVBn6axBpvA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/util-deprecate": {
@@ -13196,31 +12768,6 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/whatwg-encoding": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/whatwg-mimetype": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "db:push": "drizzle-kit push",
     "db:ensure-youtube-handle": "tsx scripts/ensure-youtube-handle-column.ts",
     "bridge:dev": "tsx bridge/src/index.ts",
+    "backfill:hltb": "tsx scripts/backfill-howlongtobeat.ts",
     "backfill:youtube-names": "tsx scripts/backfill-youtube-display-names.ts",
     "fix:users-ranking-state": "tsx scripts/fix-users-ranking-state.ts",
     "merge:duplicate-youtube-users": "tsx scripts/merge-duplicate-youtube-users.ts",
@@ -31,7 +32,6 @@
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.1",
     "framer-motion": "^12.38.0",
-    "howlongtobeat": "^1.8.0",
     "lucide-react": "^1.7.0",
     "next": "16.2.1",
     "next-auth": "^5.0.0-beta.30",
@@ -60,10 +60,5 @@
     "tsx": "^4.21.0",
     "typescript": "^5",
     "vitest": "^4.1.1"
-  },
-  "overrides": {
-    "howlongtobeat": {
-      "axios": "^1.17.0"
-    }
   }
 }

--- a/scripts/backfill-howlongtobeat.ts
+++ b/scripts/backfill-howlongtobeat.ts
@@ -1,0 +1,174 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { neon } from "@neondatabase/serverless";
+
+import { hltbAdapter } from "../src/lib/hltb";
+
+type GameSuggestionRow = {
+  id: string;
+  name: string;
+  canonical_name: string | null;
+  platforms: unknown;
+};
+
+const ROOT = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const ENV_FILES = [resolve(ROOT, ".env.local"), resolve(ROOT, ".env")];
+const DEFAULT_LIMIT = 100;
+
+function loadEnvFile(filepath: string) {
+  if (!existsSync(filepath)) {
+    return;
+  }
+
+  const raw = readFileSync(filepath, "utf8");
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    const equalIndex = trimmed.indexOf("=");
+    if (equalIndex === -1) {
+      continue;
+    }
+
+    const key = trimmed.slice(0, equalIndex).trim();
+    if (!key || process.env[key] !== undefined) {
+      continue;
+    }
+
+    let value = trimmed.slice(equalIndex + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    process.env[key] = value;
+  }
+}
+
+function loadLocalEnv() {
+  for (const filepath of ENV_FILES) {
+    loadEnvFile(filepath);
+  }
+}
+
+function parseArgs() {
+  const dryRun = process.argv.includes("--dry-run");
+  const allStatuses = process.argv.includes("--all-statuses");
+  const verbose = process.argv.includes("--verbose");
+  const limitArg = process.argv.find((arg) => arg.startsWith("--limit="));
+  const parsedLimit = limitArg ? Number.parseInt(limitArg.slice("--limit=".length), 10) : DEFAULT_LIMIT;
+
+  return {
+    allStatuses,
+    dryRun,
+    limit: Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : DEFAULT_LIMIT,
+    verbose,
+  };
+}
+
+function getSearchTitle(row: GameSuggestionRow) {
+  return (row.canonical_name ?? row.name).trim();
+}
+
+function getPlatformName(platforms: unknown) {
+  return Array.isArray(platforms) && typeof platforms[0] === "string"
+    ? platforms[0]
+    : null;
+}
+
+async function main() {
+  loadLocalEnv();
+
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error("Missing DATABASE_URL. Add it to .env.local/.env or export it before running.");
+  }
+
+  const { allStatuses, dryRun, limit, verbose } = parseArgs();
+  const sql = neon(databaseUrl);
+  const rows = (await sql`
+    SELECT id, name, canonical_name, platforms
+    FROM game_suggestions
+    WHERE hltb_id IS NULL
+      AND hltb_main_story_minutes IS NULL
+      AND hltb_main_extra_minutes IS NULL
+      AND hltb_completionist_minutes IS NULL
+      AND (
+        hltb_fetched_at IS NULL
+        OR hltb_fetched_at < NOW() - INTERVAL '15 minutes'
+      )
+      AND (${allStatuses} OR status IN ('open', 'accepted'))
+    ORDER BY total_votes DESC, created_at DESC
+    LIMIT ${limit}
+  `) as GameSuggestionRow[];
+
+  if (rows.length === 0) {
+    console.info("No game suggestions need HLTB backfill.");
+    return;
+  }
+
+  console.info(`Found ${rows.length} game suggestions to inspect.`);
+
+  let updated = 0;
+  let unresolved = 0;
+
+  for (const row of rows) {
+    const title = getSearchTitle(row);
+    const platformName = getPlatformName(row.platforms);
+    const match = await hltbAdapter.searchBestMatch({ title, platformName });
+
+    if (!match) {
+      unresolved += 1;
+      if (verbose) {
+        console.warn(`No HLTB match for ${row.id}: ${title}`);
+      }
+
+      if (!dryRun) {
+        await sql`
+          UPDATE game_suggestions
+          SET hltb_fetched_at = NOW()
+          WHERE id = ${row.id}
+        `;
+      }
+      continue;
+    }
+
+    updated += 1;
+    if (dryRun || verbose) {
+      console.info(`${dryRun ? "[dry-run] " : ""}${row.id}: ${title} -> ${match.title} (${match.hltbId})`);
+    }
+
+    if (dryRun) {
+      continue;
+    }
+
+    await sql`
+      UPDATE game_suggestions
+      SET hltb_id = ${match.hltbId},
+          hltb_name = ${match.title},
+          hltb_main_story_minutes = ${match.mainStoryMinutes},
+          hltb_main_extra_minutes = ${match.mainExtraMinutes},
+          hltb_completionist_minutes = ${match.completionistMinutes},
+          hltb_similarity = ${Math.round(match.score)},
+          hltb_fetched_at = NOW()
+      WHERE id = ${row.id}
+    `;
+  }
+
+  console.info(
+    dryRun
+      ? `Dry run complete. Would update ${updated}; unresolved ${unresolved}.`
+      : `Backfill complete. Updated ${updated}; unresolved ${unresolved}.`,
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/components/admin-current-game-panel.test.ts
+++ b/src/components/admin-current-game-panel.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldSkipGameSearch } from "@/components/admin-current-game-panel";
+
+describe("shouldSkipGameSearch", () => {
+  it("skips the initial search when the input already matches the current game", () => {
+    expect(
+      shouldSkipGameSearch({
+        query: "Clair Obscur: Expedition 33",
+        currentGameName: "Clair Obscur: Expedition 33",
+        selectedGameName: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("skips the search after selecting a game from the results", () => {
+    expect(
+      shouldSkipGameSearch({
+        query: "Hades II",
+        currentGameName: "Clair Obscur: Expedition 33",
+        selectedGameName: "Hades II",
+      }),
+    ).toBe(true);
+  });
+
+  it("allows a search when the query differs from the current and selected games", () => {
+    expect(
+      shouldSkipGameSearch({
+        query: "Hades II",
+        currentGameName: "Clair Obscur: Expedition 33",
+        selectedGameName: null,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/components/admin-current-game-panel.tsx
+++ b/src/components/admin-current-game-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
@@ -17,30 +17,57 @@ type GameSearchResult = {
   genres: string[];
 };
 
+export function shouldSkipGameSearch({
+  query,
+  selectedGameName,
+  currentGameName,
+}: {
+  query: string;
+  selectedGameName?: string | null;
+  currentGameName?: string | null;
+}) {
+  const normalizedQuery = query.trim();
+
+  return (
+    normalizedQuery.length < 2 ||
+    selectedGameName === normalizedQuery ||
+    currentGameName === normalizedQuery
+  );
+}
+
 export function AdminCurrentGamePanel({
   initialGame,
 }: {
   initialGame: CurrentGameRecord | null;
 }) {
   const router = useRouter();
+  const searchContainerRef = useRef<HTMLDivElement>(null);
   const [currentGame, setCurrentGame] = useState(initialGame);
   const [query, setQuery] = useState(initialGame?.name ?? "");
   const [results, setResults] = useState<GameSearchResult[]>([]);
   const [selectedGame, setSelectedGame] = useState<GameSearchResult | null>(null);
   const [isSearching, setIsSearching] = useState(false);
+  const [isResultsOpen, setIsResultsOpen] = useState(false);
   const [feedback, setFeedback] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
   useEffect(() => {
-    const normalizedQuery = query.trim();
-    if (normalizedQuery.length < 2 || selectedGame?.name === normalizedQuery) {
+    if (
+      shouldSkipGameSearch({
+        query,
+        selectedGameName: selectedGame?.name,
+        currentGameName: currentGame?.name,
+      })
+    ) {
       setResults([]);
+      setIsResultsOpen(false);
       setIsSearching(false);
       return;
     }
 
     const controller = new AbortController();
     const timer = window.setTimeout(async () => {
+      const normalizedQuery = query.trim();
       setIsSearching(true);
       setFeedback(null);
 
@@ -61,9 +88,11 @@ export function AdminCurrentGamePanel({
         }
 
         setResults(payload.data ?? []);
+        setIsResultsOpen((payload.data ?? []).length > 0);
       } catch (error) {
         if ((error as DOMException).name !== "AbortError") {
           setResults([]);
+          setIsResultsOpen(false);
           setFeedback("Falha ao buscar jogos.");
         }
       } finally {
@@ -77,12 +106,33 @@ export function AdminCurrentGamePanel({
       controller.abort();
       window.clearTimeout(timer);
     };
-  }, [query, selectedGame]);
+  }, [currentGame, query, selectedGame]);
+
+  useEffect(() => {
+    if (!isResultsOpen) {
+      return;
+    }
+
+    function closeResultsOnOutsidePointer(event: PointerEvent) {
+      if (!(event.target instanceof Node) || searchContainerRef.current?.contains(event.target)) {
+        return;
+      }
+
+      setIsResultsOpen(false);
+    }
+
+    window.addEventListener("pointerdown", closeResultsOnOutsidePointer);
+
+    return () => {
+      window.removeEventListener("pointerdown", closeResultsOnOutsidePointer);
+    };
+  }, [isResultsOpen]);
 
   function selectGame(game: GameSearchResult) {
     setSelectedGame(game);
     setQuery(game.name);
     setResults([]);
+    setIsResultsOpen(false);
   }
 
   function saveGame() {
@@ -124,6 +174,7 @@ export function AdminCurrentGamePanel({
       setSelectedGame(null);
       setQuery(payload.data.name);
       setResults([]);
+      setIsResultsOpen(false);
       setFeedback("Jogo atual atualizado.");
       router.refresh();
     });
@@ -154,6 +205,7 @@ export function AdminCurrentGamePanel({
       setSelectedGame(null);
       setQuery("");
       setResults([]);
+      setIsResultsOpen(false);
       setFeedback("Jogo atual removido.");
       router.refresh();
     });
@@ -209,7 +261,7 @@ export function AdminCurrentGamePanel({
             )}
           </div>
 
-          <div className="relative mt-4">
+          <div ref={searchContainerRef} className="relative mt-4">
             <label className="mono text-[10px] uppercase tracking-[0.28em] text-[var(--color-ink-soft)]">
               Buscar no IGDB
             </label>
@@ -218,6 +270,8 @@ export function AdminCurrentGamePanel({
               onChange={(event) => {
                 setQuery(event.target.value);
                 setSelectedGame(null);
+                setResults([]);
+                setIsResultsOpen(false);
               }}
               placeholder="Ex.: Hades II"
               className="mt-2"
@@ -229,7 +283,7 @@ export function AdminCurrentGamePanel({
               </p>
             ) : null}
 
-            {!selectedGame && results.length > 0 ? (
+            {!selectedGame && isResultsOpen && results.length > 0 ? (
               <div className="absolute z-20 mt-2 grid max-h-72 w-full gap-2 overflow-auto border-[3px] border-[var(--color-ink)] bg-[var(--color-paper)] p-2 shadow-purple">
                 {results.map((game) => (
                   <button

--- a/src/lib/auth/public-health.test.ts
+++ b/src/lib/auth/public-health.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getGoogleOAuthCallbackUrls } from "@/lib/auth/public-health";
+
+describe("getGoogleOAuthCallbackUrls", () => {
+  it("builds unique Google callback URLs from configured app base URLs", () => {
+    expect(
+      getGoogleOAuthCallbackUrls([
+        "https://ludylops.live/",
+        "https://ludylops.live",
+        "https://ludylops.vercel.app",
+      ]),
+    ).toEqual([
+      "https://ludylops.live/api/auth/callback/google",
+      "https://ludylops.vercel.app/api/auth/callback/google",
+    ]);
+  });
+});
+
+describe("getPublicAuthHealth", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("surfaces the Google callback URLs expected for deploy configuration", async () => {
+    vi.stubEnv("AUTH_GOOGLE_ID", "google-client-id");
+    vi.stubEnv("AUTH_GOOGLE_SECRET", "google-client-secret");
+    vi.stubEnv("APP_URL", "https://ludylops.live/");
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://ludylops.vercel.app");
+    vi.resetModules();
+
+    const { getPublicAuthHealth } = await import("@/lib/auth/public-health");
+
+    expect(getPublicAuthHealth()).toMatchObject({
+      googleOAuthConfigured: true,
+      googleOAuthCallbackUrls: [
+        "https://ludylops.live/api/auth/callback/google",
+        "https://ludylops.vercel.app/api/auth/callback/google",
+      ],
+    });
+  });
+});

--- a/src/lib/auth/public-health.ts
+++ b/src/lib/auth/public-health.ts
@@ -5,6 +5,7 @@ export type PublicAuthHealth = {
   status: "ready" | "degraded";
   availableProviders: string[];
   googleOAuthConfigured: boolean;
+  googleOAuthCallbackUrls: string[];
   demoAuthEnabled: boolean;
   nextAuthSecretConfigured: boolean;
   usesFallbackSecret: boolean;
@@ -12,10 +13,27 @@ export type PublicAuthHealth = {
   warnings: string[];
 };
 
+function normalizeBaseUrl(value: string) {
+  return value.trim().replace(/\/+$/, "");
+}
+
+export function getGoogleOAuthCallbackUrls(baseUrls: Array<string | null | undefined>) {
+  return Array.from(
+    new Set(
+      baseUrls
+        .filter((value): value is string => Boolean(value))
+        .map(normalizeBaseUrl)
+        .filter(Boolean)
+        .map((baseUrl) => `${baseUrl}/api/auth/callback/google`),
+    ),
+  );
+}
+
 export function getPublicAuthHealth(): PublicAuthHealth {
   const googleOAuthConfigured = Boolean(env.AUTH_GOOGLE_ID && env.AUTH_GOOGLE_SECRET);
   const googleOAuthPartialConfig = Boolean(env.AUTH_GOOGLE_ID || env.AUTH_GOOGLE_SECRET) && !googleOAuthConfigured;
   const nextAuthSecretConfigured = Boolean(env.NEXTAUTH_SECRET);
+  const googleOAuthCallbackUrls = getGoogleOAuthCallbackUrls([env.APP_URL, env.NEXT_PUBLIC_APP_URL]);
   const availableProviders = [
     ...(googleOAuthConfigured ? ["google"] : []),
     ...(isDemoAuthEnabled ? ["credentials"] : []),
@@ -34,6 +52,7 @@ export function getPublicAuthHealth(): PublicAuthHealth {
     status: failures.length === 0 ? "ready" : "degraded",
     availableProviders,
     googleOAuthConfigured,
+    googleOAuthCallbackUrls,
     demoAuthEnabled: isDemoAuthEnabled,
     nextAuthSecretConfigured,
     usesFallbackSecret: !nextAuthSecretConfigured,

--- a/src/lib/db/repository.test.ts
+++ b/src/lib/db/repository.test.ts
@@ -3361,6 +3361,14 @@ describe("ingestStreamerbotEvent", () => {
         presenceCriterion: "presence_tick desde o início da live",
       },
     });
+    await expect(getLiveLikeGoalOverlayState()).resolves.toMatchObject({
+      currentLikeCount: 30,
+      broadcastId: "live-like-goal-1",
+      goal: {
+        id: goal.id,
+        targetLikeCount: 30,
+      },
+    });
   });
 
   it("returns the initial like goal overlay state from the first active goal", async () => {

--- a/src/lib/db/repository.ts
+++ b/src/lib/db/repository.ts
@@ -146,7 +146,8 @@ function shouldExcludeFromRanking(email: string | null) {
 
 const DEFAULT_DEATH_COUNTER_KEY = "death_count";
 const HOWLONGTOBEAT_CACHE_TTL_MS = 1000 * 60 * 60 * 24 * 30;
-const HOWLONGTOBEAT_REFRESH_BATCH_LIMIT = 3;
+const HOWLONGTOBEAT_MISSING_CACHE_TTL_MS = 1000 * 60 * 15;
+const HOWLONGTOBEAT_REFRESH_BATCH_LIMIT = 8;
 
 const spendingHistoryLabels: Partial<Record<LedgerEntryRecord["kind"], string>> = {
   redemption_debit: "Resgate",
@@ -1811,13 +1812,25 @@ function serializeGameSuggestion(row: typeof gameSuggestions.$inferSelect): Game
 }
 
 function buildHowLongToBeatColumns(resolution: HowLongToBeatResolution) {
+  if (!resolution.match) {
+    return {
+      hltbId: null,
+      hltbName: null,
+      hltbMainStoryMinutes: null,
+      hltbMainExtraMinutes: null,
+      hltbCompletionistMinutes: null,
+      hltbSimilarity: null,
+      hltbFetchedAt: resolution.fetchedAt,
+    };
+  }
+
   return {
-    hltbId: resolution.match?.id ?? null,
-    hltbName: resolution.match?.name ?? null,
-    hltbMainStoryMinutes: resolution.match?.mainStoryMinutes ?? null,
-    hltbMainExtraMinutes: resolution.match?.mainExtraMinutes ?? null,
-    hltbCompletionistMinutes: resolution.match?.completionistMinutes ?? null,
-    hltbSimilarity: typeof resolution.match?.similarity === "number"
+    hltbId: resolution.match.id,
+    hltbName: resolution.match.name,
+    hltbMainStoryMinutes: resolution.match.mainStoryMinutes,
+    hltbMainExtraMinutes: resolution.match.mainExtraMinutes,
+    hltbCompletionistMinutes: resolution.match.completionistMinutes,
+    hltbSimilarity: typeof resolution.match.similarity === "number"
       ? Math.round(resolution.match.similarity * 100)
       : null,
     hltbFetchedAt: resolution.fetchedAt,
@@ -3007,6 +3020,11 @@ function listDemoGameSuggestions(viewerId?: string | null) {
 }
 
 function shouldRefreshHowLongToBeat(row: typeof gameSuggestions.$inferSelect, now = Date.now()) {
+  const hasCompletionTime = row.hltbMainStoryMinutes || row.hltbMainExtraMinutes || row.hltbCompletionistMinutes;
+  if (!row.hltbId && !hasCompletionTime) {
+    return !row.hltbFetchedAt || now - row.hltbFetchedAt.getTime() > HOWLONGTOBEAT_MISSING_CACHE_TTL_MS;
+  }
+
   if (!row.hltbFetchedAt) {
     return true;
   }
@@ -3016,6 +3034,12 @@ function shouldRefreshHowLongToBeat(row: typeof gameSuggestions.$inferSelect, no
 
 function getHowLongToBeatSearchTitle(row: typeof gameSuggestions.$inferSelect) {
   return (row.canonicalName ?? row.name).trim();
+}
+
+function getHowLongToBeatPlatformName(platforms: unknown) {
+  return Array.isArray(platforms) && typeof platforms[0] === "string"
+    ? platforms[0]
+    : null;
 }
 
 async function refreshStaleHowLongToBeatRows(
@@ -3032,12 +3056,17 @@ async function refreshStaleHowLongToBeatRows(
 
   const refreshedRows = new Map<string, typeof gameSuggestions.$inferSelect>();
 
-  for (const row of staleRows) {
+  await Promise.all(staleRows.map(async (row) => {
     try {
-      const resolution = await resolveHowLongToBeatGame(getHowLongToBeatSearchTitle(row));
+      const resolution = await resolveHowLongToBeatGame(
+        getHowLongToBeatSearchTitle(row),
+        getHowLongToBeatPlatformName(row.platforms),
+      );
+      const howLongToBeatColumns = buildHowLongToBeatColumns(resolution);
+
       const [updated] = await db
         .update(gameSuggestions)
-        .set(buildHowLongToBeatColumns(resolution))
+        .set(howLongToBeatColumns)
         .where(eq(gameSuggestions.id, row.id))
         .returning();
 
@@ -3047,7 +3076,7 @@ async function refreshStaleHowLongToBeatRows(
     } catch {
       // HLTB is best-effort data; stale cache must not block the recommendations list.
     }
-  }
+  }));
 
   return rows.map((row) => refreshedRows.get(row.id) ?? row);
 }
@@ -3356,7 +3385,11 @@ function listDemoCreatorSuggestions(
     .filter((entry) => (featured ? entry.status === "featured" : entry.status !== "featured"))
     .sort((a, b) => {
       if (featured) {
-        return b.name.localeCompare(a.name, "pt-BR", { sensitivity: "base" });
+        if (b.totalVotes !== a.totalVotes) {
+          return b.totalVotes - a.totalVotes;
+        }
+
+        return +new Date(b.createdAt) - +new Date(a.createdAt);
       }
 
       if (b.totalVotes !== a.totalVotes) {
@@ -5459,7 +5492,11 @@ export async function listFeaturedCreatorSuggestions() {
       .select()
       .from(creatorSuggestions)
       .where(eq(creatorSuggestions.status, "featured"))
-      .orderBy(desc(creatorSuggestions.name));
+      .orderBy(
+        desc(creatorSuggestions.totalVotes),
+        desc(creatorSuggestions.createdAt),
+        desc(creatorSuggestions.name),
+      );
   } catch (error) {
     if (isMissingCreatorSuggestionSchemaError(error)) {
       return listDemoCreatorSuggestions(null, { featured: true });
@@ -5662,7 +5699,7 @@ export async function createGameSuggestion(input: {
   }
 
   const createdAt = new Date();
-  const howLongToBeat = await resolveHowLongToBeatGame(displayName);
+  const howLongToBeat = await resolveHowLongToBeatGame(displayName, platforms[0] ?? null);
   await db.transaction(async (tx) => {
     const [existing] = await tx
       .select()
@@ -5963,7 +6000,7 @@ export async function updateGameSuggestionCatalog(input: {
     return buildGameSuggestionWithMeta({ suggestion, viewer });
   }
 
-  const howLongToBeat = await resolveHowLongToBeatGame(canonicalName);
+  const howLongToBeat = await resolveHowLongToBeatGame(canonicalName, platforms[0] ?? null);
   const [updated] = await db
     .update(gameSuggestions)
     .set({

--- a/src/lib/demo-data.ts
+++ b/src/lib/demo-data.ts
@@ -584,6 +584,20 @@ export const demoGameSuggestionBoosts: GameSuggestionBoostRecord[] = [];
 
 export const demoCreatorSuggestions: CreatorSuggestionRecord[] = [
   {
+    id: "cs-featured-rosadiariogamer",
+    viewerId: "viewer_lia",
+    slug: "rosadiariogamer",
+    name: "Rosa Diário Gamer",
+    channelUrl: "https://www.youtube.com/@rosadiariogamer",
+    platform: "youtube",
+    category: "games",
+    reason: "Canal de games com energia próxima, presença de comunidade e um jeito gostoso de acompanhar gameplay.",
+    totalVotes: 1210,
+    status: "featured",
+    createdAt: new Date(now.getTime() - 1000 * 60 * 60 * 61).toISOString(),
+    updatedAt: new Date(now.getTime() - 1000 * 60 * 60 * 61).toISOString(),
+  },
+  {
     id: "cs-featured-brksedu",
     viewerId: "viewer_lia",
     slug: "brksedu",

--- a/src/lib/health/public.test.ts
+++ b/src/lib/health/public.test.ts
@@ -7,6 +7,7 @@ const authReady = {
   status: "ready" as const,
   availableProviders: ["google"],
   googleOAuthConfigured: true,
+  googleOAuthCallbackUrls: ["https://example.test/api/auth/callback/google"],
   demoAuthEnabled: false,
   nextAuthSecretConfigured: true,
   usesFallbackSecret: false,

--- a/src/lib/hltb.ts
+++ b/src/lib/hltb.ts
@@ -1,0 +1,333 @@
+export interface EnrichedCompletionTimes {
+  hltbId: string;
+  title: string;
+  mainStoryMinutes: number | null;
+  mainExtraMinutes: number | null;
+  completionistMinutes: number | null;
+  storeUrl: string;
+  score: number;
+  rawData: HltbSearchEntry;
+}
+
+export interface CatalogCompletionTimeAdapter {
+  searchBestMatch(input: {
+    title: string;
+    platformName?: string | null;
+  }): Promise<EnrichedCompletionTimes | null>;
+}
+
+type HltbAuth = {
+  token?: string;
+  hpKey?: string;
+  hpVal?: string;
+};
+
+type HltbSearchResponse = {
+  data?: HltbSearchEntry[];
+};
+
+export type HltbSearchEntry = {
+  game_id?: number | string;
+  game_name?: string;
+  game_alias?: string | string[] | null;
+  profile_platform?: string | string[] | null;
+  comp_main?: number;
+  comp_plus?: number;
+  comp_100?: number;
+  [key: string]: unknown;
+};
+
+const HLTB_BASE_URL = "https://howlongtobeat.com";
+const HLTB_FALLBACK_SEARCH_PATH = "/api/s";
+const HLTB_MIN_SCORE = 55;
+const HLTB_REQUEST_TIMEOUT_MS = 8_000;
+const HLTB_USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125 Safari/537.36";
+
+let searchPathPromise: Promise<string> | null = null;
+
+function buildHeaders(auth?: HltbAuth) {
+  return {
+    accept: "application/json, text/plain, */*",
+    "accept-language": "en-US,en;q=0.9,pt-BR;q=0.8,pt;q=0.7",
+    "content-type": "application/json",
+    origin: HLTB_BASE_URL,
+    referer: `${HLTB_BASE_URL}/`,
+    "user-agent": HLTB_USER_AGENT,
+    ...(auth?.token ? { "x-auth-token": auth.token } : {}),
+    ...(auth?.hpKey ? { "x-hp-key": auth.hpKey } : {}),
+    ...(auth?.hpVal ? { "x-hp-val": auth.hpVal } : {}),
+  };
+}
+
+function normalizeTitle(value: string) {
+  return value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/\b(game of the year|goty|complete|definitive|ultimate|deluxe|edition|remaster(?:ed)?)\b/g, " ")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function tokenize(value: string) {
+  const normalized = normalizeTitle(value);
+  return normalized ? normalized.split(/\s+/).filter(Boolean) : [];
+}
+
+function secondsToMinutes(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.round(value / 60)
+    : null;
+}
+
+function getEntryAliases(entry: HltbSearchEntry) {
+  if (Array.isArray(entry.game_alias)) {
+    return entry.game_alias.filter((value): value is string => typeof value === "string");
+  }
+
+  return typeof entry.game_alias === "string" && entry.game_alias.trim()
+    ? entry.game_alias.split(/[,|]/).map((value) => value.trim()).filter(Boolean)
+    : [];
+}
+
+function getEntryPlatforms(entry: HltbSearchEntry) {
+  if (Array.isArray(entry.profile_platform)) {
+    return entry.profile_platform.filter((value): value is string => typeof value === "string");
+  }
+
+  return typeof entry.profile_platform === "string" && entry.profile_platform.trim()
+    ? entry.profile_platform.split(/[,|]/).map((value) => value.trim()).filter(Boolean)
+    : [];
+}
+
+function scoreTitle(candidateTitle: string, queryTitle: string) {
+  const candidate = normalizeTitle(candidateTitle);
+  const query = normalizeTitle(queryTitle);
+
+  if (!candidate || !query) {
+    return 0;
+  }
+
+  if (candidate === query) {
+    return 100;
+  }
+
+  const candidateTokens = new Set(tokenize(candidate));
+  const queryTokens = tokenize(query);
+  if (candidateTokens.size === 0 || queryTokens.length === 0) {
+    return 0;
+  }
+
+  const matchingTokens = queryTokens.filter((token) => candidateTokens.has(token)).length;
+  const tokenOverlap = (matchingTokens / queryTokens.length) * 75;
+  const containsBonus = candidate.includes(query) || query.includes(candidate) ? 20 : 0;
+  const lengthPenalty = Math.min(Math.abs(candidate.length - query.length), 20);
+
+  return Math.max(0, Math.min(100, Math.round(tokenOverlap + containsBonus - lengthPenalty)));
+}
+
+function scoreCandidate(entry: HltbSearchEntry, input: { title: string; platformName?: string | null }) {
+  const titleScores = [entry.game_name, ...getEntryAliases(entry)]
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    .map((title) => scoreTitle(title, input.title));
+
+  const titleScore = titleScores.length > 0 ? Math.max(...titleScores) : 0;
+  if (titleScore === 0) {
+    return 0;
+  }
+
+  const platform = input.platformName ? normalizeTitle(input.platformName) : "";
+  const platformBonus = platform
+    ? getEntryPlatforms(entry).some((candidatePlatform) => normalizeTitle(candidatePlatform).includes(platform))
+      ? 10
+      : 0
+    : 0;
+
+  return Math.min(100, titleScore + platformBonus);
+}
+
+function buildSearchPayload(title: string, auth: HltbAuth) {
+  const payload: Record<string, unknown> = {
+    searchType: "games",
+    searchTerms: tokenize(title),
+    searchPage: 1,
+    size: 20,
+    searchOptions: {
+      games: {
+        userId: 0,
+        platform: "",
+        sortCategory: "popular",
+        rangeCategory: "main",
+        rangeTime: { min: 0, max: 0 },
+        gameplay: { perspective: "", flow: "", genre: "", difficulty: "" },
+        rangeYear: { min: 0, max: 0 },
+        modifier: "hide_dlc",
+      },
+      users: { sortCategory: "postcount" },
+      lists: { sortCategory: "follows" },
+      filter: "",
+      sort: 0,
+      randomizer: 0,
+    },
+    useCache: true,
+  };
+
+  if (auth.hpKey) {
+    payload[auth.hpKey] = auth.hpVal ?? "";
+  }
+
+  return payload;
+}
+
+function extractScriptUrls(html: string) {
+  return [...html.matchAll(/<script[^>]+src=["']([^"']+)["']/gi)]
+    .map((match) => {
+      try {
+        return new URL(match[1], HLTB_BASE_URL).toString();
+      } catch {
+        return null;
+      }
+    })
+    .filter((url): url is string => Boolean(url))
+    .sort((left, right) => {
+      const leftPriority = left.includes("_app-") ? 1 : 0;
+      const rightPriority = right.includes("_app-") ? 1 : 0;
+      return rightPriority - leftPriority;
+    });
+}
+
+function normalizeSearchPath(path: string) {
+  return path.replace(/\/init$/, "");
+}
+
+function findSearchPathInScript(script: string) {
+  const paths = [...script.matchAll(/["'](\/api\/[a-zA-Z0-9_/-]+)["']/g)]
+    .map((match) => normalizeSearchPath(match[1]))
+    .filter((path) => !path.startsWith("/api/admin/"))
+    .filter((path) => !["/api/error", "/api/user", "/api/logout"].includes(path));
+
+  const uniquePaths = [...new Set(paths)];
+  const searchHintsPresent = script.includes("searchTerms") || script.includes("searchType") || script.includes("games");
+
+  return uniquePaths.find((path) => searchHintsPresent && script.includes(`${path}/init`))
+    ?? uniquePaths.find((path) => searchHintsPresent && path.split("/").length <= 3)
+    ?? null;
+}
+
+async function fetchText(url: string, signal: AbortSignal) {
+  const response = await fetch(url, {
+    headers: buildHeaders(),
+    signal,
+  });
+
+  if (!response.ok) {
+    throw new Error(`hltb_text_request_failed:${response.status}`);
+  }
+
+  return response.text();
+}
+
+async function fetchJson<T>(url: string, init: RequestInit) {
+  const response = await fetch(url, init);
+
+  if (!response.ok) {
+    throw new Error(`hltb_json_request_failed:${response.status}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+async function discoverSearchPath(signal: AbortSignal) {
+  if (!searchPathPromise) {
+    searchPathPromise = (async () => {
+      const html = await fetchText(HLTB_BASE_URL, signal);
+      const scripts = extractScriptUrls(html);
+
+      for (const scriptUrl of scripts) {
+        try {
+          const script = await fetchText(scriptUrl, signal);
+          const path = findSearchPathInScript(script);
+          if (path) {
+            return path;
+          }
+        } catch {
+          // Script discovery is best-effort; keep scanning the other bundles.
+        }
+      }
+
+      return HLTB_FALLBACK_SEARCH_PATH;
+    })().catch(() => HLTB_FALLBACK_SEARCH_PATH);
+  }
+
+  return searchPathPromise;
+}
+
+async function fetchAuth(searchPath: string, signal: AbortSignal) {
+  return fetchJson<HltbAuth>(`${HLTB_BASE_URL}${searchPath}/init?t=${Date.now()}`, {
+    headers: buildHeaders(),
+    signal,
+  });
+}
+
+async function searchHltb(input: { title: string; platformName?: string | null }, signal: AbortSignal) {
+  const searchPath = await discoverSearchPath(signal);
+  const auth = await fetchAuth(searchPath, signal);
+
+  return fetchJson<HltbSearchResponse>(`${HLTB_BASE_URL}${searchPath}`, {
+    method: "POST",
+    headers: buildHeaders(auth),
+    body: JSON.stringify(buildSearchPayload(input.title, auth)),
+    signal,
+  });
+}
+
+function mapHltbEntry(entry: HltbSearchEntry, score: number): EnrichedCompletionTimes | null {
+  const hltbId = String(entry.game_id ?? "").trim();
+  const title = entry.game_name?.trim();
+  const mainStoryMinutes = secondsToMinutes(entry.comp_main);
+  const mainExtraMinutes = secondsToMinutes(entry.comp_plus);
+  const completionistMinutes = secondsToMinutes(entry.comp_100);
+
+  if (!hltbId || !title || (mainStoryMinutes === null && mainExtraMinutes === null && completionistMinutes === null)) {
+    return null;
+  }
+
+  return {
+    hltbId,
+    title,
+    mainStoryMinutes,
+    mainExtraMinutes,
+    completionistMinutes,
+    storeUrl: `${HLTB_BASE_URL}/game/${hltbId}`,
+    score,
+    rawData: entry,
+  };
+}
+
+async function searchBestMatch(input: { title: string; platformName?: string | null }) {
+  const title = input.title.trim();
+  if (title.length < 2) {
+    return null;
+  }
+
+  try {
+    const signal = AbortSignal.timeout(HLTB_REQUEST_TIMEOUT_MS);
+    const response = await searchHltb({ ...input, title }, signal);
+    const candidates = (response.data ?? [])
+      .map((entry) => ({
+        entry,
+        score: scoreCandidate(entry, input),
+      }))
+      .sort((left, right) => right.score - left.score);
+
+    const best = candidates.find((candidate) => candidate.score >= HLTB_MIN_SCORE);
+    return best ? mapHltbEntry(best.entry, best.score) : null;
+  } catch {
+    return null;
+  }
+}
+
+export const hltbAdapter: CatalogCompletionTimeAdapter = {
+  searchBestMatch,
+};

--- a/src/lib/howlongtobeat.test.ts
+++ b/src/lib/howlongtobeat.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { hltbAdapter } from "@/lib/hltb";
+import { resolveHowLongToBeatGame } from "@/lib/howlongtobeat";
+
+describe("hltbAdapter", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+  });
+
+  it("discovers the current search endpoint and maps seconds to minutes", async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url === "https://howlongtobeat.com") {
+        return new Response('<script src="/_next/static/chunks/_app-demo.js"></script>');
+      }
+
+      if (url.endsWith("/_next/static/chunks/_app-demo.js")) {
+        return new Response('const endpoint="/api/bleed"; const init="/api/bleed/init"; const searchTerms=true;');
+      }
+
+      if (url.includes("/api/bleed/init")) {
+        return Response.json({
+          token: "token-123",
+          hpKey: "ign_test",
+          hpVal: "guard-value",
+        });
+      }
+
+      if (url.endsWith("/api/bleed")) {
+        expect(init?.method).toBe("POST");
+        expect((init?.headers as Record<string, string>)["x-auth-token"]).toBe("token-123");
+        expect((init?.headers as Record<string, string>)["x-hp-key"]).toBe("ign_test");
+        expect((init?.headers as Record<string, string>)["x-hp-val"]).toBe("guard-value");
+
+        const payload = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        expect(payload.searchTerms).toEqual(["celeste"]);
+        expect(payload.ign_test).toBe("guard-value");
+        expect((payload.searchOptions as { games: { modifier: string } }).games.modifier).toBe("hide_dlc");
+
+        return Response.json({
+          data: [
+            {
+              game_id: 111,
+              game_name: "Celeste DLC",
+              comp_main: 1_000,
+            },
+            {
+              game_id: 42818,
+              game_name: "Celeste",
+              game_alias: ["Celeste Classic"],
+              profile_platform: ["PC", "Nintendo Switch"],
+              comp_main: 29_921,
+              comp_plus: 52_776,
+              comp_100: 141_074,
+            },
+          ],
+        });
+      }
+
+      throw new Error(`Unexpected URL ${url}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(hltbAdapter.searchBestMatch({ title: "Celeste", platformName: "PC" })).resolves.toMatchObject({
+      hltbId: "42818",
+      title: "Celeste",
+      mainStoryMinutes: 499,
+      mainExtraMinutes: 880,
+      completionistMinutes: 2351,
+      storeUrl: "https://howlongtobeat.com/game/42818",
+      score: 100,
+    });
+  });
+
+  it("rejects weak matches instead of enriching the wrong game", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+
+        if (url === "https://howlongtobeat.com") {
+          return new Response('<script src="/search.js"></script>');
+        }
+
+        if (url.endsWith("/search.js")) {
+          return new Response('const endpoint="/api/bleed"; const init="/api/bleed/init"; const searchTerms=true;');
+        }
+
+        if (url.includes("/api/bleed/init")) {
+          return Response.json({ token: "token-123" });
+        }
+
+        if (url.endsWith("/api/bleed")) {
+          return Response.json({
+            data: [{ game_id: 1, game_name: "Hades", comp_main: 50_000 }],
+          });
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      }),
+    );
+
+    await expect(hltbAdapter.searchBestMatch({ title: "Celeste" })).resolves.toBeNull();
+  });
+
+  it("returns null when discovery and fallback requests fail", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("not found", { status: 404 })),
+    );
+
+    await expect(hltbAdapter.searchBestMatch({ title: "Celeste" })).resolves.toBeNull();
+  });
+});
+
+describe("resolveHowLongToBeatGame", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps the existing repository-facing result shape", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+
+        if (url === "https://howlongtobeat.com") {
+          return new Response('<script src="/search.js"></script>');
+        }
+
+        if (url.endsWith("/search.js")) {
+          return new Response('const endpoint="/api/bleed"; const init="/api/bleed/init"; const searchTerms=true;');
+        }
+
+        if (url.includes("/api/bleed/init")) {
+          return Response.json({ token: "token-123" });
+        }
+
+        if (url.endsWith("/api/bleed")) {
+          return Response.json({
+            data: [{ game_id: 42818, game_name: "Celeste", comp_main: 29_921 }],
+          });
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      }),
+    );
+
+    await expect(resolveHowLongToBeatGame("Celeste")).resolves.toMatchObject({
+      match: {
+        id: "42818",
+        name: "Celeste",
+        mainStoryMinutes: 499,
+        similarity: 1,
+      },
+    });
+  });
+});

--- a/src/lib/howlongtobeat.ts
+++ b/src/lib/howlongtobeat.ts
@@ -1,4 +1,4 @@
-import type { HowLongToBeatEntry, HowLongToBeatService as HowLongToBeatServiceClass } from "howlongtobeat";
+import { hltbAdapter } from "@/lib/hltb";
 
 export interface HowLongToBeatMatch {
   id: string;
@@ -14,84 +14,24 @@ export interface HowLongToBeatResolution {
   fetchedAt: Date;
 }
 
-const MIN_RELIABLE_SIMILARITY = 0.82;
-const HLTB_REQUEST_TIMEOUT_MS = 4500;
-
-type HowLongToBeatServiceInstance = InstanceType<typeof HowLongToBeatServiceClass>;
-
-let service: HowLongToBeatServiceInstance | null = null;
-
-async function getService() {
-  if (!service) {
-    const { HowLongToBeatService } = await import("howlongtobeat");
-    service = new HowLongToBeatService();
-  }
-  return service;
-}
-
-function normalizeGameTitle(value: string) {
-  return value
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, " ")
-    .trim();
-}
-
-function hoursToMinutes(value: unknown) {
-  return typeof value === "number" && Number.isFinite(value) && value > 0
-    ? Math.round(value * 60)
-    : null;
-}
-
-function isReliableMatch(entry: HowLongToBeatEntry, query: string) {
-  const normalizedQuery = normalizeGameTitle(query);
-  const normalizedName = normalizeGameTitle(entry.name);
-
-  if (!normalizedQuery || !normalizedName) {
-    return false;
-  }
-
-  if (normalizedName === normalizedQuery) {
-    return true;
-  }
-
-  return entry.similarity >= MIN_RELIABLE_SIMILARITY;
-}
-
-function toMatch(entry: HowLongToBeatEntry): HowLongToBeatMatch {
-  return {
-    id: entry.id,
-    name: entry.name,
-    mainStoryMinutes: hoursToMinutes(entry.gameplayMain),
-    mainExtraMinutes: hoursToMinutes(entry.gameplayMainExtra),
-    completionistMinutes: hoursToMinutes(entry.gameplayCompletionist),
-    similarity: typeof entry.similarity === "number" && Number.isFinite(entry.similarity)
-      ? entry.similarity
-      : null,
-  };
-}
-
-export async function resolveHowLongToBeatGame(query: string): Promise<HowLongToBeatResolution> {
+export async function resolveHowLongToBeatGame(
+  query: string,
+  platformName?: string | null,
+): Promise<HowLongToBeatResolution> {
   const fetchedAt = new Date();
-  const searchTerm = query.trim();
+  const match = await hltbAdapter.searchBestMatch({ title: query, platformName });
 
-  if (searchTerm.length < 2) {
-    return { match: null, fetchedAt };
-  }
-
-  try {
-    const signal = AbortSignal.timeout(HLTB_REQUEST_TIMEOUT_MS);
-    const results = await (await getService()).search(searchTerm, signal);
-    const match = results.find(
-      (entry) => isReliableMatch(entry, searchTerm) && hoursToMinutes(entry.gameplayMain) !== null,
-    );
-
-    return {
-      match: match ? toMatch(match) : null,
-      fetchedAt,
-    };
-  } catch {
-    return { match: null, fetchedAt };
-  }
+  return {
+    match: match
+      ? {
+          id: match.hltbId,
+          name: match.title,
+          mainStoryMinutes: match.mainStoryMinutes,
+          mainExtraMinutes: match.mainExtraMinutes,
+          completionistMinutes: match.completionistMinutes,
+          similarity: match.score / 100,
+        }
+      : null,
+    fetchedAt,
+  };
 }

--- a/src/lib/streamerbot/schemas.ts
+++ b/src/lib/streamerbot/schemas.ts
@@ -232,6 +232,7 @@ const wheelColorSchema = z
   .string()
   .trim()
   .regex(/^#[0-9a-fA-F]{6}$/);
+
 export const wheelOptionSchema = z.object({
   id: z.string().trim().min(1).max(64).optional(),
   label: z.string().trim().min(1).max(80),
@@ -240,16 +241,20 @@ export const wheelOptionSchema = z.object({
   isActive: z.boolean().default(true),
   sortOrder: z.number().int().min(0).max(999).default(0),
 });
+
 export const wheelConfigSchema = z.object({
   title: z.string().trim().min(1).max(80).default("Roleta da live"),
   spinDurationMs: z.number().int().min(2500).max(12000).default(5200),
   resultHoldSeconds: z.number().int().min(5).max(120).default(30),
   options: z.array(wheelOptionSchema).min(2).max(24),
 });
+
 export const wheelSpinRequestSchema = z.object({
   requestedBy: z.string().trim().min(1).max(255).optional(),
   source: z.string().trim().min(1).max(64).default("web"),
-});export const bridgeHeartbeatSchema = z.object({
+});
+
+export const bridgeHeartbeatSchema = z.object({
   bridgeId: z.string().min(1),
   machineKey: z.string().min(1),
   label: z.string().min(1),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -335,6 +335,7 @@ export interface WheelOptionRecord {
   isActive: boolean;
   sortOrder: number;
 }
+
 export interface WheelSpinRecord {
   spinId: string;
   optionId: string;
@@ -346,6 +347,7 @@ export interface WheelSpinRecord {
   spinDurationMs: number;
   resultVisibleUntil: string;
 }
+
 export interface WheelConfigRecord {
   title: string;
   spinDurationMs: number;
@@ -354,7 +356,9 @@ export interface WheelConfigRecord {
   updatedAt: string | null;
   updatedBy: string | null;
   lastSpin: WheelSpinRecord | null;
-}export interface StreamerbotCounterRecord {
+}
+
+export interface StreamerbotCounterRecord {
   key: string;
   scopeType: string;
   scopeKey: string;


### PR DESCRIPTION
## Summary
- replace the broken HowLongToBeat package integration with a best-effort HLTB adapter that discovers the current search endpoint and supports backfill
- prevent long-lived empty HLTB cache entries and add `npm run backfill:hltb` for existing game suggestions
- keep rebased live reward/current game/auth health updates with focused tests

## Validation
- npm test
- npx tsc --noEmit
- git diff --check