### PR TITLE
[codex] Add subscriber alert OBS overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Mais detalhes ficam em `bridge/README.md`.
 - `/obs/likes`: browser source para a meta de likes no OBS.
 - `/obs/quotes`: browser source para quotes no OBS.
 - `/obs/bets`: browser source para apostas abertas no OBS.
+- `/obs/subscribers`: browser source para alertas de novas inscrições no canal.
 
 ## Setup local
 

--- a/docs/streamerbot-live-rewards.md
+++ b/docs/streamerbot-live-rewards.md
@@ -5,7 +5,9 @@ Esta integração usa `POST /api/internal/streamerbot/events` com HMAC, como os 
 ## Inscrição no canal
 
 - Trigger no Streamer.bot: `YouTube > General > New Subscriber`.
-- Observação da documentação oficial: esse trigger depende da integração do StreamElements configurada no Streamer.bot.
+- Observação da documentação oficial consultada em 2026-06-04: esse trigger depende da integração do StreamElements configurada no Streamer.bot.
+- Variáveis oficiais relevantes para a action: `userId`, `user`, `userName`, `userProfileUrl`, `broadcastId`, `isSubscribed` e `userIsSponsor`.
+- Script recomendado: `streamerbot/channel-subscription-reward.cs`.
 - Payload esperado pelo app:
   - `eventType`: `channel_subscription`
   - `viewerExternalId`: ID do canal do YouTube da pessoa inscrita
@@ -13,7 +15,21 @@ Esta integração usa `POST /api/internal/streamerbot/events` com HMAC, como os 
   - `youtubeHandle`: handle, quando disponível
   - `occurredAt`: data em ISO
   - `payload.broadcastId`: opcional
-- Regra de pagamento: 2000 pipetz uma única vez por viewer. Se o Streamer.bot reenviar o evento, o `eventId` evita duplicidade; se outro evento chegar para o mesmo viewer, o app ignora porque já existe ledger `channel_subscription`.
+- Regra de pagamento: 2000 pipetz uma única vez por viewer. Se o Streamer.bot reenviar o mesmo `eventId`, o app evita duplicidade; se outro evento chegar para o mesmo viewer, o app ignora a nova recompensa porque já existe ledger `channel_subscription`.
+
+### Overlay de nova inscrição
+
+- Abra `/obs/subscribers` como Browser Source no OBS ou em ferramenta equivalente.
+- Use `/obs/subscribers?demo=1` para testar o visual e o som sem depender de eventos reais.
+- O overlay consulta `GET /api/obs/subscribers/current` a cada segundo e enfileira localmente os eventos novos recebidos nos últimos 2 minutos.
+- Cada alerta toca o som uma vez, fica visível por 7 segundos por padrão e sai automaticamente. Eventos consecutivos são exibidos em sequência.
+- Parâmetros opcionais do Browser Source:
+  - `imageUrl` ou `image`: imagem exibida no alerta. Exemplo: `/obs/subscribers?imageUrl=/selfie2.png`.
+  - `soundUrl` ou `sound`: arquivo de áudio do alerta. Sem esse parâmetro, o overlay usa um som sintético embutido.
+  - `durationMs` ou `duration`: duração em milissegundos, entre 3000 e 20000.
+  - `title`: texto do selo principal. Padrão: `Nova inscrição`.
+  - `subtitle`: texto abaixo do nome. Padrão: `chegou no canal`.
+  - `volume`: volume do `soundUrl`, de `0` a `1`.
 
 ## Metas de likes
 
@@ -27,7 +43,7 @@ Esta integração usa `POST /api/internal/streamerbot/events` com HMAC, como os 
   - `occurredAt`: data em ISO
 - Critério de presença: viewers com ledger `presence_tick` na mesma `broadcastId` do evento de likes, desde o início da live até o momento em que a meta bateu.
 - Overlay do OBS: use `/obs/likes` como browser source. Para testar o visual sem live, use `/obs/likes?demo=1`.
-- Feed do overlay: `/api/obs/live-like-goals/current`, atualizado pelo último `like_count_update` recebido.
+- Feed do overlay: `/api/obs/likes/current`, atualizado pelo último `like_count_update` recebido.
 
 ### Overlay da meta de likes
 

--- a/docs/streamerbot-live-rewards.md
+++ b/docs/streamerbot-live-rewards.md
@@ -24,7 +24,7 @@ Esta integração usa `POST /api/internal/streamerbot/events` com HMAC, como os 
 - O overlay consulta `GET /api/obs/subscribers/current` a cada segundo e enfileira localmente os eventos novos recebidos nos últimos 2 minutos.
 - Cada alerta toca o som uma vez, fica visível por 7 segundos por padrão e sai automaticamente. Eventos consecutivos são exibidos em sequência.
 - Parâmetros opcionais do Browser Source:
-  - `imageUrl` ou `image`: imagem exibida no alerta. Exemplo: `/obs/subscribers?imageUrl=/selfie2.png`.
+  - `imageUrl` ou `image`: imagem exibida no alerta. Sem esse parâmetro, o overlay não mostra imagem.
   - `soundUrl` ou `sound`: arquivo de áudio do alerta. Sem esse parâmetro, o overlay usa um som sintético embutido.
   - `durationMs` ou `duration`: duração em milissegundos, entre 3000 e 20000.
   - `title`: texto do selo principal. Padrão: `Nova inscrição`.

--- a/src/app/api/obs/subscribers/current/route.ts
+++ b/src/app/api/obs/subscribers/current/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+
+import { listRecentSubscriberAlerts } from "@/lib/db/repository";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const alerts = await listRecentSubscriberAlerts();
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: alerts,
+    },
+    {
+      headers: {
+        "Cache-Control": "no-store, max-age=0, must-revalidate",
+      },
+    },
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -867,6 +867,33 @@ a:focus-visible {
   transform-origin: bottom center;
 }
 
+@keyframes subscriberOverlayPop {
+  0% {
+    opacity: 0;
+    transform: translateY(54px) scale(0.9) rotate(-1.5deg);
+  }
+
+  12% {
+    opacity: 1;
+    transform: translateY(0) scale(1.03) rotate(0.8deg);
+  }
+
+  82% {
+    opacity: 1;
+    transform: translateY(0) scale(1) rotate(0deg);
+  }
+
+  100% {
+    opacity: 0;
+    transform: translateY(-24px) scale(0.98) rotate(0deg);
+  }
+}
+
+.subscriber-overlay-pop {
+  animation: subscriberOverlayPop 7s cubic-bezier(0.22, 1, 0.36, 1) both;
+  transform-origin: bottom center;
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/src/app/obs/subscribers/page.tsx
+++ b/src/app/obs/subscribers/page.tsx
@@ -1,0 +1,11 @@
+import { Suspense } from "react";
+
+import { ObsSubscriberOverlay } from "@/components/obs-subscriber-overlay";
+
+export default function ObsSubscribersPage() {
+  return (
+    <Suspense fallback={null}>
+      <ObsSubscriberOverlay />
+    </Suspense>
+  );
+}

--- a/src/components/admin-obs-overlays-panel.tsx
+++ b/src/components/admin-obs-overlays-panel.tsx
@@ -34,6 +34,14 @@ const overlays = [
     apiHref: "/api/obs/likes/current",
   },
   {
+    id: "subscribers",
+    name: "Novos inscritos no OBS",
+    description: "Overlay de nova inscrição, com imagem configurável, som de alerta e fila local para eventos consecutivos.",
+    liveHref: "/obs/subscribers",
+    demoHref: "/obs/subscribers?demo=1",
+    apiHref: "/api/obs/subscribers/current",
+  },
+  {
     id: "bets",
     name: "Apostas no OBS",
     description: "Overlay da aposta aberta, com pool, opções e distribuição dos votos atualizados automaticamente.",

--- a/src/components/obs-subscriber-overlay.tsx
+++ b/src/components/obs-subscriber-overlay.tsx
@@ -6,7 +6,6 @@ import { useEffect, useRef, useState } from "react";
 import type { SubscriberAlertRecord } from "@/lib/types";
 
 const DEFAULT_DURATION_MS = 7000;
-const DEFAULT_IMAGE_URL = "/selfie2.png";
 
 const DEMO_ALERTS: SubscriberAlertRecord[] = [
   {
@@ -104,7 +103,7 @@ export function ObsSubscriberOverlay() {
   const searchParams = useSearchParams();
   const isDemo = searchParams.get("demo") === "1";
   const durationMs = clampDuration(readParam(searchParams, ["durationMs", "duration"]));
-  const imageUrl = readParam(searchParams, ["imageUrl", "image"]) ?? DEFAULT_IMAGE_URL;
+  const imageUrl = readParam(searchParams, ["imageUrl", "image"]);
   const soundUrl = readParam(searchParams, ["soundUrl", "sound"]);
   const title = readParam(searchParams, ["title"]) ?? "Nova inscrição";
   const subtitle = readParam(searchParams, ["subtitle"]) ?? "chegou no canal";
@@ -206,21 +205,23 @@ export function ObsSubscriberOverlay() {
       {currentAlert ? (
         <section
           key={currentAlert.eventId}
-          className="subscriber-overlay-pop relative grid w-full max-w-[980px] overflow-hidden border-[4px] border-black bg-[#fff6db] text-black shadow-[12px_12px_0_#000] sm:grid-cols-[220px_1fr]"
+          className={`subscriber-overlay-pop relative grid w-full max-w-[980px] overflow-hidden border-[4px] border-black bg-[#fff6db] text-black shadow-[12px_12px_0_#000] ${imageUrl ? "sm:grid-cols-[220px_1fr]" : ""}`}
           style={{ animationDuration: `${durationMs}ms` }}
           aria-live="polite"
         >
           <div className="absolute inset-x-0 top-0 h-5 border-b-[4px] border-black bg-[repeating-linear-gradient(90deg,#000_0_28px,#ff66b3_28px_56px,#41d1ff_56px_84px,#00beae_84px_112px,#ffe066_112px_140px)]" />
 
-          <div className="relative flex min-h-[220px] items-center justify-center border-b-[4px] border-black bg-[#41d1ff] p-5 pt-10 sm:border-b-0 sm:border-r-[4px]">
-            <div className="absolute inset-4 border-[3px] border-black bg-[#ffe066]" />
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={imageUrl}
-              alt=""
-              className="relative aspect-square w-full max-w-[170px] border-[4px] border-black bg-white object-cover shadow-[8px_8px_0_#000]"
-            />
-          </div>
+          {imageUrl ? (
+            <div className="relative flex min-h-[220px] items-center justify-center border-b-[4px] border-black bg-[#41d1ff] p-5 pt-10 sm:border-b-0 sm:border-r-[4px]">
+              <div className="absolute inset-4 border-[3px] border-black bg-[#ffe066]" />
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={imageUrl}
+                alt=""
+                className="relative aspect-square w-full max-w-[170px] border-[4px] border-black bg-white object-cover shadow-[8px_8px_0_#000]"
+              />
+            </div>
+          ) : null}
 
           <div className="relative flex flex-col gap-5 px-6 pb-6 pt-10 sm:px-10 sm:pb-10 sm:pt-12">
             <div className="flex flex-wrap items-center gap-3 text-[11px] font-black uppercase tracking-[0.22em] sm:text-xs">

--- a/src/components/obs-subscriber-overlay.tsx
+++ b/src/components/obs-subscriber-overlay.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+
+import type { SubscriberAlertRecord } from "@/lib/types";
+
+const DEFAULT_DURATION_MS = 7000;
+const DEFAULT_IMAGE_URL = "/selfie2.png";
+
+const DEMO_ALERTS: SubscriberAlertRecord[] = [
+  {
+    eventId: "demo-sub-1",
+    viewerExternalId: "UC-DEMO-1",
+    displayName: "Lia Pixel",
+    youtubeHandle: "@liapixel",
+    occurredAt: "2026-06-01T21:00:00.000Z",
+    broadcastId: "demo-live",
+  },
+  {
+    eventId: "demo-sub-2",
+    viewerExternalId: "UC-DEMO-2",
+    displayName: "Ana Neon",
+    youtubeHandle: "@ananeon",
+    occurredAt: "2026-06-01T21:00:09.000Z",
+    broadcastId: "demo-live",
+  },
+];
+
+let subscriberAudioContext: AudioContext | null = null;
+
+function clampDuration(value: string | null) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_DURATION_MS;
+  }
+  return Math.min(Math.max(Math.floor(parsed), 3000), 20000);
+}
+
+function readParam(searchParams: ReturnType<typeof useSearchParams>, keys: string[]) {
+  for (const key of keys) {
+    const value = searchParams.get(key)?.trim();
+    if (value) {
+      return value;
+    }
+  }
+  return null;
+}
+
+async function playSubscriberChime() {
+  const AudioContextCtor =
+    window.AudioContext ||
+    (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+
+  if (!AudioContextCtor) {
+    return;
+  }
+
+  subscriberAudioContext ??= new AudioContextCtor();
+
+  if (subscriberAudioContext.state === "suspended") {
+    await subscriberAudioContext.resume();
+  }
+
+  const startAt = subscriberAudioContext.currentTime + 0.02;
+  const notes = [
+    { frequency: 392, delay: 0, duration: 0.14, gain: 0.045 },
+    { frequency: 523.25, delay: 0.1, duration: 0.16, gain: 0.05 },
+    { frequency: 659.25, delay: 0.22, duration: 0.2, gain: 0.052 },
+    { frequency: 783.99, delay: 0.36, duration: 0.22, gain: 0.045 },
+  ];
+
+  notes.forEach((note) => {
+    const oscillator = subscriberAudioContext!.createOscillator();
+    const gainNode = subscriberAudioContext!.createGain();
+    const noteStart = startAt + note.delay;
+    const noteEnd = noteStart + note.duration;
+
+    oscillator.type = "triangle";
+    oscillator.frequency.setValueAtTime(note.frequency, noteStart);
+    gainNode.gain.setValueAtTime(0.0001, noteStart);
+    gainNode.gain.exponentialRampToValueAtTime(note.gain, noteStart + 0.03);
+    gainNode.gain.exponentialRampToValueAtTime(0.0001, noteEnd);
+
+    oscillator.connect(gainNode);
+    gainNode.connect(subscriberAudioContext!.destination);
+    oscillator.start(noteStart);
+    oscillator.stop(noteEnd + 0.03);
+  });
+}
+
+async function playAlertSound(soundUrl: string | null, volume: number) {
+  if (soundUrl) {
+    const audio = new Audio(soundUrl);
+    audio.volume = volume;
+    await audio.play();
+    return;
+  }
+
+  await playSubscriberChime();
+}
+
+export function ObsSubscriberOverlay() {
+  const searchParams = useSearchParams();
+  const isDemo = searchParams.get("demo") === "1";
+  const durationMs = clampDuration(readParam(searchParams, ["durationMs", "duration"]));
+  const imageUrl = readParam(searchParams, ["imageUrl", "image"]) ?? DEFAULT_IMAGE_URL;
+  const soundUrl = readParam(searchParams, ["soundUrl", "sound"]);
+  const title = readParam(searchParams, ["title"]) ?? "Nova inscrição";
+  const subtitle = readParam(searchParams, ["subtitle"]) ?? "chegou no canal";
+  const rawVolume = Number(searchParams.get("volume") ?? "0.8");
+  const volume = Number.isFinite(rawVolume) ? Math.min(Math.max(rawVolume, 0), 1) : 0.8;
+  const [alerts, setAlerts] = useState<SubscriberAlertRecord[]>(isDemo ? DEMO_ALERTS : []);
+  const currentAlert = alerts[0] ?? null;
+  const seenEventIds = useRef(new Set<string>());
+  const lastDemoCycleAt = useRef(0);
+
+  useEffect(() => {
+    if (isDemo) {
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    async function loadAlerts() {
+      try {
+        const response = await fetch("/api/obs/subscribers/current", {
+          cache: "no-store",
+        });
+
+        if (!response.ok) {
+          return;
+        }
+
+        const payload = (await response.json()) as {
+          ok: boolean;
+          data: SubscriberAlertRecord[];
+        };
+
+        if (cancelled) {
+          return;
+        }
+
+        const nextAlerts = payload.data.filter((alert) => !seenEventIds.current.has(alert.eventId));
+        nextAlerts.forEach((alert) => seenEventIds.current.add(alert.eventId));
+        if (nextAlerts.length > 0) {
+          setAlerts((current) => [...current, ...nextAlerts].slice(-20));
+        }
+      } catch {
+        // Keep the current queue; the next poll can recover.
+      }
+    }
+
+    void loadAlerts();
+    const interval = window.setInterval(() => {
+      void loadAlerts();
+    }, 1000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [isDemo]);
+
+  useEffect(() => {
+    if (!isDemo) {
+      return undefined;
+    }
+
+    const interval = window.setInterval(() => {
+      const now = Date.now();
+      if (alerts.length === 0 && now - lastDemoCycleAt.current > 1500) {
+        lastDemoCycleAt.current = now;
+        setAlerts(
+          DEMO_ALERTS.map((alert) => ({
+            ...alert,
+            eventId: `${alert.eventId}-${now}`,
+          })),
+        );
+      }
+    }, 1000);
+
+    return () => window.clearInterval(interval);
+  }, [alerts.length, isDemo]);
+
+  useEffect(() => {
+    if (!currentAlert) {
+      return undefined;
+    }
+
+    void playAlertSound(soundUrl, volume).catch(() => {
+      // Browser autoplay can block audio outside OBS; visual alert still works.
+    });
+
+    const timeout = window.setTimeout(() => {
+      setAlerts((current) =>
+        current[0]?.eventId === currentAlert.eventId ? current.slice(1) : current,
+      );
+    }, durationMs);
+
+    return () => window.clearTimeout(timeout);
+  }, [currentAlert, durationMs, soundUrl, volume]);
+
+  return (
+    <div className="pointer-events-none flex min-h-screen items-end justify-center p-6 sm:p-10 lg:p-14">
+      {currentAlert ? (
+        <section
+          key={currentAlert.eventId}
+          className="subscriber-overlay-pop relative grid w-full max-w-[980px] overflow-hidden border-[4px] border-black bg-[#fff6db] text-black shadow-[12px_12px_0_#000] sm:grid-cols-[220px_1fr]"
+          style={{ animationDuration: `${durationMs}ms` }}
+          aria-live="polite"
+        >
+          <div className="absolute inset-x-0 top-0 h-5 border-b-[4px] border-black bg-[repeating-linear-gradient(90deg,#000_0_28px,#ff66b3_28px_56px,#41d1ff_56px_84px,#00beae_84px_112px,#ffe066_112px_140px)]" />
+
+          <div className="relative flex min-h-[220px] items-center justify-center border-b-[4px] border-black bg-[#41d1ff] p-5 pt-10 sm:border-b-0 sm:border-r-[4px]">
+            <div className="absolute inset-4 border-[3px] border-black bg-[#ffe066]" />
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={imageUrl}
+              alt=""
+              className="relative aspect-square w-full max-w-[170px] border-[4px] border-black bg-white object-cover shadow-[8px_8px_0_#000]"
+            />
+          </div>
+
+          <div className="relative flex flex-col gap-5 px-6 pb-6 pt-10 sm:px-10 sm:pb-10 sm:pt-12">
+            <div className="flex flex-wrap items-center gap-3 text-[11px] font-black uppercase tracking-[0.22em] sm:text-xs">
+              <span className="border-[3px] border-black bg-black px-3 py-1 text-white">
+                {title}
+              </span>
+              {currentAlert.youtubeHandle ? (
+                <span className="border-[3px] border-black bg-[#00beae] px-3 py-1">
+                  {currentAlert.youtubeHandle}
+                </span>
+              ) : null}
+            </div>
+
+            <h1
+              className="max-w-[18ch] break-words text-[2.4rem] font-black uppercase leading-[0.94] sm:text-[3.4rem] lg:text-[4.8rem]"
+              style={{ fontFamily: "var(--font-display)" }}
+            >
+              {currentAlert.displayName}
+            </h1>
+
+            <p className="w-fit max-w-full border-[3px] border-black bg-[#ff66b3] px-4 py-2 text-lg font-black uppercase leading-tight sm:text-2xl">
+              {subtitle}
+            </p>
+          </div>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/db/repository.test.ts
+++ b/src/lib/db/repository.test.ts
@@ -87,6 +87,7 @@ import {
   issueViewerLinkCode,
   listAdminProductRecommendations,
   listAdminViewerDirectory,
+  listRecentSubscriberAlerts,
   listBets,
   listGameSuggestions,
   listAdminGameSuggestions,
@@ -3440,6 +3441,67 @@ describe("ingestStreamerbotEvent", () => {
         targetLikeCount: 50,
       },
     });
+  });
+
+  it("lists recent subscriber alerts in chronological display order", async () => {
+    getDbMock.mockReturnValue(null);
+
+    await ingestStreamerbotEvent({
+      eventId: "sub-old",
+      eventType: "channel_subscription",
+      viewerExternalId: "yt_caio",
+      youtubeDisplayName: "Caio CRT",
+      youtubeHandle: "@caiocrt",
+      occurredAt: "2026-04-01T11:55:00.000Z",
+      payload: {
+        broadcastId: "live-sub-alerts",
+      },
+    });
+    await ingestStreamerbotEvent({
+      eventId: "sub-lia",
+      eventType: "channel_subscription",
+      viewerExternalId: "yt_lia",
+      youtubeDisplayName: "Lia Pixel",
+      youtubeHandle: "@liapixel",
+      occurredAt: "2026-04-01T12:00:01.000Z",
+      payload: {
+        broadcastId: "live-sub-alerts",
+      },
+    });
+    await ingestStreamerbotEvent({
+      eventId: "sub-ana",
+      eventType: "channel_subscription",
+      viewerExternalId: "yt_ana",
+      youtubeDisplayName: "Ana Neon",
+      youtubeHandle: "@ananeon",
+      occurredAt: "2026-04-01T12:00:03.000Z",
+      payload: {
+        broadcastId: "live-sub-alerts",
+      },
+    });
+
+    const alerts = await listRecentSubscriberAlerts({
+      since: new Date("2026-04-01T12:00:00.000Z"),
+    });
+
+    expect(alerts).toEqual([
+      {
+        eventId: "sub-lia",
+        viewerExternalId: "yt_lia",
+        displayName: "Lia Pixel",
+        youtubeHandle: "@liapixel",
+        occurredAt: "2026-04-01T12:00:01.000Z",
+        broadcastId: "live-sub-alerts",
+      },
+      {
+        eventId: "sub-ana",
+        viewerExternalId: "yt_ana",
+        displayName: "Ana Neon",
+        youtubeHandle: "@ananeon",
+        occurredAt: "2026-04-01T12:00:03.000Z",
+        broadcastId: "live-sub-alerts",
+      },
+    ]);
   });
 
 });

--- a/src/lib/db/repository.ts
+++ b/src/lib/db/repository.ts
@@ -122,6 +122,7 @@ import {
   QuoteRecord,
   ProductRecommendationRecord,
   RedemptionRecord,
+  SubscriberAlertRecord,
   StreamerbotEventType,
   StreamerbotCounterRecord,
   StreamerbotCounterSummaryRecord,
@@ -1700,6 +1701,42 @@ function buildLiveLikeGoalOverlayState(
       : 0,
     remainingLikes: goal ? Math.max(goal.targetLikeCount - currentLikeCount, 0) : null,
     isGoalReached: goal ? currentLikeCount >= goal.targetLikeCount : false,
+  };
+}
+
+function readSubscriberName(input: {
+  viewer?: ViewerRecord | null;
+  viewerExternalId?: string | null;
+  payload: Record<string, unknown>;
+}) {
+  return (
+    input.viewer?.youtubeDisplayName ||
+    readStringFromPayload(input.payload, "youtubeDisplayName") ||
+    readStringFromPayload(input.payload, "displayName") ||
+    readStringFromPayload(input.payload, "user") ||
+    input.viewerExternalId ||
+    "Nova pessoa"
+  );
+}
+
+function buildSubscriberAlert(input: {
+  eventId: string;
+  viewerExternalId: string | null;
+  payload: Record<string, unknown>;
+  occurredAt: string;
+  viewer?: ViewerRecord | null;
+}): SubscriberAlertRecord {
+  const youtubeHandle =
+    input.viewer?.youtubeHandle ??
+    normalizeYoutubeHandle(readStringFromPayload(input.payload, "youtubeHandle") ?? undefined);
+
+  return {
+    eventId: input.eventId,
+    viewerExternalId: input.viewerExternalId,
+    displayName: readSubscriberName(input),
+    youtubeHandle,
+    occurredAt: input.occurredAt,
+    broadcastId: readStringFromPayload(input.payload, "broadcastId"),
   };
 }
 
@@ -8511,6 +8548,87 @@ export async function getLiveLikeGoalOverlayState(): Promise<LiveLikeGoalOverlay
   return buildLiveLikeGoalOverlayState(goalRows.map(serializeLiveLikeGoal), latestEvent);
 }
 
+export async function listRecentSubscriberAlerts({
+  limit = 20,
+  since = new Date(Date.now() - 2 * 60 * 1000),
+}: {
+  limit?: number;
+  since?: Date;
+} = {}): Promise<SubscriberAlertRecord[]> {
+  const safeLimit = Math.min(Math.max(Math.floor(limit), 1), 50);
+  const db = getDb();
+
+  if (isDemoMode || !db) {
+    const store = getDemoStore();
+    return store.streamerbotEvents
+      .filter(
+        (entry) =>
+          entry.eventType === "channel_subscription" &&
+          new Date(entry.occurredAt).getTime() >= since.getTime(),
+      )
+      .sort((left, right) => new Date(right.occurredAt).getTime() - new Date(left.occurredAt).getTime())
+      .slice(0, safeLimit)
+      .reverse()
+      .map((entry) => {
+        const viewerExternalId =
+          typeof entry.payload.viewerExternalId === "string" ? entry.payload.viewerExternalId : null;
+        const viewer = viewerExternalId
+          ? store.viewers.find((candidate) => candidate.youtubeChannelId === viewerExternalId)
+          : null;
+
+        return buildSubscriberAlert({
+          eventId: entry.eventId,
+          viewerExternalId,
+          payload: entry.payload,
+          occurredAt: entry.occurredAt,
+          viewer,
+        });
+      });
+  }
+
+  const eventRows = await db
+    .select()
+    .from(streamerbotEventLog)
+    .where(
+      and(
+        eq(streamerbotEventLog.eventType, "channel_subscription"),
+        gte(streamerbotEventLog.occurredAt, since),
+      ),
+    )
+    .orderBy(desc(streamerbotEventLog.occurredAt))
+    .limit(safeLimit);
+
+  const viewerExternalIds = [
+    ...new Set(
+      eventRows
+        .map((entry) => entry.viewerExternalId)
+        .filter((value): value is string => Boolean(value)),
+    ),
+  ];
+  const viewerRows =
+    viewerExternalIds.length > 0
+      ? await db
+          .select()
+          .from(users)
+          .where(inArray(users.youtubeChannelId, viewerExternalIds))
+      : [];
+  const viewersByChannelId = new Map(
+    viewerRows.map((viewer) => [viewer.youtubeChannelId, serializeViewer(viewer)]),
+  );
+
+  return eventRows
+    .reverse()
+    .map((entry) =>
+      buildSubscriberAlert({
+        eventId: entry.eventId,
+        viewerExternalId: entry.viewerExternalId,
+        payload: asRecord(entry.payload),
+        occurredAt: entry.occurredAt.toISOString(),
+        viewer: entry.viewerExternalId ? viewersByChannelId.get(entry.viewerExternalId) : null,
+      }),
+    );
+}
+
 export async function createLiveLikeGoal(input: {
   label?: string | null;
   targetLikeCount: number;
@@ -8775,7 +8893,12 @@ export async function ingestStreamerbotEvent(input: {
       eventId: input.eventId,
       eventType: input.eventType,
       balance: input.balance ?? null,
-      payload: eventLogPayload,
+      payload: {
+        ...eventLogPayload,
+        ...(input.viewerExternalId ? { viewerExternalId: input.viewerExternalId } : {}),
+        ...(input.youtubeDisplayName ? { youtubeDisplayName: input.youtubeDisplayName } : {}),
+        ...(youtubeHandle ? { youtubeHandle } : {}),
+      },
       occurredAt: input.occurredAt,
     });
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -482,6 +482,15 @@ export interface LiveLikeGoalOverlayStateRecord {
   isGoalReached: boolean;
 }
 
+export interface SubscriberAlertRecord {
+  eventId: string;
+  viewerExternalId: string | null;
+  displayName: string;
+  youtubeHandle: string | null;
+  occurredAt: string;
+  broadcastId: string | null;
+}
+
 export interface BetViewerPositionRecord {
   amount: number;
   optionId: string;


### PR DESCRIPTION
## O que mudou

- Adiciona o overlay `/obs/subscribers` para alertas de novas inscrições no canal.
- Adiciona `GET /api/obs/subscribers/current` para expor inscrições recentes vindas do Streamer.bot.
- Enfileira eventos consecutivos no cliente, toca som uma vez por alerta e permite configurar imagem, som, duração, título e subtítulo via query string.
- Documenta a configuração do Streamer.bot e adiciona o overlay ao painel admin.

## Validação

- `npm run lint` passou com um warning já existente em `admin-dashboard-tabs.tsx`.
- `npm test -- src/lib/db/repository.test.ts`
- `npm test -- src/lib/streamerbot/security.test.ts src/lib/streamerbot/live-status.test.ts`
- `npm run build`
- Demo verificado em `http://localhost:3000/obs/subscribers?demo=1&durationMs=5000`.

Closes #113