### PR TITLE
[codex] Reorganize admin dashboard UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 devserver-*.log
+.dev-*.log
 
 # env files (can opt-in for committing if needed)
 .env*

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -62,16 +62,18 @@ export default async function AdminPage() {
     getPipetzPricing(),
     getWheelConfig(),
   ]);
+  const openBetCount = bets.filter((bet) => bet.status === "open").length;
+  const queuedRedemptionCount = redemptions.filter((entry) => entry.status === "queued").length;
+  const activeWheelOptionCount = wheelConfig.options.filter(
+    (option) => option.isActive && option.label.trim(),
+  ).length;
 
   return (
     <div className="flex w-full flex-col">
       <section className="landing-plane surface-hero py-8 sm:py-10">
         <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
-          <p className="mono text-xs font-bold uppercase tracking-[0.32em] text-[var(--color-ink-soft)]">
-            Painel operacional
-          </p>
           <h1
-            className="mt-3 text-4xl uppercase sm:text-6xl"
+            className="text-4xl uppercase sm:text-6xl"
             style={{ fontFamily: "var(--font-display)" }}
           >
             Admin Pipetz
@@ -80,64 +82,141 @@ export default async function AdminPage() {
       </section>
 
       <AdminDashboardTabs
-        tabs={[
+        sections={[
+          {
+            id: "live",
+            title: "Live e OBS",
+            items: [
+              {
+                id: "status-live",
+                label: "Status da live",
+                description: "Bridge, modo manual e estado efetivo.",
+                badge: liveStatus.isLive ? "ao vivo" : "offline",
+                content: <LiveStatusPanel bridge={bridge} initialStatus={liveStatus} />,
+              },
+              {
+                id: "overlays",
+                label: "Overlays",
+                description: "Browser sources, fila e links do OBS.",
+                badge: `${obsOverlayStatus.pendingCount}`,
+                content: <AdminObsOverlaysPanel initialStatus={obsOverlayStatus} embedded />,
+              },
+              {
+                id: "roleta",
+                label: "Roleta",
+                description: "Prêmios, pesos e overlay da roleta.",
+                badge: `${activeWheelOptionCount}`,
+                content: <AdminWheelPanel initialConfig={wheelConfig} />,
+              },
+              {
+                id: "jogo-atual",
+                label: "Jogo atual",
+                description: "Capa e metadados da landing page.",
+                badge: currentGame ? "ativo" : undefined,
+                content: <AdminCurrentGamePanel initialGame={currentGame} />,
+              },
+              {
+                id: "metas-likes",
+                label: "Metas de likes",
+                description: "Recompensas automáticas da live.",
+                badge: `${likeGoals.length}`,
+                content: <AdminLiveLikeGoalsPanel initialGoals={likeGoals} />,
+              },
+            ],
+          },
           {
             id: "apostas",
-            label: "Apostas",
-            description: "Ciclo de vida, travas e pagamentos.",
-            badge: `${bets.length}`,
-            content: <AdminBetsPanel bets={bets} embedded />,
+            title: "Apostas",
+            items: [
+              {
+                id: "apostas-live",
+                label: "Apostas da live",
+                description: "Ciclo de vida, travas e pagamentos.",
+                badge: `${openBetCount}/${bets.length}`,
+                content: <AdminBetsPanel bets={bets} embedded />,
+              },
+            ],
           },
           {
             id: "comunidade",
-            label: "Comunidade",
-            description: "Vínculos, indicações e recomendações.",
-            badge: `${suggestions.length + videoSuggestions.length + recommendations.length}`,
-            content: (
-              <div className="space-y-6">
-                <AdminViewerLinksPanel entries={viewers} />
-                <AdminGameSuggestionsPanel suggestions={suggestions} boostSettings={gameBoostSettings} />
-                <AdminVideoSuggestionsPanel suggestions={videoSuggestions} />
-                <AdminRecommendationsPanel recommendations={recommendations} />
-              </div>
-            ),
-          },
-          {
-            id: "operacao",
-            label: "Operação",
-            description: "Live, overlays, mortes e preços.",
-            badge: liveStatus.isLive ? "ao vivo" : "offline",
-            content: (
-              <div className="grid gap-6 xl:grid-cols-[0.95fr_1.05fr]">
-                <div className="space-y-6">
-                  <LiveStatusPanel bridge={bridge} initialStatus={liveStatus} />
-                  <AdminWheelPanel initialConfig={wheelConfig} />
-                  <AdminCurrentGamePanel initialGame={currentGame} />
-                  <AdminPipetzPricingPanel initialPricing={pricing} />
-                  <AdminLiveLikeGoalsPanel initialGoals={likeGoals} />
-                </div>
-                <AdminObsOverlaysPanel initialStatus={obsOverlayStatus} />
-              </div>
-            ),
+            title: "Comunidade",
+            items: [
+              {
+                id: "vinculos",
+                label: "Vínculos",
+                description: "Contas Google e canais do YouTube.",
+                badge: `${viewers.length}`,
+                content: <AdminViewerLinksPanel entries={viewers} embedded />,
+              },
+              {
+                id: "sugestoes-jogos",
+                label: "Sugestões de jogos",
+                description: "Fila, prioridade e multiplicadores.",
+                badge: `${suggestions.length}`,
+                content: (
+                  <AdminGameSuggestionsPanel
+                    suggestions={suggestions}
+                    boostSettings={gameBoostSettings}
+                    embedded
+                  />
+                ),
+              },
+              {
+                id: "videos",
+                label: "Vídeos",
+                description: "Sugestões para reação em live.",
+                badge: `${videoSuggestions.length}`,
+                content: <AdminVideoSuggestionsPanel suggestions={videoSuggestions} embedded />,
+              },
+              {
+                id: "produtos",
+                label: "Produtos",
+                description: "Recomendações públicas e links.",
+                badge: `${recommendations.length}`,
+                content: <AdminRecommendationsPanel recommendations={recommendations} />,
+              },
+            ],
           },
           {
             id: "pipetz",
-            label: "Pipetz",
-            description: "Fila, ranking, airdrop e catálogo.",
-            badge: `${redemptions.length}`,
-            content: (
-              <div className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
-                <div className="space-y-6">
+            title: "Pipetz",
+            items: [
+              {
+                id: "precos",
+                label: "Preços",
+                description: "Custos de ações pagas.",
+                content: <AdminPipetzPricingPanel initialPricing={pricing} />,
+              },
+              {
+                id: "airdrop",
+                label: "Airdrop",
+                description: "Distribuição manual de pipetz.",
+                content: <AdminPipetzAirdropPanel viewers={viewers} />,
+              },
+              {
+                id: "fila-resgates",
+                label: "Fila de resgates",
+                description: "Últimos resgates e status.",
+                badge: `${queuedRedemptionCount}/${redemptions.length}`,
+                content: (
                   <div className="panel surface-section p-6">
-                    <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
-                      Fila recente
-                    </p>
+                    <h2
+                      className="text-3xl uppercase"
+                      style={{ fontFamily: "var(--font-display)" }}
+                    >
+                      Fila de resgates
+                    </h2>
                     <div className="mt-6 grid gap-3">
-                      {redemptions.slice(0, 6).map((entry) => {
+                      {redemptions.length === 0 ? (
+                        <div className="card-brutal-static p-4 text-sm font-bold text-[var(--color-ink-soft)]">
+                          Nenhum resgate recente.
+                        </div>
+                      ) : null}
+                      {redemptions.slice(0, 10).map((entry) => {
                         const statusBg = statusColorMap[entry.status] ?? "var(--color-paper)";
                         return (
                           <div key={entry.id} className="card-brutal-static p-4">
-                            <div className="flex items-center justify-between gap-3">
+                            <div className="flex flex-wrap items-center justify-between gap-3">
                               <span
                                 className="badge-brutal px-2 py-1 text-[10px] text-[var(--color-ink)]"
                                 style={{ backgroundColor: statusBg }}
@@ -156,21 +235,35 @@ export default async function AdminPage() {
                       })}
                     </div>
                   </div>
+                ),
+              },
+              {
+                id: "ranking",
+                label: "Ranking",
+                description: "Top viewers por saldo.",
+                badge: `${leaderboard.length}`,
+                content: (
                   <div className="panel surface-section p-6">
-                    <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
+                    <h2
+                      className="text-3xl uppercase"
+                      style={{ fontFamily: "var(--font-display)" }}
+                    >
                       Ranking de pipetz
-                    </p>
+                    </h2>
                     <div className="mt-6">
-                      <LeaderboardTable entries={leaderboard.slice(0, 10)} />
+                      <LeaderboardTable entries={leaderboard.slice(0, 20)} />
                     </div>
                   </div>
-                </div>
-                <div className="space-y-6">
-                  <AdminPipetzAirdropPanel viewers={viewers} />
-                  <RedemptionGrid items={catalog} expanded staticCards />
-                </div>
-              </div>
-            ),
+                ),
+              },
+              {
+                id: "catalogo",
+                label: "Catálogo",
+                description: "Resgates disponíveis na loja.",
+                badge: `${catalog.length}`,
+                content: <RedemptionGrid items={catalog} expanded staticCards />,
+              },
+            ],
           },
         ]}
       />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -29,6 +29,8 @@
   --color-paper-pink: #ffdff2;
   --color-ink-soft: #1d1822;
   --color-surface-strong: #ffffff;
+  --color-line: #000000;
+  --color-line-soft: rgba(0, 0, 0, 0.18);
 
   --bg-page: #f9f9f9;
   --surface-hero: #f0e8f8;
@@ -107,8 +109,8 @@
 }
 
 html[data-theme="dark"] {
-  --color-ink: #f8f8f8;
-  --color-paper: #090909;
+  --color-ink: #f4f7fb;
+  --color-paper: #101316;
   --color-purple: #b998ff;
   --color-purple-mid: #d0b6ff;
   --color-purple-bold: #eadcff;
@@ -125,36 +127,39 @@ html[data-theme="dark"] {
   --color-periwinkle: #1a1630;
   --color-rose: #26141c;
   --color-lilac: #111111;
-  --color-muted: #f8f8f8;
-  --color-cream: #020202;
-  --color-paper-warm: #141414;
-  --color-paper-pink: #1a0f17;
-  --color-ink-soft: #d7d7d7;
-  --color-surface-strong: #111111;
+  --color-muted: #f4f7fb;
+  --color-cream: #0a0c0f;
+  --color-paper-warm: #15191d;
+  --color-paper-pink: #171019;
+  --color-ink-soft: #c6ccd4;
+  --color-surface-strong: #15191d;
+  --color-line: #5b6672;
+  --color-line-soft: #2a3038;
 
-  --bg-page: #000000;
-  --surface-hero: #0c0c0c;
-  --surface-section: #080808;
-  --surface-card: #111111;
-  --surface-card-alt: #1a1a1a;
-  --surface-card-accent: #101d25;
-  --surface-community-cta: #1a1a1a;
-  --color-header-surface: rgba(0, 0, 0, 0.94);
+  --bg-page: #080a0d;
+  --surface-hero: #101316;
+  --surface-section: #0d1013;
+  --surface-card: #15191d;
+  --surface-card-alt: #1b2026;
+  --surface-card-accent: #12202a;
+  --surface-community-cta: #171c22;
+  --color-header-surface: rgba(8, 10, 13, 0.96);
   --color-ticker-bg: #000000;
   --color-window-bar: #131313;
   --color-backdrop: rgba(0, 0, 0, 0.65);
   --color-grid-line: rgba(255, 255, 255, 0.12);
   --color-halftone-dot: rgba(84, 199, 255, 0.2);
-  --color-dot: #ffffff;
-  --color-dot-soft: #ffffff;
+  --color-dot: rgba(244, 247, 251, 0.12);
+  --color-dot-soft: rgba(244, 247, 251, 0.16);
   --color-podium-gold: #ffd44d;
   --color-podium-silver: #b998ff;
   --color-podium-bronze: #ff78bf;
   --color-on-yellow: #000000;
   --color-accent-ink-soft: #161616;
 
-  --shadow-color: #ffffff;
-  --shadow-soft-color: rgba(255, 255, 255, 0.88);
+  --border-strong: var(--border-w) solid var(--color-line);
+  --shadow-color: rgba(148, 163, 184, 0.24);
+  --shadow-soft-color: rgba(148, 163, 184, 0.2);
 
   --background: var(--bg-page);
   --foreground: var(--color-ink);
@@ -171,8 +176,8 @@ html[data-theme="dark"] {
   --accent: var(--color-sky);
   --accent-foreground: var(--color-ink);
   --destructive: var(--color-pink-hot);
-  --input: var(--color-ink);
-  --border: var(--color-ink);
+  --input: var(--color-line);
+  --border: var(--color-line);
   --ring: var(--color-purple-mid);
   --chart-1: var(--color-blue);
   --chart-2: var(--color-purple);
@@ -185,7 +190,7 @@ html[data-theme="dark"] {
   --sidebar-primary-foreground: var(--color-accent-ink);
   --sidebar-accent: var(--color-lavender);
   --sidebar-accent-foreground: var(--color-ink);
-  --sidebar-border: var(--color-ink);
+  --sidebar-border: var(--color-line);
   --sidebar-ring: var(--color-purple-mid);
 }
 
@@ -240,6 +245,7 @@ html[data-theme="dark"] {
 
 html {
   scroll-behavior: smooth;
+  overflow-y: scroll;
 }
 
 body {
@@ -530,6 +536,77 @@ button {
 
 .meta-pill-soft {
   background: var(--surface-card-alt);
+}
+
+html[data-theme="dark"] :where(
+  .panel,
+  .panel-soft,
+  .panel-inset,
+  .panel-flat,
+  .card-brutal,
+  .card-brutal-static,
+  .card-poster,
+  .card-flat,
+  .btn-brutal,
+  .badge-brutal,
+  .retro-label,
+  .retro-ribbon,
+  .meta-pill,
+  .sticker,
+  [class*="[var(--color-ink)]"]
+) {
+  border-color: var(--color-line) !important;
+}
+
+html[data-theme="dark"] :where(
+  [class*="border-[3px]"],
+  [class*="border-2"],
+  [class*="border-t-[3px]"],
+  [class*="border-r-[3px]"],
+  [class*="border-b-[3px]"],
+  [class*="border-l-[3px]"],
+  [class*="border-t-2"],
+  [class*="border-r-2"],
+  [class*="border-b-2"],
+  [class*="border-l-2"]
+) {
+  border-width: 1px !important;
+}
+
+html[data-theme="dark"] :where(
+  [class*="border-t-[3px]"],
+  [class*="border-t-2"]
+) {
+  border-top-width: 1px !important;
+}
+
+html[data-theme="dark"] :where(
+  [class*="border-r-[3px]"],
+  [class*="border-r-2"]
+) {
+  border-right-width: 1px !important;
+}
+
+html[data-theme="dark"] :where(
+  [class*="border-b-[3px]"],
+  [class*="border-b-2"]
+) {
+  border-bottom-width: 1px !important;
+}
+
+html[data-theme="dark"] :where(
+  [class*="border-l-[3px]"],
+  [class*="border-l-2"]
+) {
+  border-left-width: 1px !important;
+}
+
+html[data-theme="dark"] :where(.landing-divider, .marquee-strip, .retro-window-bar) {
+  border-color: var(--color-line-soft) !important;
+}
+
+html[data-theme="dark"] :where(.panel:hover, .card-brutal:hover, .card-brutal-static:hover, .card-poster:hover, .card-flat:hover, .panel-flat:hover) {
+  box-shadow: 2px 2px 0 var(--shadow-color);
 }
 
 .retro-ribbon {

--- a/src/components/admin-bets-panel.tsx
+++ b/src/components/admin-bets-panel.tsx
@@ -64,6 +64,8 @@ const statusTone: Record<BetStatus, string> = {
   cancelled: "bg-[var(--color-rose)]",
 };
 
+const INITIAL_VISIBLE_BETS = 5;
+
 function lifecycleRows(bet: BetWithOptionsRecord) {
   return [
     { label: "Criada", value: bet.createdAt },
@@ -105,6 +107,7 @@ export function AdminBetsPanel({
   const [optionsText, setOptionsText] = useState("Sim\nNão");
   const [feedback, setFeedback] = useState<string | null>(null);
   const [resolveSelections, setResolveSelections] = useState<Record<string, string>>({});
+  const [showAllBets, setShowAllBets] = useState(false);
   const [isPending, startTransition] = useTransition();
 
   async function runAction(url: string, body?: Record<string, unknown>) {
@@ -200,6 +203,8 @@ export function AdminBetsPanel({
   const unresolvedPool = bets
     .filter((bet) => bet.status === "open" || bet.status === "locked")
     .reduce((sum, bet) => sum + bet.totalPool, 0);
+  const visibleBets = showAllBets ? bets : bets.slice(0, INITIAL_VISIBLE_BETS);
+  const hiddenBetCount = Math.max(bets.length - visibleBets.length, 0);
 
   const content = (
     <div className="grid gap-6 xl:grid-cols-[0.85fr_1.15fr]">
@@ -286,7 +291,7 @@ export function AdminBetsPanel({
           </div>
         ) : null}
 
-        {bets.map((bet) => {
+        {visibleBets.map((bet) => {
           const canLock = evaluateBetLifecycleAction({ action: "lock", status: bet.status }).canTransition;
           const canResolve = evaluateBetLifecycleAction({
             action: "resolve",
@@ -468,6 +473,18 @@ export function AdminBetsPanel({
             </article>
           );
         })}
+        {hiddenBetCount > 0 || showAllBets ? (
+          <div className="card-brutal-static flex justify-center p-4">
+            <Button
+              type="button"
+              onClick={() => setShowAllBets((current) => !current)}
+              variant="neutral"
+              size="sm"
+            >
+              {showAllBets ? "Ver menos" : `Ver mais ${hiddenBetCount}`}
+            </Button>
+          </div>
+        ) : null}
       </div>
     </div>
   );
@@ -477,11 +494,8 @@ export function AdminBetsPanel({
       <div className="space-y-4">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div>
-            <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
-              Apostas
-            </p>
             <h2
-              className="mt-2 text-3xl uppercase"
+              className="text-3xl uppercase"
               style={{ fontFamily: "var(--font-display)" }}
             >
               Auditoria da live
@@ -499,11 +513,8 @@ export function AdminBetsPanel({
       <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div>
-            <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-accent-ink-soft)]">
-              Apostas
-            </p>
             <h2
-              className="mt-2 text-3xl uppercase"
+              className="text-3xl uppercase"
               style={{ fontFamily: "var(--font-display)" }}
             >
               Auditoria da live

--- a/src/components/admin-current-game-panel.tsx
+++ b/src/components/admin-current-game-panel.tsx
@@ -215,10 +215,7 @@ export function AdminCurrentGamePanel({
 
   return (
     <div className="panel surface-section p-6">
-      <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
-        Landing page
-      </p>
-      <h2 className="mt-2 text-2xl font-bold uppercase" style={{ fontFamily: "var(--font-display)" }}>
+      <h2 className="text-2xl font-bold uppercase" style={{ fontFamily: "var(--font-display)" }}>
         Jogo atual da live
       </h2>
       <p className="mt-3 text-sm leading-7 text-[var(--color-ink-soft)]">

--- a/src/components/admin-dashboard-tabs.tsx
+++ b/src/components/admin-dashboard-tabs.tsx
@@ -12,7 +12,14 @@ type AdminDashboardTab = {
   content: ReactNode;
 };
 
-export function AdminDashboardTabs({ tabs }: { tabs: AdminDashboardTab[] }) {
+type AdminDashboardSection = {
+  id: string;
+  title: string;
+  items: AdminDashboardTab[];
+};
+
+export function AdminDashboardTabs({ sections }: { sections: AdminDashboardSection[] }) {
+  const tabs = sections.flatMap((section) => section.items);
   const [activeTab, setActiveTab] = useState(tabs[0]?.id ?? "");
   const selected = tabs.find((tab) => tab.id === activeTab) ?? tabs[0];
 
@@ -21,45 +28,59 @@ export function AdminDashboardTabs({ tabs }: { tabs: AdminDashboardTab[] }) {
   }
 
   return (
-    <section className="landing-plane landing-divider bg-[var(--color-paper-pink)] py-6 sm:py-8">
-      <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
-        <div className="panel surface-section p-3 sm:p-4">
-          <div className="grid gap-3 md:grid-cols-4" role="tablist" aria-label="Áreas do admin">
-            {tabs.map((tab) => {
-              const isActive = tab.id === selected.id;
-              return (
-                <Button
-                  key={tab.id}
-                  type="button"
-                  variant={isActive ? "accent" : "neutral"}
-                  size="sm"
-                  onClick={() => setActiveTab(tab.id)}
-                  className="min-h-20 w-full items-start justify-start whitespace-normal p-3 text-left"
-                  role="tab"
-                  aria-controls={`admin-tab-${tab.id}`}
-                  aria-pressed={isActive}
-                  aria-selected={isActive}
-                >
-                  <span className="grid gap-1">
-                    <span className="flex flex-wrap items-center gap-2 text-sm font-black uppercase">
-                      {tab.label}
-                      {tab.badge ? (
-                        <span className="badge-brutal bg-[var(--color-paper)] px-2 py-0.5 text-[10px] text-[var(--color-ink)]">
-                          {tab.badge}
+    <section className="landing-plane landing-divider bg-[var(--color-paper-pink)] py-6 sm:py-8 lg:h-[calc(100vh-10.5rem)] lg:min-h-[640px] lg:overflow-hidden">
+      <div className="mx-auto grid h-full w-full max-w-[1500px] items-start gap-6 px-4 sm:px-6 lg:grid-cols-[280px_minmax(0,1fr)] lg:px-10">
+        <aside className="panel surface-section p-3 lg:h-full lg:overflow-y-auto lg:overscroll-contain">
+          <div className="grid gap-4" role="tablist" aria-label="Módulos do admin">
+            {sections.map((section) => (
+              <div key={section.id} className="grid gap-2">
+                <p className="px-2 text-xs font-black uppercase text-[var(--color-ink-soft)]">
+                  {section.title}
+                </p>
+                <div className="grid gap-2">
+                  {section.items.map((tab) => {
+                    const isActive = tab.id === selected.id;
+                    return (
+                      <Button
+                        key={tab.id}
+                        type="button"
+                        variant={isActive ? "accent" : "neutral"}
+                        size="sm"
+                        onClick={() => setActiveTab(tab.id)}
+                        className="min-h-16 w-full items-start justify-start whitespace-normal p-3 text-left"
+                        role="tab"
+                        id={`admin-tab-trigger-${tab.id}`}
+                        aria-controls={`admin-tab-${tab.id}`}
+                        aria-selected={isActive}
+                      >
+                        <span className="grid gap-1">
+                          <span className="flex flex-wrap items-center gap-2 text-sm font-black uppercase">
+                            {tab.label}
+                            {tab.badge ? (
+                              <span className="badge-brutal bg-[var(--color-paper)] px-2 py-0.5 text-[10px] text-[var(--color-ink)]">
+                                {tab.badge}
+                              </span>
+                            ) : null}
+                          </span>
+                          <span className="text-xs normal-case leading-snug opacity-80">
+                            {tab.description}
+                          </span>
                         </span>
-                      ) : null}
-                    </span>
-                    <span className="text-xs normal-case leading-snug opacity-80">
-                      {tab.description}
-                    </span>
-                  </span>
-                </Button>
-              );
-            })}
+                      </Button>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
           </div>
-        </div>
+        </aside>
 
-        <div className="mt-6" id={`admin-tab-${selected.id}`} role="tabpanel">
+        <div
+          className="min-w-0 self-start lg:h-full lg:overflow-y-auto lg:overscroll-contain lg:pr-2"
+          id={`admin-tab-${selected.id}`}
+          role="tabpanel"
+          aria-labelledby={`admin-tab-trigger-${selected.id}`}
+        >
           {selected.content}
         </div>
       </div>

--- a/src/components/admin-game-suggestions-panel.tsx
+++ b/src/components/admin-game-suggestions-panel.tsx
@@ -81,9 +81,11 @@ function formatMultiplier(value: number) {
 export function AdminGameSuggestionsPanel({
   suggestions,
   boostSettings: initialBoostSettings,
+  embedded = false,
 }: {
   suggestions: GameSuggestionWithMeta[];
   boostSettings: GameSuggestionBoostSettingsRecord;
+  embedded?: boolean;
 }) {
   const router = useRouter();
   const [feedback, setFeedback] = useState<string | null>(null);
@@ -169,16 +171,12 @@ export function AdminGameSuggestionsPanel({
     });
   }
 
-  return (
-    <section className="landing-plane landing-divider bg-[var(--color-paper-pink)] py-8 sm:py-10">
-      <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
+  const content = (
+    <>
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div>
-            <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
-              Jogos
-            </p>
             <h2
-              className="mt-2 text-3xl uppercase"
+              className="text-3xl uppercase"
               style={{ fontFamily: "var(--font-display)" }}
             >
               Fila de sugestões
@@ -361,6 +359,17 @@ export function AdminGameSuggestionsPanel({
             </div>
           ) : null}
         </div>
+    </>
+  );
+
+  if (embedded) {
+    return <section className="space-y-6">{content}</section>;
+  }
+
+  return (
+    <section className="landing-plane landing-divider bg-[var(--color-paper-pink)] py-8 sm:py-10">
+      <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
+        {content}
       </div>
     </section>
   );

--- a/src/components/admin-live-like-goals-panel.tsx
+++ b/src/components/admin-live-like-goals-panel.tsx
@@ -98,10 +98,7 @@ export function AdminLiveLikeGoalsPanel({
     <section className="panel surface-section p-6">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
-            Metas de likes
-          </p>
-          <h2 className="mt-2 text-3xl uppercase" style={{ fontFamily: "var(--font-display)" }}>
+          <h2 className="text-3xl uppercase" style={{ fontFamily: "var(--font-display)" }}>
             Recompensas da live
           </h2>
         </div>

--- a/src/components/admin-obs-overlays-panel.tsx
+++ b/src/components/admin-obs-overlays-panel.tsx
@@ -61,8 +61,10 @@ const overlays = [
 
 export function AdminObsOverlaysPanel({
   initialStatus,
+  embedded = false,
 }: {
   initialStatus: ObsOverlayAdminStatusRecord;
+  embedded?: boolean;
 }) {
   const router = useRouter();
   const [status, setStatus] = useState(initialStatus);
@@ -108,15 +110,10 @@ export function AdminObsOverlaysPanel({
     });
   }
 
-  return (
-    <section className="landing-plane landing-divider bg-[var(--color-paper)] py-8 sm:py-10">
-      <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
-        <div className="panel surface-section p-6">
-          <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
-            Overlays do OBS
-          </p>
+  const content = (
+    <div className="panel surface-section p-6">
           <h2
-            className="mt-3 text-3xl uppercase sm:text-4xl"
+            className="text-3xl uppercase sm:text-4xl"
             style={{ fontFamily: "var(--font-display)" }}
           >
             Seus browser sources
@@ -286,6 +283,16 @@ export function AdminObsOverlaysPanel({
             ))}
           </div>
         </div>
+  );
+
+  if (embedded) {
+    return content;
+  }
+
+  return (
+    <section className="landing-plane landing-divider bg-[var(--color-paper)] py-8 sm:py-10">
+      <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
+        {content}
       </div>
     </section>
   );

--- a/src/components/admin-pipetz-airdrop-panel.tsx
+++ b/src/components/admin-pipetz-airdrop-panel.tsx
@@ -128,10 +128,7 @@ export function AdminPipetzAirdropPanel({
     <section className="panel surface-section p-6">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
-            Airdrop
-          </p>
-          <h2 className="mt-2 text-3xl uppercase" style={{ fontFamily: "var(--font-display)" }}>
+          <h2 className="text-3xl uppercase" style={{ fontFamily: "var(--font-display)" }}>
             Dar pipetz
           </h2>
         </div>

--- a/src/components/admin-pipetz-pricing-panel.tsx
+++ b/src/components/admin-pipetz-pricing-panel.tsx
@@ -17,18 +17,18 @@ const pricingFields: Array<{
 }> = [
   {
     key: "gameSuggestionCost",
-    label: "Sugestao de jogo",
-    description: "Valor cobrado quando alguem indica um novo jogo.",
+    label: "Sugestão de jogo",
+    description: "Valor cobrado quando alguém indica um novo jogo.",
   },
   {
     key: "videoSuggestionCost",
-    label: "Sugestao de video",
-    description: "Valor cobrado para enviar um novo video do YouTube.",
+    label: "Sugestão de vídeo",
+    description: "Valor cobrado para enviar um novo vídeo do YouTube.",
   },
   {
     key: "quoteOverlayCost",
     label: "Quote no OBS",
-    description: "Valor cobrado por !quoteobs e pelo botao publico de OBS.",
+    description: "Valor cobrado por !quoteobs e pelo botão público de OBS.",
   },
 ];
 
@@ -87,16 +87,16 @@ export function AdminPipetzPricingPanel({
         };
 
         if (!response.ok || !result.ok || !result.data) {
-          setFeedback(result.error ?? "Falha ao salvar precos.");
+          setFeedback(result.error ?? "Falha ao salvar preços.");
           return;
         }
 
         setPricing(result.data);
         setForm(toFormState(result.data));
-        setFeedback("Precos atualizados.");
+        setFeedback("Preços atualizados.");
         router.refresh();
       } catch (error) {
-        setFeedback(error instanceof Error ? error.message : "Falha ao salvar precos.");
+        setFeedback(error instanceof Error ? error.message : "Falha ao salvar preços.");
       }
     });
   }
@@ -105,14 +105,11 @@ export function AdminPipetzPricingPanel({
     <div className="panel surface-section p-6">
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
-          <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
-            Precos Pipetz
-          </p>
           <h2
-            className="mt-2 text-2xl font-bold uppercase"
+            className="text-2xl font-bold uppercase"
             style={{ fontFamily: "var(--font-display)" }}
           >
-            Acoes pagas
+            Ações pagas
           </h2>
         </div>
         {feedback ? <div className="retro-label neutral-chip">{feedback}</div> : null}
@@ -147,7 +144,7 @@ export function AdminPipetzPricingPanel({
 
       <div className="mt-5 flex flex-wrap items-center gap-3">
         <Button type="button" onClick={savePricing} disabled={isPending} variant="success" size="sm">
-          {isPending ? "Salvando..." : "Salvar precos"}
+          {isPending ? "Salvando..." : "Salvar preços"}
         </Button>
         {pricing.updatedAt ? (
           <span className="text-sm font-bold text-[var(--color-ink-soft)]">

--- a/src/components/admin-recommendations-panel.tsx
+++ b/src/components/admin-recommendations-panel.tsx
@@ -156,7 +156,7 @@ export function AdminRecommendationsPanel({
         await runAction("/api/admin/recommendations", "POST", parsed.data);
 
         resetForm();
-        setFeedback("Recomendacao adicionada.");
+        setFeedback("Recomendação adicionada.");
         router.refresh();
       } catch (error) {
         setFeedback(
@@ -175,7 +175,7 @@ export function AdminRecommendationsPanel({
         });
         setFieldErrors({});
         setConfirmingDeleteId(null);
-        setFeedback(item.isActive ? "Recomendacao desativada." : "Recomendacao ativada.");
+        setFeedback(item.isActive ? "Recomendação desativada." : "Recomendação ativada.");
         router.refresh();
       } catch (error) {
         setFeedback(
@@ -246,7 +246,7 @@ export function AdminRecommendationsPanel({
         await runAction(`/api/admin/recommendations/${item.id}`, "DELETE");
         setFieldErrors({});
         setConfirmingDeleteId(null);
-        setFeedback("Recomendacao excluida.");
+        setFeedback("Recomendação excluída.");
         router.refresh();
       } catch (error) {
         setFeedback(
@@ -260,11 +260,8 @@ export function AdminRecommendationsPanel({
     <section className="panel bg-[var(--color-periwinkle)] p-6">
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
-          <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
-            Indicações
-          </p>
           <h2
-            className="mt-2 text-3xl uppercase"
+            className="text-3xl uppercase"
             style={{ fontFamily: "var(--font-display)" }}
           >
             Produtos recomendados

--- a/src/components/admin-video-suggestions-panel.tsx
+++ b/src/components/admin-video-suggestions-panel.tsx
@@ -25,6 +25,8 @@ const statusBgMap: Record<AdminVideoSuggestionStatus, string> = {
   rejected: "var(--color-periwinkle)",
 };
 
+const INITIAL_VISIBLE_VIDEO_SUGGESTIONS = 6;
+
 function mapSuggestionError(message: string) {
   switch (message) {
     case "suggestion_not_found":
@@ -36,12 +38,19 @@ function mapSuggestionError(message: string) {
 
 export function AdminVideoSuggestionsPanel({
   suggestions,
+  embedded = false,
 }: {
   suggestions: VideoSuggestionWithMeta[];
+  embedded?: boolean;
 }) {
   const router = useRouter();
   const [feedback, setFeedback] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+  const [showAllSuggestions, setShowAllSuggestions] = useState(false);
+  const visibleSuggestions = showAllSuggestions
+    ? suggestions
+    : suggestions.slice(0, INITIAL_VISIBLE_VIDEO_SUGGESTIONS);
+  const hiddenSuggestionCount = Math.max(suggestions.length - visibleSuggestions.length, 0);
 
   function submitStatus(suggestionId: string, status: AdminVideoSuggestionStatus) {
     setFeedback(null);
@@ -65,16 +74,12 @@ export function AdminVideoSuggestionsPanel({
     });
   }
 
-  return (
-    <section className="landing-plane landing-divider bg-[var(--color-sky)] py-8 sm:py-10">
-      <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
+  const content = (
+    <>
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div>
-            <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
-              Vídeos
-            </p>
             <h2
-              className="mt-2 text-3xl uppercase"
+              className="text-3xl uppercase"
               style={{ fontFamily: "var(--font-display)" }}
             >
               Fila de reações
@@ -94,7 +99,7 @@ export function AdminVideoSuggestionsPanel({
             </div>
           ) : null}
 
-          {suggestions.map((suggestion) => {
+          {visibleSuggestions.map((suggestion) => {
             const normalizedStatus = normalizeVideoSuggestionStatus(suggestion.status);
             const actions = getVideoSuggestionAdminActions(suggestion.status);
 
@@ -173,7 +178,30 @@ export function AdminVideoSuggestionsPanel({
               </article>
             );
           })}
+          {hiddenSuggestionCount > 0 || showAllSuggestions ? (
+            <div className="card-brutal-static flex justify-center p-4">
+              <Button
+                type="button"
+                onClick={() => setShowAllSuggestions((current) => !current)}
+                variant="neutral"
+                size="sm"
+              >
+                {showAllSuggestions ? "Ver menos" : `Ver mais ${hiddenSuggestionCount}`}
+              </Button>
+            </div>
+          ) : null}
         </div>
+    </>
+  );
+
+  if (embedded) {
+    return <section className="space-y-6">{content}</section>;
+  }
+
+  return (
+    <section className="landing-plane landing-divider bg-[var(--color-sky)] py-8 sm:py-10">
+      <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
+        {content}
       </div>
     </section>
   );

--- a/src/components/admin-viewer-links-panel.tsx
+++ b/src/components/admin-viewer-links-panel.tsx
@@ -92,8 +92,10 @@ function maskEmail(email: string | null | undefined) {
 
 export function AdminViewerLinksPanel({
   entries,
+  embedded = false,
 }: {
   entries: AdminViewerDirectoryRecord[];
+  embedded?: boolean;
 }) {
   const router = useRouter();
   const [googleViewerId, setGoogleViewerId] = useState("");
@@ -190,7 +192,7 @@ export function AdminViewerLinksPanel({
           return;
         }
 
-        setFeedback("Usuarios vinculados com sucesso.");
+        setFeedback("Usuários vinculados com sucesso.");
         setGoogleViewerId("");
         setYoutubeViewerId("");
         setConfirmationText("");
@@ -243,16 +245,12 @@ export function AdminViewerLinksPanel({
     });
   }
 
-  return (
-    <section className="landing-plane landing-divider bg-[var(--color-lilac)] py-8 sm:py-10">
-      <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
+  const content = (
+    <>
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div>
-            <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
-              Usuarios
-            </p>
             <h2
-              className="mt-2 text-3xl uppercase"
+              className="text-3xl uppercase"
               style={{ fontFamily: "var(--font-display)" }}
             >
               Vínculos Google + YouTube
@@ -274,7 +272,7 @@ export function AdminViewerLinksPanel({
             <div className="mt-4 grid gap-4">
               <label className="grid gap-2">
                 <span className="text-sm font-black uppercase tracking-[0.14em] text-[var(--color-ink)]">
-                  Usuario Google
+                  Usuário Google
                 </span>
                 <Select value={googleViewerId || null} onValueChange={(value) => setGoogleViewerId(value ?? "")}>
                   <SelectTrigger className="w-full">
@@ -304,7 +302,7 @@ export function AdminViewerLinksPanel({
 
               <label className="grid gap-2">
                 <span className="text-sm font-black uppercase tracking-[0.14em] text-[var(--color-ink)]">
-                  Usuario YouTube
+                  Usuário YouTube
                 </span>
                 <Select value={youtubeViewerId || null} onValueChange={(value) => setYoutubeViewerId(value ?? "")}>
                   <SelectTrigger className="w-full">
@@ -549,14 +547,15 @@ export function AdminViewerLinksPanel({
           </Button>
         </div>
 
-        <div className="mt-6 overflow-hidden rounded-[var(--radius)] border-[3px] border-[var(--color-ink)] shadow-[4px_4px_0_var(--shadow-color)]">
-          <div className="grid grid-cols-[minmax(0,1.3fr)_minmax(0,1fr)_120px_120px] gap-3 border-b-[3px] border-[var(--color-ink)] bg-[var(--color-blue)] px-4 py-3 text-xs font-bold uppercase tracking-[0.18em]">
-            <span>Usuario</span>
-            <span>Conta Google</span>
-            <span>Status</span>
-            <span>Saldo</span>
-          </div>
-          <div>
+        <div className="mt-6 overflow-x-auto rounded-[var(--radius)] border-[3px] border-[var(--color-ink)] shadow-[4px_4px_0_var(--shadow-color)]">
+          <div className="min-w-[760px]">
+            <div className="grid grid-cols-[minmax(0,1.3fr)_minmax(0,1fr)_120px_120px] gap-3 border-b-[3px] border-[var(--color-ink)] bg-[var(--color-blue)] px-4 py-3 text-xs font-bold uppercase tracking-[0.18em]">
+              <span>Usuário</span>
+              <span>Conta Google</span>
+              <span>Status</span>
+              <span>Saldo</span>
+            </div>
+            <div>
             {visibleEntries.map((entry) => {
               const status = getViewerStatus(entry);
 
@@ -583,7 +582,7 @@ export function AdminViewerLinksPanel({
                       {entry.googleAccountId
                         ? entry.googleAccountActiveViewerId === entry.id
                           ? "viewer ativo da conta"
-                          : "viewer secundario da conta"
+                          : "viewer secundário da conta"
                         : entry.isSyntheticYoutubeChannel
                           ? "sessão sem conta vinculada"
                           : "canal sem conta Google"}
@@ -608,20 +607,32 @@ export function AdminViewerLinksPanel({
                 </div>
               );
             })}
-          </div>
-          {hiddenViewerCount > 0 || showAllViewers ? (
-            <div className="border-t-[3px] border-[var(--color-ink)] bg-[var(--color-paper)] px-4 py-4">
-              <Button
-                type="button"
-                onClick={() => setShowAllViewers((current) => !current)}
-                variant="neutral"
-                size="sm"
-              >
-                {showAllViewers ? "Ver menos" : `Ver mais ${hiddenViewerCount}`}
-              </Button>
             </div>
-          ) : null}
+            {hiddenViewerCount > 0 || showAllViewers ? (
+              <div className="border-t-[3px] border-[var(--color-ink)] bg-[var(--color-paper)] px-4 py-4">
+                <Button
+                  type="button"
+                  onClick={() => setShowAllViewers((current) => !current)}
+                  variant="neutral"
+                  size="sm"
+                >
+                  {showAllViewers ? "Ver menos" : `Ver mais ${hiddenViewerCount}`}
+                </Button>
+              </div>
+            ) : null}
+            </div>
         </div>
+    </>
+  );
+
+  if (embedded) {
+    return <section className="space-y-6">{content}</section>;
+  }
+
+  return (
+    <section className="landing-plane landing-divider bg-[var(--color-lilac)] py-8 sm:py-10">
+      <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
+        {content}
       </div>
     </section>
   );

--- a/src/components/admin-wheel-panel.tsx
+++ b/src/components/admin-wheel-panel.tsx
@@ -109,10 +109,7 @@ export function AdminWheelPanel({ initialConfig }: { initialConfig: WheelConfigR
     <section className="panel surface-section p-6">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
-            Roleta da live
-          </p>
-          <h2 className="mt-2 text-3xl uppercase" style={{ fontFamily: "var(--font-display)" }}>
+          <h2 className="text-3xl uppercase" style={{ fontFamily: "var(--font-display)" }}>
             Prêmios do chat
           </h2>
         </div>

--- a/src/components/live-status-panel.tsx
+++ b/src/components/live-status-panel.tsx
@@ -120,15 +120,12 @@ export function LiveStatusPanel({
 
   return (
     <div className="panel surface-section relative overflow-hidden p-6">
-      <div className="bg-dots-light pointer-events-none absolute inset-0 opacity-15" />
+      <div className="bg-dots-light pointer-events-none absolute inset-0 opacity-5" />
       <div className="relative">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
-            <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
-              Bridge da live
-            </p>
             <h2
-              className="mt-2 text-2xl font-bold uppercase"
+              className="text-2xl font-bold uppercase"
               style={{ fontFamily: "var(--font-display)" }}
             >
               {current?.label ?? "Aguardando conector"}


### PR DESCRIPTION
﻿## O que mudou

- Reorganiza o admin em uma navegação lateral por módulos e fluxos de trabalho.
- Divide grupos grandes em áreas menores: Live e OBS, Apostas, Comunidade e Pipetz.
- Condensa listas longas com controles de expansão e evita que filas históricas dominem a tela.
- Reduz ruído visual no dark mode com linhas mais finas, bordas cinza e padrões de fundo menos contrastados.
- Remove indicadores e rótulos redundantes que competiam com as ações principais.

## Por quê

A página do admin acumulava muitas funcionalidades em poucos grupos grandes, dificultando localizar tarefas recorrentes e manter foco operacional. A nova estrutura prioriza navegação por tarefa e exibe um módulo por vez.

## Validação

- `npm run lint`
- `npx tsc --noEmit`
- `npm test`

Closes #124
