### PR TITLE
Fail closed in production when NEXTAUTH_SECRET is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ STEAM_STORE_LANGUAGE=brazilian
 
 Checklist de deploy para Google OAuth:
 
+- Em produção, o app não inicia sem `NEXTAUTH_SECRET` configurado; defina o valor no ambiente de deploy antes de publicar.
 - Em `APP_URL` e `NEXT_PUBLIC_APP_URL`, use as URLs públicas finais do deploy, sem barra no fim.
 - No Google Cloud Console, em **Authorized redirect URIs**, cadastre uma callback para cada domínio público usado pelo app, no formato `https://seu-dominio/api/auth/callback/google`.
 - Para este projeto, o domínio principal deve ter `https://ludylops.live/api/auth/callback/google`; se o deploy da Vercel também for usado para login, cadastre também a URL equivalente de `*.vercel.app`.

--- a/plans/README.md
+++ b/plans/README.md
@@ -11,8 +11,8 @@ Verification baseline at `06f0792`: `npm run lint`, `npx tsc --noEmit`, `npm tes
 
 | Plan | Title | Priority | Effort | Depends on | Issue | Status |
 |------|-------|----------|--------|------------|-------|--------|
-| 001  | CI verification baseline (lint, typecheck, tests, build) | P1 | S | — | [#136](https://github.com/ludmila-omlopes/ludylops-live/issues/136) | TODO |
-| 002  | Fail closed in production when auth-critical env vars missing | P1 | S | 001 | [#137](https://github.com/ludmila-omlopes/ludylops-live/issues/137) | TODO |
+| 001  | CI verification baseline (lint, typecheck, tests, build) | P1 | S | — | [#136](https://github.com/ludmila-omlopes/ludylops-live/issues/136) | DONE (PR #143) |
+| 002  | Fail closed in production when auth-critical env vars missing | P1 | S | 001 | [#137](https://github.com/ludmila-omlopes/ludylops-live/issues/137) | DONE |
 | 003  | Route-level tests for bridge + Streamer.bot endpoints | P1 | M | 001 | [#138](https://github.com/ludmila-omlopes/ludylops-live/issues/138) | TODO |
 | 004  | Bridge redemption claim/complete/fail idempotency | P1 | M | 003 | [#139](https://github.com/ludmila-omlopes/ludylops-live/issues/139) | TODO |
 | 005  | redeemItem balance overdraw + stock oversell guards | P1 | S | 001 | [#140](https://github.com/ludmila-omlopes/ludylops-live/issues/140) | TODO |

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,6 +1,31 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { isTrustedAppMutationRequest } from "@/lib/request-origin";
+
+const authMock = vi.hoisted(() => vi.fn());
+const envState = vi.hoisted(() => ({
+  isDemoMode: false,
+  isProduction: false,
+  adminEmails: new Set<string>(),
+}));
+
+vi.mock("@/auth", () => ({
+  auth: authMock,
+}));
+
+vi.mock("@/lib/env", () => ({
+  get isDemoMode() {
+    return envState.isDemoMode;
+  },
+  get isProduction() {
+    return envState.isProduction;
+  },
+  get adminEmails() {
+    return envState.adminEmails;
+  },
+}));
+
+import { requireAdminApiSession } from "@/lib/api";
 
 describe("isTrustedAppMutationRequest", () => {
   it("accepts matching origin headers", () => {
@@ -42,5 +67,32 @@ describe("isTrustedAppMutationRequest", () => {
     });
 
     expect(isTrustedAppMutationRequest(request)).toBe(false);
+  });
+});
+
+describe("requireAdminApiSession", () => {
+  const session = {
+    expires: "2099-01-01T00:00:00.000Z",
+    user: { email: "viewer@example.com" },
+  };
+
+  beforeEach(() => {
+    authMock.mockReset();
+    authMock.mockResolvedValue(session);
+    envState.isDemoMode = true;
+    envState.isProduction = false;
+    envState.adminEmails = new Set<string>();
+  });
+
+  it("rejects a non-admin user in production demo mode", async () => {
+    envState.isProduction = true;
+
+    await expect(requireAdminApiSession()).resolves.toBeNull();
+  });
+
+  it("keeps the demo admin bypass outside production", async () => {
+    envState.isProduction = false;
+
+    await expect(requireAdminApiSession()).resolves.toBe(session);
   });
 });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { auth } from "@/auth";
-import { adminEmails, isDemoMode } from "@/lib/env";
+import { adminEmails, isDemoMode, isProduction } from "@/lib/env";
 export { isTrustedAppMutationRequest } from "@/lib/request-origin";
 
 export function ok(data: unknown, init?: ResponseInit) {
@@ -33,7 +33,7 @@ export async function requireAdminApiSession() {
   if (!session?.user?.email) {
     return null;
   }
-  if (isDemoMode) {
+  if (isDemoMode && !isProduction) {
     return session;
   }
 

--- a/src/lib/env.test.ts
+++ b/src/lib/env.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("env authSecret", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("DATABASE_URL", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("throws in production when NEXTAUTH_SECRET is missing", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXTAUTH_SECRET", undefined);
+
+    await expect(import("@/lib/env")).rejects.toThrow(/NEXTAUTH_SECRET/);
+  });
+
+  it("uses the configured secret in production", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXTAUTH_SECRET", "abc");
+
+    const { authSecret } = await import("@/lib/env");
+
+    expect(authSecret).toBe("abc");
+  });
+
+  it("falls back to dev-secret outside production", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("NEXTAUTH_SECRET", undefined);
+
+    const { authSecret } = await import("@/lib/env");
+
+    expect(authSecret).toBe("dev-secret");
+  });
+});

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -60,13 +60,19 @@ export const adminEmails = new Set(
 
 export const isDemoMode = !env.DATABASE_URL;
 export const isDemoAuthEnabled = isDemoMode;
-export const authSecret =
-  env.NEXTAUTH_SECRET ?? (isProduction ? "pipetz-production-demo-secret" : "dev-secret");
 
-const missingProductionEnv = [
-  !env.DATABASE_URL ? "DATABASE_URL" : null,
-  !env.NEXTAUTH_SECRET ? "NEXTAUTH_SECRET" : null,
-].filter((entry): entry is string => Boolean(entry));
+if (isProduction && !env.NEXTAUTH_SECRET) {
+  throw new Error(
+    "[env] NEXTAUTH_SECRET is required in production. " +
+      "Set it in the deployment environment before starting the app.",
+  );
+}
+
+export const authSecret = env.NEXTAUTH_SECRET ?? "dev-secret";
+
+const missingProductionEnv = [!env.DATABASE_URL ? "DATABASE_URL" : null].filter(
+  (entry): entry is string => Boolean(entry),
+);
 
 if (isProduction && missingProductionEnv.length > 0) {
   console.warn(


### PR DESCRIPTION
Production deploys now refuse to boot without `NEXTAUTH_SECRET` (previously fell back to a hardcoded, publicly-known secret), and the demo-mode admin bypass no longer applies in production (previously any logged-in user became admin if `DATABASE_URL` was unset).

- `src/lib/env.ts`: throws at module load when `NODE_ENV=production` and `NEXTAUTH_SECRET` is unset; dev keeps the `dev-secret` fallback.
- `src/lib/api.ts`: demo admin bypass gated to non-production.
- 5 new tests (201 total); verified both build modes: with secret → builds, without → fails with the intended error.
- README deploy checklist updated; plans index updated (001, 002 done).

Executes plan 002 from `plans/`.

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)