### PR TITLE
Centralizar códigos C# do Streamer.bot no painel admin

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,4 +1,5 @@
 import { AdminObsOverlaysPanel } from "@/components/admin-obs-overlays-panel";
+import { AdminStreamerbotScriptsPanel } from "@/components/admin-streamerbot-scripts-panel";
 import { AdminCurrentGamePanel } from "@/components/admin-current-game-panel";
 import { AdminDashboardTabs } from "@/components/admin-dashboard-tabs";
 import { AdminBetsPanel } from "@/components/admin-bets-panel";
@@ -30,6 +31,7 @@ import {
   listAdminRedemptions,
 } from "@/lib/db/repository";
 import { getStreamerbotLivestreamStatus } from "@/lib/streamerbot/live-status";
+import { listStreamerbotScripts } from "@/lib/streamerbot/scripts.server";
 import { getCurrentGame } from "@/lib/current-game";
 import { formatDateTime, formatPipetz } from "@/lib/utils";
 import { getWheelConfig } from "@/lib/wheel";
@@ -44,7 +46,25 @@ const statusColorMap: Record<string, string> = {
 
 export default async function AdminPage() {
   await requireAdminSession();
-  const [catalog, leaderboard, bridge, liveStatus, currentGame, redemptions, bets, likeGoals, suggestions, gameBoostSettings, videoSuggestions, recommendations, viewers, obsOverlayStatus, pricing, wheelConfig] = await Promise.all([
+  const [
+    catalog,
+    leaderboard,
+    bridge,
+    liveStatus,
+    currentGame,
+    redemptions,
+    bets,
+    likeGoals,
+    suggestions,
+    gameBoostSettings,
+    videoSuggestions,
+    recommendations,
+    viewers,
+    obsOverlayStatus,
+    pricing,
+    wheelConfig,
+    streamerbotScripts,
+  ] = await Promise.all([
     getCatalog(),
     getLeaderboard(),
     getBridgeStatus(),
@@ -61,6 +81,7 @@ export default async function AdminPage() {
     getObsOverlayAdminStatus(),
     getPipetzPricing(),
     getWheelConfig(),
+    Promise.resolve(listStreamerbotScripts()),
   ]);
   const openBetCount = bets.filter((bet) => bet.status === "open").length;
   const queuedRedemptionCount = redemptions.filter((entry) => entry.status === "queued").length;
@@ -100,6 +121,13 @@ export default async function AdminPage() {
                 description: "Browser sources, fila e links do OBS.",
                 badge: `${obsOverlayStatus.pendingCount}`,
                 content: <AdminObsOverlaysPanel initialStatus={obsOverlayStatus} embedded />,
+              },
+              {
+                id: "streamerbot",
+                label: "Streamer.bot",
+                description: "Scripts C#, triggers e globals da integração.",
+                badge: `${streamerbotScripts.length}`,
+                content: <AdminStreamerbotScriptsPanel scripts={streamerbotScripts} />,
               },
               {
                 id: "roleta",

--- a/src/components/admin-streamerbot-scripts-panel.tsx
+++ b/src/components/admin-streamerbot-scripts-panel.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  groupStreamerbotScripts,
+  streamerbotGlobalVariables,
+  type StreamerbotScriptRecord,
+} from "@/lib/streamerbot/scripts-catalog";
+
+function CopyCodeButton({ source, label }: { source: string; label: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(source);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+    }
+  }
+
+  return (
+    <Button type="button" variant="neutral" size="sm" onClick={handleCopy}>
+      {copied ? "Copiado" : label}
+    </Button>
+  );
+}
+
+function StreamerbotScriptCard({ script }: { script: StreamerbotScriptRecord }) {
+  return (
+    <Card className="card-brutal-static overflow-hidden bg-[var(--color-paper)]">
+      <CardHeader className="gap-2 border-b-2 border-[var(--color-ink)] p-4">
+        <CardTitle className="text-lg uppercase">{script.title}</CardTitle>
+        <CardDescription className="text-sm leading-6 text-[var(--color-ink-soft)]">
+          {script.description}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-4 p-4">
+        <p className="text-sm">
+          <span className="font-black uppercase tracking-[0.12em]">Trigger ou comando:</span>{" "}
+          <span className="text-[var(--color-ink-soft)]">{script.trigger}</span>
+        </p>
+        <pre className="max-h-[420px] overflow-auto rounded-none border-2 border-[var(--color-ink)] bg-[var(--color-ink)] p-4 text-xs leading-5 text-[var(--color-paper)]">
+          <code>{script.source}</code>
+        </pre>
+      </CardContent>
+      <CardFooter className="flex flex-wrap gap-3 border-t-2 border-[var(--color-ink)] p-4">
+        <CopyCodeButton source={script.source} label="Copiar código C#" />
+      </CardFooter>
+    </Card>
+  );
+}
+
+export function AdminStreamerbotScriptsPanel({
+  scripts,
+}: {
+  scripts: StreamerbotScriptRecord[];
+}) {
+  const groupedScripts = useMemo(() => groupStreamerbotScripts(scripts), [scripts]);
+
+  return (
+    <div className="panel surface-section p-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
+            Streamer.bot
+          </p>
+          <h2
+            className="mt-2 text-2xl font-bold uppercase"
+            style={{ fontFamily: "var(--font-display)" }}
+          >
+            Códigos C# da integração
+          </h2>
+          <p className="mt-3 max-w-3xl text-sm leading-7 text-[var(--color-ink-soft)]">
+            Todos os scripts usados pelo app ficam centralizados aqui. Copie o trecho desejado e
+            cole em uma Sub-Action Execute C# Code no Streamer.bot. Antes de publicar instruções
+            novas, confira a documentação oficial em{" "}
+            <a
+              href="https://docs.streamer.bot/"
+              target="_blank"
+              rel="noreferrer"
+              className="font-bold underline decoration-[3px] underline-offset-4"
+            >
+              docs.streamer.bot
+            </a>
+            .
+          </p>
+        </div>
+        <span className="badge-brutal bg-[var(--color-mint)] px-3 py-1 text-xs font-black uppercase">
+          {scripts.length} scripts
+        </span>
+      </div>
+
+      <div className="mt-6 grid gap-4">
+        <div className="card-brutal-static bg-[var(--color-paper-pink)] p-4">
+          <h3 className="text-sm font-black uppercase tracking-[0.12em]">Globals obrigatórias</h3>
+          <div className="mt-3 grid gap-3">
+            {streamerbotGlobalVariables.map((variable) => (
+              <div key={variable.name} className="grid gap-1 text-sm">
+                <p className="font-bold">
+                  <code className="rounded border-2 border-[var(--color-ink)] bg-[var(--color-paper)] px-2 py-0.5 text-xs">
+                    {variable.name}
+                  </code>
+                  {variable.required ? (
+                    <span className="ml-2 text-xs uppercase tracking-[0.12em] text-[var(--color-ink-soft)]">
+                      obrigatória
+                    </span>
+                  ) : (
+                    <span className="ml-2 text-xs uppercase tracking-[0.12em] text-[var(--color-ink-soft)]">
+                      opcional
+                    </span>
+                  )}
+                </p>
+                <p className="text-[var(--color-ink-soft)]">{variable.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="card-brutal-static bg-[var(--color-lavender)] p-4 text-sm leading-7">
+          <p className="font-black uppercase tracking-[0.12em]">Roleta da live</p>
+          <p className="mt-2 text-[var(--color-ink-soft)]">
+            O giro da roleta usa POST assinado em{" "}
+            <code className="rounded border-2 border-[var(--color-ink)] bg-[var(--color-paper)] px-2 py-0.5 text-xs">
+              /api/internal/streamerbot/wheel
+            </code>
+            . Ainda não há arquivo em{" "}
+            <code className="rounded border-2 border-[var(--color-ink)] bg-[var(--color-paper)] px-2 py-0.5 text-xs">
+              streamerbot/
+            </code>
+            ; siga{" "}
+            <code className="rounded border-2 border-[var(--color-ink)] bg-[var(--color-paper)] px-2 py-0.5 text-xs">
+              docs/twitch-wheel.md
+            </code>{" "}
+            para montar a action manualmente.
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-8 grid gap-8">
+        {groupedScripts.map((group) => (
+          <section key={group.category} className="grid gap-4">
+            <div>
+              <h3
+                className="text-xl font-bold uppercase"
+                style={{ fontFamily: "var(--font-display)" }}
+              >
+                {group.label}
+              </h3>
+              <p className="mt-1 text-sm text-[var(--color-ink-soft)]">{group.description}</p>
+            </div>
+            <div className="grid gap-4">
+              {group.scripts.map((script) => (
+                <StreamerbotScriptCard key={script.id} script={script} />
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/streamerbot/scripts-catalog.ts
+++ b/src/lib/streamerbot/scripts-catalog.ts
@@ -1,0 +1,236 @@
+export type StreamerbotScriptCategory =
+  | "live"
+  | "pipetz"
+  | "apostas"
+  | "quotes"
+  | "contadores"
+  | "chat";
+
+export type StreamerbotScriptDefinition = {
+  id: string;
+  filename: string;
+  title: string;
+  description: string;
+  category: StreamerbotScriptCategory;
+  trigger: string;
+  setupInstructions: string;
+  sortOrder: number;
+};
+
+export type StreamerbotScriptRecord = StreamerbotScriptDefinition & {
+  source: string;
+};
+
+export const streamerbotScriptCategories: Record<
+  StreamerbotScriptCategory,
+  { label: string; description: string }
+> = {
+  live: {
+    label: "Live e recompensas",
+    description: "Eventos automáticos da transmissão, metas de likes e presença na live.",
+  },
+  pipetz: {
+    label: "Pipetz e vínculo",
+    description: "Comandos de saldo e vinculação da conta YouTube com o app.",
+  },
+  apostas: {
+    label: "Apostas",
+    description: "Entrada de apostas pelo chat durante a live.",
+  },
+  quotes: {
+    label: "Quotes",
+    description: "Cadastro, consulta e exibição de quotes pagas em pipetz.",
+  },
+  contadores: {
+    label: "Contadores",
+    description: "Contagem de mortes e integração com o jogo ativo da live.",
+  },
+  chat: {
+    label: "Chat e comandos",
+    description: "Respostas locais no chat sem chamada HTTP ao app.",
+  },
+};
+
+export const streamerbotGlobalVariables = [
+  {
+    name: "lojaneon.appBaseUrl",
+    description: "URL pública do app, sem barra no final. Exemplo: https://live.ludylops.com.br",
+    required: true,
+  },
+  {
+    name: "lojaneon.streamerbotSharedSecret",
+    description: "Segredo compartilhado usado para assinar requisições HMAC enviadas ao app.",
+    required: true,
+  },
+  {
+    name: "lojaneon.useBotAccount",
+    description: "Quando true, respostas de chat saem pela conta do bot. Padrão varia por script.",
+    required: false,
+  },
+  {
+    name: "lojaneon.activeBetId",
+    description: "ID da aposta aberta usada pelo comando !bet quando o chat não informa outra.",
+    required: false,
+  },
+  {
+    name: "lojaneon.quoteOverlayDurationSeconds",
+    description: "Tempo em segundos que a quote fica visível no overlay OBS.",
+    required: false,
+  },
+  {
+    name: "lojaneon.counterGameKey",
+    description: "Chave do jogo ativo para o contador de mortes quando não vem do argumento da action.",
+    required: false,
+  },
+  {
+    name: "lojaneon.counterGameLabel",
+    description: "Nome exibido do jogo ativo no contador de mortes.",
+    required: false,
+  },
+];
+
+export const streamerbotScriptDefinitions: StreamerbotScriptDefinition[] = [
+  {
+    id: "channel-subscription-reward",
+    filename: "channel-subscription-reward.cs",
+    title: "Recompensa de nova inscrição",
+    description:
+      "Envia evento channel_subscription para o app e habilita o overlay de novos inscritos.",
+    category: "live",
+    trigger: "YouTube > General > New Subscriber",
+    setupInstructions:
+      "Crie uma Sub-Action com Execute C# Code apontando para este arquivo. Confirme que a integração do StreamElements está ativa no Streamer.bot, pois o trigger de New Subscriber depende dela. Abra /obs/subscribers como Browser Source no OBS.",
+    sortOrder: 10,
+  },
+  {
+    id: "like-count-update",
+    filename: "like-count-update.cs",
+    title: "Atualização de likes da live",
+    description:
+      "Publica like_count_update com o total atual de likes e alimenta a meta cadastrada no admin.",
+    category: "live",
+    trigger: "YouTube > Broadcast > Statistics Updated",
+    setupInstructions:
+      "Use este script na action ligada ao trigger Statistics Updated. Garanta que a variável likeCount esteja disponível. Abra /obs/likes como Browser Source para exibir o progresso da meta.",
+    sortOrder: 20,
+  },
+  {
+    id: "presence-tick-from-present-viewers",
+    filename: "presence-tick-from-present-viewers.cs",
+    title: "Presença na live",
+    description:
+      "Marca viewers presentes na transmissão para elegibilidade de recompensas como metas de likes.",
+    category: "live",
+    trigger: "YouTube > General > Present Viewers",
+    setupInstructions:
+      "Configure uma action periódica no trigger Present Viewers. O script percorre a lista users e envia presence_tick para cada viewer elegível.",
+    sortOrder: 30,
+  },
+  {
+    id: "link-account-from-chat",
+    filename: "link-account-from-chat.cs",
+    title: "Vincular conta pelo chat",
+    description: "Processa !link CODIGO e associa o canal YouTube ao viewer no app.",
+    category: "pipetz",
+    trigger: "Comando de chat !link",
+    setupInstructions:
+      "Crie um comando !link com argumento de código. Use este script na Sub-Action Execute C# Code. O viewer precisa gerar o código em /conta no site antes de usar o comando.",
+    sortOrder: 40,
+  },
+  {
+    id: "get-points-from-chat",
+    filename: "get-points-from-chat.cs",
+    title: "Consultar saldo de pipetz",
+    description: "Responde !pontos, !saldo, !pipetz ou !points com o saldo atual do viewer.",
+    category: "pipetz",
+    trigger: "Comandos de chat !pontos / !saldo / !pipetz / !points",
+    setupInstructions:
+      "Registre os aliases desejados apontando para a mesma action com este script. A conta precisa estar vinculada para retornar saldo.",
+    sortOrder: 50,
+  },
+  {
+    id: "place-bet-from-chat",
+    filename: "place-bet-from-chat.cs",
+    title: "Apostar pelo chat",
+    description: "Processa !bet <opção> <valor> e registra a aposta aberta no app.",
+    category: "apostas",
+    trigger: "Comando de chat !bet",
+    setupInstructions:
+      "Configure !bet com dois argumentos. Opcionalmente defina lojaneon.activeBetId para fixar a aposta aberta. Abra /obs/bets como Browser Source para mostrar o placar ao vivo.",
+    sortOrder: 60,
+  },
+  {
+    id: "add-quote-from-chat",
+    filename: "add-quote-from-chat.cs",
+    title: "Adicionar quote",
+    description: "Cadastra uma nova quote paga em pipetz a partir do chat.",
+    category: "quotes",
+    trigger: "Comando de chat !addquote ou fluxo equivalente",
+    setupInstructions:
+      "Use em uma action de moderador ou comando configurado no Streamer.bot. O script envia o texto informado para POST /api/internal/streamerbot/quotes.",
+    sortOrder: 70,
+  },
+  {
+    id: "get-quote-from-chat",
+    filename: "get-quote-from-chat.cs",
+    title: "Consultar quote",
+    description: "Responde !quote [número] com o texto da quote solicitada.",
+    category: "quotes",
+    trigger: "Comando de chat !quote",
+    setupInstructions:
+      "Registre !quote com argumento opcional de número. Sem número, o script pode retornar uma quote aleatória conforme a lógica do arquivo.",
+    sortOrder: 80,
+  },
+  {
+    id: "show-quote-on-obs",
+    filename: "show-quote-on-obs.cs",
+    title: "Exibir quote no OBS",
+    description: "Dispara a quote escolhida no overlay /obs/quotes com duração configurável.",
+    category: "quotes",
+    trigger: "Comando de chat !quoteobs",
+    setupInstructions:
+      "Configure !quoteobs <número> para moderadores. Defina lojaneon.quoteOverlayDurationSeconds se quiser alterar o tempo na tela. Abra /obs/quotes como Browser Source.",
+    sortOrder: 90,
+  },
+  {
+    id: "death-counter-from-chat",
+    filename: "death-counter-from-chat.cs",
+    title: "Contador de mortes",
+    description: "Incrementa ou consulta mortes do jogo ativo da live via !deaths.",
+    category: "contadores",
+    trigger: "Comando de chat !deaths",
+    setupInstructions:
+      "Configure !deaths na action desejada. O jogo ativo pode vir do admin ou das globals lojaneon.counterGameKey e lojaneon.counterGameLabel.",
+    sortOrder: 100,
+  },
+  {
+    id: "list-commands-from-chat",
+    filename: "list-commands-from-chat.cs",
+    title: "Listar comandos disponíveis",
+    description:
+      "Responde no chat com a lista pública de comandos e uma versão estendida para moderadores.",
+    category: "chat",
+    trigger: "Comando de chat !comandos ou !help",
+    setupInstructions:
+      "Este script não chama o app. Personalize as linhas com lojaneon.commandsListPublic1, lojaneon.commandsListPublic2 e lojaneon.commandsListMod se quiser textos diferentes.",
+    sortOrder: 110,
+  },
+];
+
+export function groupStreamerbotScripts(scripts: StreamerbotScriptRecord[]) {
+  const grouped = new Map<StreamerbotScriptCategory, StreamerbotScriptRecord[]>();
+
+  for (const script of scripts) {
+    const current = grouped.get(script.category) ?? [];
+    current.push(script);
+    grouped.set(script.category, current);
+  }
+
+  return (Object.keys(streamerbotScriptCategories) as StreamerbotScriptCategory[])
+    .map((category) => ({
+      category,
+      ...streamerbotScriptCategories[category],
+      scripts: grouped.get(category) ?? [],
+    }))
+    .filter((entry) => entry.scripts.length > 0);
+}

--- a/src/lib/streamerbot/scripts.server.ts
+++ b/src/lib/streamerbot/scripts.server.ts
@@ -1,0 +1,26 @@
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+
+import {
+  streamerbotScriptDefinitions,
+  type StreamerbotScriptRecord,
+} from "@/lib/streamerbot/scripts-catalog";
+
+function readStreamerbotSource(filename: string) {
+  const filePath = path.join(process.cwd(), "streamerbot", filename);
+  return readFileSync(filePath, "utf8");
+}
+
+export function listStreamerbotScripts(): StreamerbotScriptRecord[] {
+  const availableFiles = new Set(
+    readdirSync(path.join(process.cwd(), "streamerbot")).filter((entry) => entry.endsWith(".cs")),
+  );
+
+  return streamerbotScriptDefinitions
+    .filter((definition) => availableFiles.has(definition.filename))
+    .map((definition) => ({
+      ...definition,
+      source: readStreamerbotSource(definition.filename),
+    }))
+    .sort((left, right) => left.sortOrder - right.sortOrder);
+}

--- a/src/lib/streamerbot/scripts.test.ts
+++ b/src/lib/streamerbot/scripts.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  groupStreamerbotScripts,
+  streamerbotScriptCategories,
+} from "@/lib/streamerbot/scripts-catalog";
+import { listStreamerbotScripts } from "@/lib/streamerbot/scripts.server";
+
+describe("streamerbot scripts catalog", () => {
+  it("loads every cataloged C# file from streamerbot/", () => {
+    const scripts = listStreamerbotScripts();
+
+    expect(scripts.length).toBeGreaterThanOrEqual(11);
+    expect(scripts.every((script) => script.source.includes("public class CPHInline"))).toBe(true);
+    expect(scripts.find((script) => script.id === "like-count-update")?.trigger).toContain(
+      "Statistics Updated",
+    );
+  });
+
+  it("groups scripts by category with Portuguese labels", () => {
+    const grouped = groupStreamerbotScripts(listStreamerbotScripts());
+
+    expect(grouped.some((entry) => entry.category === "live" && entry.label === "Live e recompensas")).toBe(
+      true,
+    );
+    expect(grouped.every((entry) => entry.scripts.length > 0)).toBe(true);
+    expect(Object.keys(streamerbotScriptCategories)).toHaveLength(6);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a Streamer.bot scripts catalog with grouped C# snippets, descriptions, and global variables for the live integration.
- Expose scripts via a server helper and a new admin dashboard tab with copy-to-clipboard cards and script count badge.
- Wire the panel into the admin page and add unit tests for the catalog loader.

## Test plan
- [ ] Run the project test suite and confirm scripts.test.ts passes.
- [ ] Sign in as admin, open the dashboard, and select the Streamer.bot tab.
- [ ] Verify scripts render by group, global variables are listed, and copy copies the C# source.

Closes #132