### PR TITLE
[codex] Add game suggestion boost modifiers

### DIFF
--- a/src/app/(public)/jogos/page.tsx
+++ b/src/app/(public)/jogos/page.tsx
@@ -2,7 +2,7 @@ import { auth } from "@/auth";
 import { GameSuggestForm } from "@/components/game-suggest-form";
 import { GameSuggestionList } from "@/components/game-suggestion-list";
 import { getPipetzPricing, getViewerDashboard, listGameSuggestions } from "@/lib/db/repository";
-import { adminEmails } from "@/lib/env";
+import { adminEmails, isDemoMode } from "@/lib/env";
 
 export default async function JogosPage() {
   const session = await auth();
@@ -15,7 +15,9 @@ export default async function JogosPage() {
 
   const viewerBalance = dashboard?.balance.currentBalance ?? null;
   const canInteract = Boolean(activeViewerId && dashboard?.viewer.isLinked);
-  const isAdmin = Boolean(session?.user?.email && adminEmails.has(session.user.email.toLowerCase()));
+  const isAdmin = Boolean(
+    session?.user?.email && (isDemoMode || adminEmails.has(session.user.email.toLowerCase())),
+  );
 
   return (
     <div className="flex w-full flex-col">

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -17,6 +17,7 @@ import { requireAdminSession } from "@/lib/auth/session";
 import {
   getBridgeStatus,
   getCatalog,
+  getGameSuggestionBoostSettings,
   getLeaderboard,
   getObsOverlayAdminStatus,
   getPipetzPricing,
@@ -43,7 +44,7 @@ const statusColorMap: Record<string, string> = {
 
 export default async function AdminPage() {
   await requireAdminSession();
-  const [catalog, leaderboard, bridge, liveStatus, currentGame, redemptions, bets, likeGoals, suggestions, videoSuggestions, recommendations, viewers, obsOverlayStatus, pricing, wheelConfig] = await Promise.all([
+  const [catalog, leaderboard, bridge, liveStatus, currentGame, redemptions, bets, likeGoals, suggestions, gameBoostSettings, videoSuggestions, recommendations, viewers, obsOverlayStatus, pricing, wheelConfig] = await Promise.all([
     getCatalog(),
     getLeaderboard(),
     getBridgeStatus(),
@@ -53,6 +54,7 @@ export default async function AdminPage() {
     listAdminBets(),
     listAdminLiveLikeGoals(),
     listAdminGameSuggestions(),
+    getGameSuggestionBoostSettings(),
     listAdminVideoSuggestions(),
     listAdminProductRecommendations(),
     listAdminViewerDirectory(),
@@ -94,7 +96,7 @@ export default async function AdminPage() {
             content: (
               <div className="space-y-6">
                 <AdminViewerLinksPanel entries={viewers} />
-                <AdminGameSuggestionsPanel suggestions={suggestions} />
+                <AdminGameSuggestionsPanel suggestions={suggestions} boostSettings={gameBoostSettings} />
                 <AdminVideoSuggestionsPanel suggestions={videoSuggestions} />
                 <AdminRecommendationsPanel recommendations={recommendations} />
               </div>

--- a/src/app/api/admin/game-suggestions/boost-settings/route.ts
+++ b/src/app/api/admin/game-suggestions/boost-settings/route.ts
@@ -1,0 +1,53 @@
+import { fail, isTrustedAppMutationRequest, ok, requireAdminApiSession } from "@/lib/api";
+import {
+  getGameSuggestionBoostSettings,
+  updateGameSuggestionBoostSettings,
+} from "@/lib/db/repository";
+import {
+  formatGameSuggestionSchemaError,
+  updateGameSuggestionBoostSettingsSchema,
+} from "@/lib/game-suggestions/service";
+
+export async function GET() {
+  const session = await requireAdminApiSession();
+  if (!session) {
+    return fail("Forbidden", 403);
+  }
+
+  return ok(await getGameSuggestionBoostSettings());
+}
+
+export async function PATCH(request: Request) {
+  if (!isTrustedAppMutationRequest(request)) {
+    return fail("Forbidden", 403);
+  }
+
+  const session = await requireAdminApiSession();
+  if (!session) {
+    return fail("Forbidden", 403);
+  }
+
+  try {
+    const parsed = updateGameSuggestionBoostSettingsSchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return fail(formatGameSuggestionSchemaError(parsed.error), 400);
+    }
+
+    const data = await updateGameSuggestionBoostSettings({
+      ...parsed.data,
+      updatedBy: session.user?.email?.toLowerCase() ?? null,
+    });
+
+    return ok(data);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return fail("Payload inválido.", 400);
+    }
+
+    if (error instanceof Error && error.message === "invalid_multiplier") {
+      return fail("Multiplicadores devem ficar entre 0 e 10.", 400);
+    }
+
+    return fail(error instanceof Error ? error.message : "Falha ao salvar multiplicadores.", 400);
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,7 @@ import { auth } from "@/auth";
 import { AppChrome } from "@/components/app-chrome";
 import { Providers } from "@/components/providers";
 import "./globals.css";
-import { adminEmails } from "@/lib/env";
+import { adminEmails, isDemoMode } from "@/lib/env";
 import { isStreamerbotLivestreamActive } from "@/lib/streamerbot/live-status";
 import { isThemeMode, themeCookieKey, themeStorageKey } from "@/lib/theme";
 import { cn } from "@/lib/utils";
@@ -71,7 +71,9 @@ export default async function RootLayout({
     auth(),
     isStreamerbotLivestreamActive(),
   ]);
-  const isAdmin = Boolean(session?.user?.email && adminEmails.has(session.user.email.toLowerCase()));
+  const isAdmin = Boolean(
+    session?.user?.email && (isDemoMode || adminEmails.has(session.user.email.toLowerCase())),
+  );
 
   return (
     <html

--- a/src/components/admin-game-suggestions-panel.tsx
+++ b/src/components/admin-game-suggestions-panel.tsx
@@ -4,8 +4,39 @@ import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
-import type { GameSuggestionWithMeta } from "@/lib/types";
+import { Input } from "@/components/ui/input";
+import type {
+  GameSuggestionBoostSettingsRecord,
+  GameSuggestionWithMeta,
+} from "@/lib/types";
 import { formatDateTime, formatPipetz } from "@/lib/utils";
+
+type BoostSettingField = keyof Pick<
+  GameSuggestionBoostSettingsRecord,
+  "psPlusMultiplier" | "shortGameMultiplier" | "adminSuggestionMultiplier"
+>;
+
+const boostSettingFields: Array<{
+  key: BoostSettingField;
+  label: string;
+  description: string;
+}> = [
+  {
+    key: "psPlusMultiplier",
+    label: "Disponível na PS Plus",
+    description: "Aplica quando a sugestão aparece no catálogo PlayStation Plus.",
+  },
+  {
+    key: "shortGameMultiplier",
+    label: "Menos de 10h no HLTB",
+    description: "Aplica quando o tempo de história principal do HowLongToBeat fica abaixo de 10h.",
+  },
+  {
+    key: "adminSuggestionMultiplier",
+    label: "Enviada pelo admin",
+    description: "Aplica quando o viewer que enviou a sugestão usa um e-mail de admin.",
+  },
+];
 
 const statusLabels: Record<GameSuggestionWithMeta["status"], string> = {
   open: "Aberta",
@@ -32,19 +63,89 @@ function mapSuggestionError(message: string) {
   }
 }
 
+function toBoostFormState(settings: GameSuggestionBoostSettingsRecord) {
+  return {
+    psPlusMultiplier: String(settings.psPlusMultiplier),
+    shortGameMultiplier: String(settings.shortGameMultiplier),
+    adminSuggestionMultiplier: String(settings.adminSuggestionMultiplier),
+  };
+}
+
+function formatMultiplier(value: number) {
+  return `${value.toLocaleString("pt-BR", {
+    minimumFractionDigits: Number.isInteger(value) ? 0 : 2,
+    maximumFractionDigits: 2,
+  })}x`;
+}
+
 export function AdminGameSuggestionsPanel({
   suggestions,
+  boostSettings: initialBoostSettings,
 }: {
   suggestions: GameSuggestionWithMeta[];
+  boostSettings: GameSuggestionBoostSettingsRecord;
 }) {
   const router = useRouter();
   const [feedback, setFeedback] = useState<string | null>(null);
+  const [boostSettings, setBoostSettings] = useState(initialBoostSettings);
+  const [boostForm, setBoostForm] = useState(toBoostFormState(initialBoostSettings));
   const [isPending, startTransition] = useTransition();
   const [showAllSuggestions, setShowAllSuggestions] = useState(false);
   const visibleSuggestions = showAllSuggestions
     ? suggestions
     : suggestions.slice(0, INITIAL_VISIBLE_GAME_SUGGESTIONS);
   const hiddenSuggestionCount = Math.max(suggestions.length - visibleSuggestions.length, 0);
+
+  function updateBoostField(field: BoostSettingField, value: string) {
+    setBoostForm((current) => ({
+      ...current,
+      [field]: value,
+    }));
+  }
+
+  function saveBoostSettings() {
+    const payload = {
+      psPlusMultiplier: Number(boostForm.psPlusMultiplier),
+      shortGameMultiplier: Number(boostForm.shortGameMultiplier),
+      adminSuggestionMultiplier: Number(boostForm.adminSuggestionMultiplier),
+    };
+
+    if (Object.values(payload).some((value) => !Number.isFinite(value) || value < 0 || value > 10)) {
+      setFeedback("Use multiplicadores entre 0 e 10.");
+      return;
+    }
+
+    setFeedback(null);
+    startTransition(async () => {
+      try {
+        const response = await fetch("/api/admin/game-suggestions/boost-settings", {
+          method: "PATCH",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify(payload),
+        });
+
+        const result = (await response.json()) as {
+          ok?: boolean;
+          error?: string;
+          data?: GameSuggestionBoostSettingsRecord;
+        };
+
+        if (!response.ok || !result.ok || !result.data) {
+          setFeedback(result.error ?? "Falha ao salvar multiplicadores.");
+          return;
+        }
+
+        setBoostSettings(result.data);
+        setBoostForm(toBoostFormState(result.data));
+        setFeedback("Multiplicadores atualizados.");
+        router.refresh();
+      } catch (error) {
+        setFeedback(error instanceof Error ? error.message : "Falha ao salvar multiplicadores.");
+      }
+    });
+  }
 
   function submitStatus(suggestionId: string, status: GameSuggestionWithMeta["status"]) {
     setFeedback(null);
@@ -72,119 +173,193 @@ export function AdminGameSuggestionsPanel({
     <section className="landing-plane landing-divider bg-[var(--color-paper-pink)] py-8 sm:py-10">
       <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
         <div className="flex flex-wrap items-start justify-between gap-4">
-        <div>
-          <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
-            Jogos
-          </p>
-          <h2
-            className="mt-2 text-3xl uppercase"
-            style={{ fontFamily: "var(--font-display)" }}
-          >
-            Fila de sugestões
-          </h2>
-        </div>
-        {feedback ? (
-          <div className="retro-label neutral-chip">
-            {feedback}
-          </div>
-        ) : null}
-      </div>
-
-        <div className="mt-6 grid gap-3">
-        {suggestions.length === 0 ? (
-          <div className="card-brutal-static p-4 text-sm font-bold text-[var(--color-ink-soft)]">
-            Nenhuma sugestão cadastrada.
-          </div>
-        ) : null}
-
-        {visibleSuggestions.map((suggestion) => (
-          <article key={suggestion.id} className="card-brutal-static p-4">
-            <div className="flex flex-wrap items-start justify-between gap-3">
-              <div>
-                <div className="flex flex-wrap items-center gap-2">
-                  <p className="text-lg font-bold">{suggestion.name}</p>
-                  <span
-                    className="badge-brutal px-2 py-1 text-[10px] text-[var(--color-ink)]"
-                    style={{ backgroundColor: statusBgMap[suggestion.status] }}
-                  >
-                    {statusLabels[suggestion.status]}
-                  </span>
-                </div>
-                {suggestion.description ? (
-                  <p className="mt-2 text-sm text-[var(--color-ink-soft)]">
-                    {suggestion.description}
-                  </p>
-                ) : null}
-                <p className="mono mt-2 text-[10px] uppercase tracking-[0.18em] text-[var(--color-ink-soft)]">
-                  por {suggestion.suggestedBy} . {formatDateTime(suggestion.createdAt)}
-                </p>
-              </div>
-
-              <span className="retro-label neutral-chip">
-                {formatPipetz(suggestion.totalVotes)}
-              </span>
-            </div>
-
-            <div className="mt-4 flex flex-wrap gap-2">
-              {suggestion.status !== "accepted" ? (
-                <Button
-                  type="button"
-                  onClick={() => submitStatus(suggestion.id, "accepted")}
-                  disabled={isPending}
-                  variant="success"
-                  size="sm"
-                >
-                  Aceitar
-                </Button>
-              ) : null}
-              {suggestion.status !== "played" ? (
-                <Button
-                  type="button"
-                  onClick={() => submitStatus(suggestion.id, "played")}
-                  disabled={isPending}
-                  variant="neutral"
-                  size="sm"
-                >
-                  Marcar jogado
-                </Button>
-              ) : null}
-              {suggestion.status !== "rejected" ? (
-                <Button
-                  type="button"
-                  onClick={() => submitStatus(suggestion.id, "rejected")}
-                  disabled={isPending}
-                  variant="danger"
-                  size="sm"
-                >
-                  Rejeitar
-                </Button>
-              ) : null}
-              {suggestion.status !== "open" ? (
-                <Button
-                  type="button"
-                  onClick={() => submitStatus(suggestion.id, "open")}
-                  disabled={isPending}
-                  variant="info"
-                  size="sm"
-                >
-                  Reabrir
-                </Button>
-              ) : null}
-            </div>
-          </article>
-        ))}
-        {hiddenSuggestionCount > 0 || showAllSuggestions ? (
-          <div className="card-brutal-static flex justify-center p-4">
-            <Button
-              type="button"
-              onClick={() => setShowAllSuggestions((current) => !current)}
-              variant="neutral"
-              size="sm"
+          <div>
+            <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
+              Jogos
+            </p>
+            <h2
+              className="mt-2 text-3xl uppercase"
+              style={{ fontFamily: "var(--font-display)" }}
             >
-              {showAllSuggestions ? "Ver menos" : `Ver mais ${hiddenSuggestionCount}`}
+              Fila de sugestões
+            </h2>
+          </div>
+          {feedback ? (
+            <div className="retro-label neutral-chip">
+              {feedback}
+            </div>
+          ) : null}
+        </div>
+
+        <div className="mt-6 panel surface-section p-5">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
+                Boosts automáticos
+              </p>
+              <h3
+                className="mt-2 text-2xl font-bold uppercase"
+                style={{ fontFamily: "var(--font-display)" }}
+              >
+                Multiplicadores
+              </h3>
+              <p className="mt-2 max-w-3xl text-sm leading-6 text-[var(--color-ink-soft)]">
+                Quando mais de um critério se aplica, os multiplicadores são multiplicados entre si.
+                A pontuação efetiva é arredondada e usada para ordenar as sugestões.
+              </p>
+            </div>
+            {boostSettings.updatedAt ? (
+              <span className="text-sm font-bold text-[var(--color-ink-soft)]">
+                Atualizado em {formatDateTime(boostSettings.updatedAt)}
+                {boostSettings.updatedBy ? ` por ${boostSettings.updatedBy}` : ""}
+              </span>
+            ) : null}
+          </div>
+
+          <div className="mt-5 grid gap-4 xl:grid-cols-3">
+            {boostSettingFields.map((field) => (
+              <label key={field.key} className="card-brutal-static surface-card grid gap-3 p-4">
+                <div>
+                  <span className="text-sm font-black uppercase tracking-[0.14em]">
+                    {field.label}
+                  </span>
+                  <p className="mt-1 text-sm leading-6 text-[var(--color-ink-soft)]">
+                    {field.description}
+                  </p>
+                </div>
+                <span className="retro-label accent-chip w-fit">
+                  atual {formatMultiplier(boostSettings[field.key])}
+                </span>
+                <Input
+                  type="number"
+                  min={0}
+                  max={10}
+                  step={0.05}
+                  value={boostForm[field.key]}
+                  onChange={(event) => updateBoostField(field.key, event.target.value)}
+                />
+              </label>
+            ))}
+          </div>
+
+          <div className="mt-5">
+            <Button type="button" onClick={saveBoostSettings} disabled={isPending} variant="success" size="sm">
+              {isPending ? "Salvando..." : "Salvar multiplicadores"}
             </Button>
           </div>
-        ) : null}
+        </div>
+
+        <div className="mt-6 grid gap-3">
+          {suggestions.length === 0 ? (
+            <div className="card-brutal-static p-4 text-sm font-bold text-[var(--color-ink-soft)]">
+              Nenhuma sugestão cadastrada.
+            </div>
+          ) : null}
+
+          {visibleSuggestions.map((suggestion) => (
+            <article key={suggestion.id} className="card-brutal-static p-4">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="text-lg font-bold">{suggestion.name}</p>
+                    <span
+                      className="badge-brutal px-2 py-1 text-[10px] text-[var(--color-ink)]"
+                      style={{ backgroundColor: statusBgMap[suggestion.status] }}
+                    >
+                      {statusLabels[suggestion.status]}
+                    </span>
+                  </div>
+                  {suggestion.description ? (
+                    <p className="mt-2 text-sm text-[var(--color-ink-soft)]">
+                      {suggestion.description}
+                    </p>
+                  ) : null}
+                  <p className="mono mt-2 text-[10px] uppercase tracking-[0.18em] text-[var(--color-ink-soft)]">
+                    por {suggestion.suggestedBy} . {formatDateTime(suggestion.createdAt)}
+                  </p>
+                  {suggestion.appliedBoostModifiers.length > 0 ? (
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {suggestion.appliedBoostModifiers.map((modifier) => (
+                        <span key={modifier.key} className="retro-label neutral-chip">
+                          {modifier.label} {formatMultiplier(modifier.multiplier)}
+                        </span>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+
+                <div className="grid justify-items-end gap-2">
+                  <span className="retro-label accent-chip">
+                    prioridade {formatPipetz(suggestion.boostedScore)}
+                  </span>
+                  {suggestion.boostedScore !== suggestion.totalVotes ? (
+                    <span className="mono text-[10px] font-bold uppercase tracking-[0.14em] text-[var(--color-ink-soft)]">
+                      votos reais {formatPipetz(suggestion.totalVotes)}
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+
+              <div className="mt-4 flex flex-wrap gap-2">
+                {suggestion.status !== "accepted" ? (
+                  <Button
+                    type="button"
+                    onClick={() => submitStatus(suggestion.id, "accepted")}
+                    disabled={isPending}
+                    variant="success"
+                    size="sm"
+                  >
+                    Aceitar
+                  </Button>
+                ) : null}
+                {suggestion.status !== "played" ? (
+                  <Button
+                    type="button"
+                    onClick={() => submitStatus(suggestion.id, "played")}
+                    disabled={isPending}
+                    variant="neutral"
+                    size="sm"
+                  >
+                    Marcar jogado
+                  </Button>
+                ) : null}
+                {suggestion.status !== "rejected" ? (
+                  <Button
+                    type="button"
+                    onClick={() => submitStatus(suggestion.id, "rejected")}
+                    disabled={isPending}
+                    variant="danger"
+                    size="sm"
+                  >
+                    Rejeitar
+                  </Button>
+                ) : null}
+                {suggestion.status !== "open" ? (
+                  <Button
+                    type="button"
+                    onClick={() => submitStatus(suggestion.id, "open")}
+                    disabled={isPending}
+                    variant="info"
+                    size="sm"
+                  >
+                    Reabrir
+                  </Button>
+                ) : null}
+              </div>
+            </article>
+          ))}
+          {hiddenSuggestionCount > 0 || showAllSuggestions ? (
+            <div className="card-brutal-static flex justify-center p-4">
+              <Button
+                type="button"
+                onClick={() => setShowAllSuggestions((current) => !current)}
+                variant="neutral"
+                size="sm"
+              >
+                {showAllSuggestions ? "Ver menos" : `Ver mais ${hiddenSuggestionCount}`}
+              </Button>
+            </div>
+          ) : null}
         </div>
       </div>
     </section>

--- a/src/components/game-suggestion-card.tsx
+++ b/src/components/game-suggestion-card.tsx
@@ -51,6 +51,13 @@ function formatCompletionTime(minutes: number | null) {
   return `${hours}h${String(remainingMinutes).padStart(2, "0")}`;
 }
 
+function formatMultiplier(value: number) {
+  return `${value.toLocaleString("pt-BR", {
+    minimumFractionDigits: Number.isInteger(value) ? 0 : 2,
+    maximumFractionDigits: 2,
+  })}x`;
+}
+
 function buildHowLongToBeatTooltip(suggestion: GameSuggestionWithMeta) {
   const howLongToBeat = suggestion.howLongToBeat;
 
@@ -338,6 +345,16 @@ export function GameSuggestionCard({
             </span>
           </div>
 
+          {suggestion.appliedBoostModifiers.length > 0 ? (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {suggestion.appliedBoostModifiers.map((modifier) => (
+                <span key={modifier.key} className="retro-label neutral-chip">
+                  {modifier.label} {formatMultiplier(modifier.multiplier)}
+                </span>
+              ))}
+            </div>
+          ) : null}
+
           <div className="mt-auto pt-5">
             <p className="mono text-xs opacity-75">
               Sugerido por {suggestion.suggestedBy}
@@ -418,12 +435,22 @@ export function GameSuggestionCard({
         </div>
 
         <aside className="flex items-start justify-between gap-4 border-t-2 border-[var(--color-ink)] bg-[var(--color-paper)] p-5 md:min-w-36 md:flex-col md:border-l-1 md:border-t-0">
-          <p
-            className="text-3xl font-bold leading-none text-[var(--color-purple-bold)] sm:text-4xl"
-            style={{ fontFamily: "var(--font-display)" }}
-          >
-            {formatPipetz(suggestion.totalVotes)}
-          </p>
+          <div>
+            <p
+              className="text-3xl font-bold leading-none text-[var(--color-purple-bold)] sm:text-4xl"
+              style={{ fontFamily: "var(--font-display)" }}
+            >
+              {formatPipetz(suggestion.boostedScore)}
+            </p>
+            <p className="mono mt-2 text-[10px] font-bold uppercase tracking-[0.14em] text-[var(--color-ink-soft)]">
+              prioridade
+            </p>
+            {suggestion.boostedScore !== suggestion.totalVotes ? (
+              <p className="mono mt-1 text-[10px] font-bold uppercase tracking-[0.14em] text-[var(--color-ink-soft)]">
+                votos reais: {formatPipetz(suggestion.totalVotes)}
+              </p>
+            ) : null}
+          </div>
         </aside>
       </div>
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { auth } from "@/auth";
-import { adminEmails } from "@/lib/env";
+import { adminEmails, isDemoMode } from "@/lib/env";
 export { isTrustedAppMutationRequest } from "@/lib/request-origin";
 
 export function ok(data: unknown, init?: ResponseInit) {
@@ -33,6 +33,10 @@ export async function requireAdminApiSession() {
   if (!session?.user?.email) {
     return null;
   }
+  if (isDemoMode) {
+    return session;
+  }
+
   if (!adminEmails.has(session.user.email.toLowerCase())) {
     return null;
   }

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -1,7 +1,7 @@
 import { redirect } from "next/navigation";
 
 import { auth } from "@/auth";
-import { adminEmails } from "@/lib/env";
+import { adminEmails, isDemoMode } from "@/lib/env";
 
 export async function requireSession() {
   const session = await auth();
@@ -13,6 +13,10 @@ export async function requireSession() {
 
 export async function requireAdminSession() {
   const session = await requireSession();
+  if (isDemoMode) {
+    return session;
+  }
+
   const email = session.user?.email?.toLowerCase();
   if (!email || !adminEmails.has(email)) {
     redirect("/");

--- a/src/lib/db/repository.test.ts
+++ b/src/lib/db/repository.test.ts
@@ -78,6 +78,7 @@ import {
   ensureViewerFromSession,
   getViewerDashboard,
   getActiveQuoteOverlay,
+  getGameSuggestionBoostSettings,
   getLiveLikeGoalOverlayState,
   getObsOverlayAdminStatus,
   getSessionViewerState,
@@ -110,6 +111,7 @@ import {
   showQuoteOverlayForViewer,
   cancelQueuedQuoteOverlays,
   updateGameSuggestionStatus,
+  updateGameSuggestionBoostSettings,
   updateVideoSuggestionStatus,
 } from "@/lib/db/repository";
 import { GOOGLE_RISC_EVENT_TYPES } from "@/lib/google/risc";
@@ -2120,6 +2122,46 @@ describe("game suggestions", () => {
     const after = await getViewerDashboard("viewer_ana");
     expect(after?.balance.currentBalance).toBe(beforeBalance - 120);
     expect(after?.balance.lifetimeSpent).toBe(beforeSpent + 120);
+  });
+
+  it("persists game suggestion boost multipliers and applies them to priority", async () => {
+    expect(await getGameSuggestionBoostSettings()).toMatchObject({
+      psPlusMultiplier: 1,
+      shortGameMultiplier: 1,
+      adminSuggestionMultiplier: 1,
+    });
+
+    const settings = await updateGameSuggestionBoostSettings({
+      psPlusMultiplier: 2,
+      shortGameMultiplier: 1.5,
+      adminSuggestionMultiplier: 1,
+      updatedBy: "admin@example.com",
+    });
+
+    expect(settings).toMatchObject({
+      psPlusMultiplier: 2,
+      shortGameMultiplier: 1.5,
+      adminSuggestionMultiplier: 1,
+      updatedBy: "admin@example.com",
+    });
+
+    const suggestions = await listGameSuggestions();
+    const psPlusSuggestion = suggestions.find((entry) => entry.id === "gs-ps-plus-demo");
+    const shortSuggestion = suggestions.find((entry) => entry.id === "gs-2");
+
+    expect(psPlusSuggestion?.boostedScore).toBe(8200);
+    expect(psPlusSuggestion?.appliedBoostModifiers).toContainEqual({
+      key: "ps_plus",
+      label: "PS Plus",
+      multiplier: 2,
+    });
+    expect(shortSuggestion?.boostedScore).toBe(2700);
+    expect(shortSuggestion?.appliedBoostModifiers).toContainEqual({
+      key: "short_game",
+      label: "Menos de 10h",
+      multiplier: 1.5,
+    });
+    expect(suggestions[0]?.id).toBe("gs-ps-plus-demo");
   });
 
   it("blocks boost when the viewer has insufficient balance", async () => {

--- a/src/lib/db/repository.ts
+++ b/src/lib/db/repository.ts
@@ -102,7 +102,9 @@ import {
   CreatorSuggestionBoostRecord,
   CreatorSuggestionRecord,
   CreatorSuggestionWithMeta,
+  GameSuggestionAppliedBoostModifier,
   GameSuggestionBoostRecord,
+  GameSuggestionBoostSettingsRecord,
   GameSuggestionRecord,
   GameSuggestionWithMeta,
   GoogleAccountRecord,
@@ -260,12 +262,26 @@ const PIPETZ_PRICING_SETTING_KEYS = {
   videoSuggestionCost: "pricing_video_suggestion",
   quoteOverlayCost: "pricing_quote_overlay",
 } as const;
+const GAME_SUGGESTION_BOOST_SETTING_SCOPE_KEY = "game_suggestion_boosts";
+const GAME_SUGGESTION_BOOST_SETTING_KEYS = {
+  psPlusMultiplier: "game_boost_ps_plus",
+  shortGameMultiplier: "game_boost_short_game",
+  adminSuggestionMultiplier: "game_boost_admin",
+} as const;
+const GAME_SUGGESTION_BOOST_MULTIPLIER_STORAGE_FACTOR = 100;
 const PS_PLUS_SYNC_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 const DEFAULT_PIPETZ_PRICING: PipetzPricingRecord = {
   gameSuggestionCost: GAME_SUGGESTION_CREATION_COST,
   videoSuggestionCost: VIDEO_SUGGESTION_CREATION_COST,
   quoteOverlayCost: QUOTE_OVERLAY_COST,
+  updatedAt: null,
+  updatedBy: null,
+};
+const DEFAULT_GAME_SUGGESTION_BOOST_SETTINGS: GameSuggestionBoostSettingsRecord = {
+  psPlusMultiplier: 1,
+  shortGameMultiplier: 1,
+  adminSuggestionMultiplier: 1,
   updatedAt: null,
   updatedBy: null,
 };
@@ -745,6 +761,159 @@ export async function updatePipetzPricing(input: {
   });
 
   return getPipetzPricing();
+}
+
+function serializeGameSuggestionBoostSettingRow(
+  row: StreamerbotCounterRecord | typeof streamerbotCounters.$inferSelect,
+) {
+  const metadata = row.metadata as Record<string, unknown>;
+
+  return {
+    multiplier: row.value / GAME_SUGGESTION_BOOST_MULTIPLIER_STORAGE_FACTOR,
+    updatedAt: row.updatedAt instanceof Date ? row.updatedAt.toISOString() : row.updatedAt,
+    updatedBy: typeof metadata.updatedBy === "string" ? metadata.updatedBy : null,
+  };
+}
+
+function normalizeGameSuggestionBoostMultiplier(value: number) {
+  if (!Number.isFinite(value) || value < 0 || value > 10) {
+    throw new Error("invalid_multiplier");
+  }
+
+  return Math.round(value * GAME_SUGGESTION_BOOST_MULTIPLIER_STORAGE_FACTOR) /
+    GAME_SUGGESTION_BOOST_MULTIPLIER_STORAGE_FACTOR;
+}
+
+export async function getGameSuggestionBoostSettings(): Promise<GameSuggestionBoostSettingsRecord> {
+  const db = getDb();
+  const keys = Object.values(GAME_SUGGESTION_BOOST_SETTING_KEYS) as string[];
+  const settings = { ...DEFAULT_GAME_SUGGESTION_BOOST_SETTINGS };
+
+  if (isDemoMode || !db) {
+    for (const row of getDemoStore().streamerbotCounters.filter((entry) => keys.includes(entry.key))) {
+      const serialized = serializeGameSuggestionBoostSettingRow(row);
+      const field = Object.entries(GAME_SUGGESTION_BOOST_SETTING_KEYS).find(([, key]) => key === row.key)?.[0] as
+        | keyof typeof GAME_SUGGESTION_BOOST_SETTING_KEYS
+        | undefined;
+      if (!field) {
+        continue;
+      }
+
+      settings[field] = serialized.multiplier;
+      settings.updatedAt = serialized.updatedAt;
+      settings.updatedBy = serialized.updatedBy;
+    }
+
+    return settings;
+  }
+
+  try {
+    const rows = await db.select().from(streamerbotCounters).where(inArray(streamerbotCounters.key, keys));
+    for (const row of rows) {
+      const serialized = serializeGameSuggestionBoostSettingRow(row);
+      const field = Object.entries(GAME_SUGGESTION_BOOST_SETTING_KEYS).find(([, key]) => key === row.key)?.[0] as
+        | keyof typeof GAME_SUGGESTION_BOOST_SETTING_KEYS
+        | undefined;
+      if (!field) {
+        continue;
+      }
+
+      settings[field] = serialized.multiplier;
+      settings.updatedAt = serialized.updatedAt;
+      settings.updatedBy = serialized.updatedBy;
+    }
+  } catch (error) {
+    if (!isMissingStreamerbotCountersTableError(error)) {
+      throw error;
+    }
+  }
+
+  return settings;
+}
+
+export async function updateGameSuggestionBoostSettings(input: {
+  psPlusMultiplier: number;
+  shortGameMultiplier: number;
+  adminSuggestionMultiplier: number;
+  updatedBy: string | null;
+}): Promise<GameSuggestionBoostSettingsRecord> {
+  const db = getDb();
+  const updatedAt = new Date();
+  const values = {
+    psPlusMultiplier: normalizeGameSuggestionBoostMultiplier(input.psPlusMultiplier),
+    shortGameMultiplier: normalizeGameSuggestionBoostMultiplier(input.shortGameMultiplier),
+    adminSuggestionMultiplier: normalizeGameSuggestionBoostMultiplier(input.adminSuggestionMultiplier),
+  };
+
+  if (isDemoMode || !db) {
+    const store = getDemoStore();
+    for (const [field, key] of Object.entries(GAME_SUGGESTION_BOOST_SETTING_KEYS)) {
+      const multiplier = values[field as keyof typeof values];
+      const value = Math.round(multiplier * GAME_SUGGESTION_BOOST_MULTIPLIER_STORAGE_FACTOR);
+      const existing = store.streamerbotCounters.find((entry) => entry.key === key);
+      if (existing) {
+        existing.value = value;
+        existing.updatedAt = updatedAt.toISOString();
+        existing.metadata = {
+          ...existing.metadata,
+          updatedBy: input.updatedBy,
+        };
+      } else {
+        store.streamerbotCounters.push({
+          key,
+          scopeType: PIPETZ_PRICING_SETTING_SCOPE_TYPE,
+          scopeKey: GAME_SUGGESTION_BOOST_SETTING_SCOPE_KEY,
+          value,
+          lastResetAt: null,
+          updatedAt: updatedAt.toISOString(),
+          metadata: {
+            setting: field,
+            scopeType: PIPETZ_PRICING_SETTING_SCOPE_TYPE,
+            scopeKey: GAME_SUGGESTION_BOOST_SETTING_SCOPE_KEY,
+            updatedBy: input.updatedBy,
+          },
+        });
+      }
+    }
+
+    return getGameSuggestionBoostSettings();
+  }
+
+  await db.transaction(async (tx) => {
+    for (const [field, key] of Object.entries(GAME_SUGGESTION_BOOST_SETTING_KEYS)) {
+      const multiplier = values[field as keyof typeof values];
+      const value = Math.round(multiplier * GAME_SUGGESTION_BOOST_MULTIPLIER_STORAGE_FACTOR);
+      await tx
+        .insert(streamerbotCounters)
+        .values({
+          key,
+          value,
+          lastResetAt: null,
+          updatedAt,
+          metadata: {
+            setting: field,
+            scopeType: PIPETZ_PRICING_SETTING_SCOPE_TYPE,
+            scopeKey: GAME_SUGGESTION_BOOST_SETTING_SCOPE_KEY,
+            updatedBy: input.updatedBy,
+          },
+        })
+        .onConflictDoUpdate({
+          target: streamerbotCounters.key,
+          set: {
+            value,
+            updatedAt,
+            metadata: {
+              setting: field,
+              scopeType: PIPETZ_PRICING_SETTING_SCOPE_TYPE,
+              scopeKey: GAME_SUGGESTION_BOOST_SETTING_SCOPE_KEY,
+              updatedBy: input.updatedBy,
+            },
+          },
+        });
+    }
+  });
+
+  return getGameSuggestionBoostSettings();
 }
 
 function sanitizePublicCounterSummaries(
@@ -2154,14 +2323,63 @@ function buildGameSuggestionWithMeta(params: {
   suggestion: GameSuggestionRecord;
   viewer: ViewerRecord | null;
   boosts?: GameSuggestionBoostRecord[];
+  boostSettings?: GameSuggestionBoostSettingsRecord;
 }): GameSuggestionWithMeta {
   const boosts = params.boosts ?? [];
+  const boostSettings = params.boostSettings ?? DEFAULT_GAME_SUGGESTION_BOOST_SETTINGS;
+  const appliedBoostModifiers = getAppliedGameSuggestionBoostModifiers(
+    params.suggestion,
+    params.viewer,
+    boostSettings,
+  );
+  const totalMultiplier = appliedBoostModifiers.reduce((product, entry) => product * entry.multiplier, 1);
+
   return {
     ...params.suggestion,
     suggestedBy: params.viewer?.youtubeDisplayName ?? "Viewer",
     suggestedByYoutubeHandle: params.viewer?.youtubeHandle ?? null,
     viewerBoostTotal: boosts.reduce((sum, entry) => sum + entry.amount, 0),
+    boostedScore: Math.round(params.suggestion.totalVotes * totalMultiplier),
+    appliedBoostModifiers,
   };
+}
+
+function getAppliedGameSuggestionBoostModifiers(
+  suggestion: GameSuggestionRecord,
+  viewer: ViewerRecord | null,
+  settings: GameSuggestionBoostSettingsRecord,
+): GameSuggestionAppliedBoostModifier[] {
+  const modifiers: GameSuggestionAppliedBoostModifier[] = [];
+
+  if (suggestion.psPlusAvailable) {
+    modifiers.push({
+      key: "ps_plus",
+      label: "PS Plus",
+      multiplier: settings.psPlusMultiplier,
+    });
+  }
+
+  if (
+    typeof suggestion.howLongToBeat?.mainStoryMinutes === "number" &&
+    suggestion.howLongToBeat.mainStoryMinutes > 0 &&
+    suggestion.howLongToBeat.mainStoryMinutes < 10 * 60
+  ) {
+    modifiers.push({
+      key: "short_game",
+      label: "Menos de 10h",
+      multiplier: settings.shortGameMultiplier,
+    });
+  }
+
+  if (viewer?.email && (isDemoMode || adminEmails.has(viewer.email.toLowerCase()))) {
+    modifiers.push({
+      key: "admin_suggestion",
+      label: "Enviada pelo admin",
+      multiplier: settings.adminSuggestionMultiplier,
+    });
+  }
+
+  return modifiers;
 }
 
 function buildVideoSuggestionWithMeta(params: {
@@ -3033,27 +3251,37 @@ export async function cancelQueuedQuoteOverlays(input: { updatedBy?: string | nu
   return getObsOverlayAdminStatus();
 }
 
-function listDemoGameSuggestions(viewerId?: string | null) {
+function sortGameSuggestionWithMeta(left: GameSuggestionWithMeta, right: GameSuggestionWithMeta) {
+  if (right.boostedScore !== left.boostedScore) {
+    return right.boostedScore - left.boostedScore;
+  }
+
+  if (right.totalVotes !== left.totalVotes) {
+    return right.totalVotes - left.totalVotes;
+  }
+
+  return +new Date(right.createdAt) - +new Date(left.createdAt);
+}
+
+function listDemoGameSuggestions(
+  viewerId?: string | null,
+  boostSettings: GameSuggestionBoostSettingsRecord = DEFAULT_GAME_SUGGESTION_BOOST_SETTINGS,
+) {
   const store = getDemoStore();
   const viewerBoosts = viewerId
     ? store.gameSuggestionBoosts.filter((entry) => entry.viewerId === viewerId)
     : [];
 
   return [...store.gameSuggestions]
-    .sort((a, b) => {
-      if (b.totalVotes !== a.totalVotes) {
-        return b.totalVotes - a.totalVotes;
-      }
-
-      return +new Date(b.createdAt) - +new Date(a.createdAt);
-    })
     .map((suggestion) =>
       buildGameSuggestionWithMeta({
         suggestion,
         viewer: getDemoViewerById(store, suggestion.viewerId),
         boosts: viewerBoosts.filter((entry) => entry.suggestionId === suggestion.id),
+        boostSettings,
       }),
-    );
+    )
+    .sort(sortGameSuggestionWithMeta);
 }
 
 function shouldRefreshHowLongToBeat(row: typeof gameSuggestions.$inferSelect, now = Date.now()) {
@@ -5382,22 +5610,24 @@ export async function listGameSuggestions(viewerId?: string | null) {
   const db = getDb();
 
   if (isDemoMode || !db) {
-    return listDemoGameSuggestions(viewerId);
+    return listDemoGameSuggestions(viewerId, await getGameSuggestionBoostSettings());
   }
 
   let suggestionRows: Array<typeof gameSuggestions.$inferSelect>;
   let boostRows: Array<typeof gameSuggestionBoosts.$inferSelect>;
+  let boostSettings: GameSuggestionBoostSettingsRecord;
 
   try {
-    [suggestionRows, boostRows] = await Promise.all([
+    [suggestionRows, boostRows, boostSettings] = await Promise.all([
       db.select().from(gameSuggestions).orderBy(desc(gameSuggestions.totalVotes), desc(gameSuggestions.createdAt)),
       viewerId
         ? db.select().from(gameSuggestionBoosts).where(eq(gameSuggestionBoosts.viewerId, viewerId))
         : Promise.resolve([]),
+      getGameSuggestionBoostSettings(),
     ]);
   } catch (error) {
     if (isMissingGameSuggestionSchemaError(error)) {
-      return listDemoGameSuggestions(viewerId);
+      return listDemoGameSuggestions(viewerId, await getGameSuggestionBoostSettings());
     }
     throw error;
   }
@@ -5412,13 +5642,16 @@ export async function listGameSuggestions(viewerId?: string | null) {
   const viewerMap = new Map(suggestionViewers.map((row) => [row.id, serializeViewer(row)]));
   const serializedBoosts = boostRows.map(serializeGameSuggestionBoost);
 
-  return serializedSuggestions.map((suggestion) =>
-    buildGameSuggestionWithMeta({
-      suggestion,
-      viewer: viewerMap.get(suggestion.viewerId) ?? null,
-      boosts: serializedBoosts.filter((entry) => entry.suggestionId === suggestion.id),
-    }),
-  );
+  return serializedSuggestions
+    .map((suggestion) =>
+      buildGameSuggestionWithMeta({
+        suggestion,
+        viewer: viewerMap.get(suggestion.viewerId) ?? null,
+        boosts: serializedBoosts.filter((entry) => entry.suggestionId === suggestion.id),
+        boostSettings,
+      }),
+    )
+    .sort(sortGameSuggestionWithMeta);
 }
 
 export async function listAdminGameSuggestions() {
@@ -5732,7 +5965,12 @@ export async function createGameSuggestion(input: {
       createdAt,
     });
 
-    return buildGameSuggestionWithMeta({ suggestion, viewer, boosts: [] });
+    return buildGameSuggestionWithMeta({
+      suggestion,
+      viewer,
+      boosts: [],
+      boostSettings: await getGameSuggestionBoostSettings(),
+    });
   }
 
   const createdAt = new Date();
@@ -5885,6 +6123,7 @@ export async function boostGameSuggestion(input: {
       boosts: store.gameSuggestionBoosts.filter(
         (entry) => entry.viewerId === input.viewerId && entry.suggestionId === suggestion.id,
       ),
+      boostSettings: await getGameSuggestionBoostSettings(),
     });
   }
 
@@ -5972,6 +6211,7 @@ export async function updateGameSuggestionStatus(input: {
     return buildGameSuggestionWithMeta({
       suggestion,
       viewer: getDemoViewerById(store, suggestion.viewerId),
+      boostSettings: await getGameSuggestionBoostSettings(),
     });
   }
 
@@ -6034,7 +6274,11 @@ export async function updateGameSuggestionCatalog(input: {
     suggestion.updatedAt = new Date().toISOString();
 
     const viewer = store.viewers.find((entry) => entry.id === suggestion.viewerId) ?? null;
-    return buildGameSuggestionWithMeta({ suggestion, viewer });
+    return buildGameSuggestionWithMeta({
+      suggestion,
+      viewer,
+      boostSettings: await getGameSuggestionBoostSettings(),
+    });
   }
 
   const howLongToBeat = await resolveHowLongToBeatGame(canonicalName, platforms[0] ?? null);

--- a/src/lib/game-suggestions/sections.test.ts
+++ b/src/lib/game-suggestions/sections.test.ts
@@ -7,6 +7,7 @@ function suggestion(input: {
   id: string;
   status: GameSuggestionWithMeta["status"];
   totalVotes: number;
+  boostedScore?: number;
   createdAt: string;
 }): GameSuggestionWithMeta {
   return {
@@ -38,6 +39,8 @@ function suggestion(input: {
     suggestedBy: "Ludy",
     suggestedByYoutubeHandle: null,
     viewerBoostTotal: 0,
+    boostedScore: input.boostedScore ?? input.totalVotes,
+    appliedBoostModifiers: [],
   };
 }
 
@@ -65,5 +68,29 @@ describe("getVisibleGameSuggestionSections", () => {
 
     expect(sections.recommendedSuggestions.map((entry) => entry.id)).toEqual(["open-newer", "open-older"]);
     expect(sections.playedSuggestions.map((entry) => entry.id)).toEqual(["played-higher", "played-newer"]);
+  });
+
+  it("orders by effective boosted score before raw votes", () => {
+    const sections = getVisibleGameSuggestionSections([
+      suggestion({
+        id: "raw-higher",
+        status: "open",
+        totalVotes: 100,
+        boostedScore: 100,
+        createdAt: "2026-01-01T10:00:00.000Z",
+      }),
+      suggestion({
+        id: "boosted-priority",
+        status: "open",
+        totalVotes: 80,
+        boostedScore: 120,
+        createdAt: "2026-01-02T10:00:00.000Z",
+      }),
+    ]);
+
+    expect(sections.recommendedSuggestions.map((entry) => entry.id)).toEqual([
+      "boosted-priority",
+      "raw-higher",
+    ]);
   });
 });

--- a/src/lib/game-suggestions/sections.ts
+++ b/src/lib/game-suggestions/sections.ts
@@ -2,6 +2,10 @@ import type { GameSuggestionWithMeta } from "@/lib/types";
 
 function sortGameSuggestions(items: GameSuggestionWithMeta[]) {
   return [...items].sort((a, b) => {
+    if (b.boostedScore !== a.boostedScore) {
+      return b.boostedScore - a.boostedScore;
+    }
+
     if (b.totalVotes !== a.totalVotes) {
       return b.totalVotes - a.totalVotes;
     }

--- a/src/lib/game-suggestions/service.ts
+++ b/src/lib/game-suggestions/service.ts
@@ -3,11 +3,11 @@ import { z } from "zod";
 export const gameSuggestionStatusSchema = z.enum(["open", "accepted", "played", "rejected"]);
 
 export const createGameSuggestionSchema = z.object({
-  name: z.string().trim().min(2, "Digite pelo menos 2 caracteres.").max(120, "Use no maximo 120 caracteres."),
+  name: z.string().trim().min(2, "Digite pelo menos 2 caracteres.").max(120, "Use no máximo 120 caracteres."),
   description: z
     .string()
     .trim()
-    .max(500, "Use no maximo 500 caracteres.")
+    .max(500, "Use no máximo 500 caracteres.")
     .optional()
     .transform((value) => (value ? value : undefined)),
   igdbId: z.number().int().positive().optional(),
@@ -33,6 +33,12 @@ export const updateGameSuggestionCatalogSchema = z.object({
   releaseYear: z.number().int().min(1950).max(2100).nullable().optional(),
   platforms: z.array(z.string().trim().min(1).max(80)).max(4).optional(),
   genres: z.array(z.string().trim().min(1).max(80)).max(3).optional(),
+});
+
+export const updateGameSuggestionBoostSettingsSchema = z.object({
+  psPlusMultiplier: z.number().min(0).max(10),
+  shortGameMultiplier: z.number().min(0).max(10),
+  adminSuggestionMultiplier: z.number().min(0).max(10),
 });
 
 export function validateGameSuggestionDraft(input: {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -327,6 +327,14 @@ export interface PipetzPricingRecord {
   updatedBy: string | null;
 }
 
+export interface GameSuggestionBoostSettingsRecord {
+  psPlusMultiplier: number;
+  shortGameMultiplier: number;
+  adminSuggestionMultiplier: number;
+  updatedAt: string | null;
+  updatedBy: string | null;
+}
+
 export interface WheelOptionRecord {
   id: string;
   label: string;
@@ -566,10 +574,20 @@ export interface GameSuggestionBoostRecord {
   createdAt: string;
 }
 
+export type GameSuggestionBoostModifierKey = "ps_plus" | "short_game" | "admin_suggestion";
+
+export interface GameSuggestionAppliedBoostModifier {
+  key: GameSuggestionBoostModifierKey;
+  label: string;
+  multiplier: number;
+}
+
 export interface GameSuggestionWithMeta extends GameSuggestionRecord {
   suggestedBy: string;
   suggestedByYoutubeHandle: string | null;
   viewerBoostTotal: number;
+  boostedScore: number;
+  appliedBoostModifiers: GameSuggestionAppliedBoostModifier[];
 }
 
 export interface VideoSuggestionRecord {


### PR DESCRIPTION
## O que mudou

- Adiciona multiplicadores configuráveis para sugestões de jogos no painel admin.
- Persiste os multiplicadores em `streamerbot_counters`, seguindo o padrão de configurações existente.
- Aplica boosts automáticos quando o jogo está na PS Plus, tem menos de 10h no HowLongToBeat ou foi enviado por admin.
- Usa `boostedScore` para priorização, mantendo `totalVotes` como votos reais.
- Libera acesso admin no modo demo para validar a configuração sem `ADMIN_EMAILS`.

## Regra de combinação

Quando mais de um critério se aplica, os multiplicadores são multiplicados entre si e a pontuação efetiva é arredondada.

## Validação

- `npm test`
- `npm run build`
- `npm run lint` (sem erros; mantém um warning existente em `admin-dashboard-tabs.tsx`)

Closes #119