### PR TITLE
[codex] Add route tests for bridge and Streamer.bot endpoints

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -13,7 +13,7 @@ Verification baseline at `06f0792`: `npm run lint`, `npx tsc --noEmit`, `npm tes
 |------|-------|----------|--------|------------|-------|--------|
 | 001  | CI verification baseline (lint, typecheck, tests, build) | P1 | S | — | [#136](https://github.com/ludmila-omlopes/ludylops-live/issues/136) | DONE (PR #143) |
 | 002  | Fail closed in production when auth-critical env vars missing | P1 | S | 001 | [#137](https://github.com/ludmila-omlopes/ludylops-live/issues/137) | DONE |
-| 003  | Route-level tests for bridge + Streamer.bot endpoints | P1 | M | 001 | [#138](https://github.com/ludmila-omlopes/ludylops-live/issues/138) | TODO |
+| 003  | Route-level tests for bridge + Streamer.bot endpoints | P1 | M | 001 | [#138](https://github.com/ludmila-omlopes/ludylops-live/issues/138) | DONE |
 | 004  | Bridge redemption claim/complete/fail idempotency | P1 | M | 003 | [#139](https://github.com/ludmila-omlopes/ludylops-live/issues/139) | TODO |
 | 005  | redeemItem balance overdraw + stock oversell guards | P1 | S | 001 | [#140](https://github.com/ludmila-omlopes/ludylops-live/issues/140) | TODO |
 | 006  | Hardening batch: timing-safe sync auth, dep vulns, FK indexes | P2 | M | 001 | [#141](https://github.com/ludmila-omlopes/ludylops-live/issues/141) | TODO |

--- a/src/app/api/internal/bridge/bridge-routes.test.ts
+++ b/src/app/api/internal/bridge/bridge-routes.test.ts
@@ -1,0 +1,270 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const authMock = vi.hoisted(() => vi.fn());
+const bridgeHeartbeatMock = vi.hoisted(() => vi.fn());
+const bridgePullMock = vi.hoisted(() => vi.fn());
+const bridgeClaimMock = vi.hoisted(() => vi.fn());
+const bridgeCompleteMock = vi.hoisted(() => vi.fn());
+const bridgeFailMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/auth", () => ({
+  auth: authMock,
+}));
+
+vi.mock("@/lib/env", () => ({
+  env: {
+    BRIDGE_SHARED_SECRET: "test-bridge-secret",
+  },
+  isDemoMode: true,
+  isProduction: false,
+  adminEmails: new Set<string>(),
+}));
+
+vi.mock("@/lib/db/repository", () => ({
+  bridgeHeartbeat: bridgeHeartbeatMock,
+  bridgePull: bridgePullMock,
+  bridgeClaim: bridgeClaimMock,
+  bridgeComplete: bridgeCompleteMock,
+  bridgeFail: bridgeFailMock,
+}));
+
+import { buildSignature } from "@/lib/streamerbot/security";
+import { POST as heartbeatPost } from "@/app/api/internal/bridge/heartbeat/route";
+import { POST as pullPost } from "@/app/api/internal/bridge/pull/route";
+import { POST as claimPost } from "@/app/api/internal/bridge/[redemptionId]/claim/route";
+import { POST as completePost } from "@/app/api/internal/bridge/[redemptionId]/complete/route";
+import { POST as failPost } from "@/app/api/internal/bridge/[redemptionId]/fail/route";
+
+function signedRequest(
+  body: unknown,
+  options: { secret?: string; timestamp?: number; includeSignature?: boolean } = {},
+) {
+  const raw = JSON.stringify(body);
+  const timestamp = `${options.timestamp ?? Date.now()}`;
+  const headers = new Headers({
+    "content-type": "application/json",
+    "x-timestamp": timestamp,
+  });
+
+  if (options.includeSignature !== false) {
+    headers.set(
+      "x-signature",
+      buildSignature({
+        body: raw,
+        timestamp,
+        secret: options.secret ?? "test-bridge-secret",
+      }),
+    );
+  }
+
+  return new Request("http://localhost/api/internal/bridge", {
+    method: "POST",
+    headers,
+    body: raw,
+  });
+}
+
+function redemptionParams(redemptionId = "red-1") {
+  return {
+    params: Promise.resolve({ redemptionId }),
+  };
+}
+
+describe("bridge route handlers", () => {
+  beforeEach(() => {
+    authMock.mockReset();
+    bridgeHeartbeatMock.mockReset();
+    bridgePullMock.mockReset();
+    bridgeClaimMock.mockReset();
+    bridgeCompleteMock.mockReset();
+    bridgeFailMock.mockReset();
+  });
+
+  it("rejects unsigned heartbeat requests", async () => {
+    const response = await heartbeatPost(
+      signedRequest({ bridgeId: "bridge-1", machineKey: "machine-1", label: "Bridge local" }, { includeSignature: false }),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({ ok: false, error: "Invalid signature." });
+    expect(bridgeHeartbeatMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects heartbeat requests signed with the wrong secret", async () => {
+    const response = await heartbeatPost(
+      signedRequest(
+        { bridgeId: "bridge-1", machineKey: "machine-1", label: "Bridge local" },
+        { secret: "other-secret" },
+      ),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({ ok: false, error: "Invalid signature." });
+    expect(bridgeHeartbeatMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts valid heartbeat requests", async () => {
+    const payload = { bridgeId: "bridge-1", machineKey: "machine-1", label: "Bridge local" };
+    bridgeHeartbeatMock.mockResolvedValueOnce({ acknowledged: true });
+
+    const response = await heartbeatPost(signedRequest(payload));
+
+    expect(bridgeHeartbeatMock).toHaveBeenCalledWith(payload);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      data: { acknowledged: true },
+    });
+  });
+
+  it("rejects unsigned pull requests", async () => {
+    const response = await pullPost(signedRequest({ requestedBy: "bridge" }, { includeSignature: false }));
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({ ok: false, error: "Invalid signature." });
+    expect(bridgePullMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects pull requests signed with the wrong secret", async () => {
+    const response = await pullPost(signedRequest({ requestedBy: "bridge" }, { secret: "other-secret" }));
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({ ok: false, error: "Invalid signature." });
+    expect(bridgePullMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts valid pull requests", async () => {
+    bridgePullMock.mockResolvedValueOnce([{ id: "red-1" }]);
+
+    const response = await pullPost(signedRequest({ requestedBy: "bridge" }));
+
+    expect(bridgePullMock).toHaveBeenCalledWith();
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      data: [{ id: "red-1" }],
+    });
+  });
+
+  it("rejects unsigned claim requests", async () => {
+    const response = await claimPost(
+      signedRequest({ bridgeId: "bridge-1" }, { includeSignature: false }),
+      redemptionParams(),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({ ok: false, error: "Invalid signature." });
+    expect(bridgeClaimMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects claim requests signed with the wrong secret", async () => {
+    const response = await claimPost(
+      signedRequest({ bridgeId: "bridge-1" }, { secret: "other-secret" }),
+      redemptionParams(),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({ ok: false, error: "Invalid signature." });
+    expect(bridgeClaimMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts valid claim requests", async () => {
+    bridgeClaimMock.mockResolvedValueOnce({ claimed: true });
+
+    const response = await claimPost(signedRequest({ bridgeId: "bridge-1" }), redemptionParams("red-1"));
+
+    expect(bridgeClaimMock).toHaveBeenCalledWith("red-1", "bridge-1");
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      data: { claimed: true },
+    });
+  });
+
+  it("rejects claim requests with a stale timestamp", async () => {
+    const response = await claimPost(
+      signedRequest({ bridgeId: "bridge-1" }, { timestamp: Date.now() - 10 * 60 * 1000 }),
+      redemptionParams(),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({ ok: false, error: "Invalid signature." });
+    expect(bridgeClaimMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsigned complete requests", async () => {
+    const response = await completePost(
+      signedRequest({ bridgeId: "bridge-1", executionNote: "done" }, { includeSignature: false }),
+      redemptionParams(),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({ ok: false, error: "Invalid signature." });
+    expect(bridgeCompleteMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects complete requests signed with the wrong secret", async () => {
+    const response = await completePost(
+      signedRequest({ bridgeId: "bridge-1", executionNote: "done" }, { secret: "other-secret" }),
+      redemptionParams(),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({ ok: false, error: "Invalid signature." });
+    expect(bridgeCompleteMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts valid complete requests", async () => {
+    bridgeCompleteMock.mockResolvedValueOnce({ completed: true });
+
+    const response = await completePost(
+      signedRequest({ bridgeId: "bridge-1", executionNote: "done" }),
+      redemptionParams("red-1"),
+    );
+
+    expect(bridgeCompleteMock).toHaveBeenCalledWith("red-1");
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      data: { completed: true },
+    });
+  });
+
+  it("rejects unsigned fail requests", async () => {
+    const response = await failPost(
+      signedRequest({ bridgeId: "bridge-1", failureReason: "Timed out" }, { includeSignature: false }),
+      redemptionParams(),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({ ok: false, error: "Invalid signature." });
+    expect(bridgeFailMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects fail requests signed with the wrong secret", async () => {
+    const response = await failPost(
+      signedRequest({ bridgeId: "bridge-1", failureReason: "Timed out" }, { secret: "other-secret" }),
+      redemptionParams(),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({ ok: false, error: "Invalid signature." });
+    expect(bridgeFailMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts valid fail requests", async () => {
+    bridgeFailMock.mockResolvedValueOnce({ failed: true });
+
+    const response = await failPost(
+      signedRequest({ bridgeId: "bridge-1", failureReason: "Timed out" }),
+      redemptionParams("red-1"),
+    );
+
+    expect(bridgeFailMock).toHaveBeenCalledWith("red-1", "Timed out");
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      data: { failed: true },
+    });
+  });
+});

--- a/src/app/api/internal/streamerbot/streamerbot-routes.test.ts
+++ b/src/app/api/internal/streamerbot/streamerbot-routes.test.ts
@@ -1,0 +1,505 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const authMock = vi.hoisted(() => vi.fn());
+const ingestStreamerbotEventMock = vi.hoisted(() => vi.fn());
+const claimViewerLinkCodeFromStreamerbotMock = vi.hoisted(() => vi.fn());
+const getViewerBalanceFromChatCommandMock = vi.hoisted(() => vi.fn());
+const placeBetFromChatCommandMock = vi.hoisted(() => vi.fn());
+const runStreamerbotCounterCommandMock = vi.hoisted(() => vi.fn());
+const runDeathCounterCommandMock = vi.hoisted(() => vi.fn());
+const runQuoteCommandFromChatMock = vi.hoisted(() => vi.fn());
+const getPipetzPricingMock = vi.hoisted(() => vi.fn());
+const triggerWheelSpinMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/auth", () => ({
+  auth: authMock,
+}));
+
+vi.mock("@/lib/env", () => ({
+  env: {
+    STREAMERBOT_SHARED_SECRET: "test-streamerbot-secret",
+  },
+  isDemoMode: true,
+  isProduction: false,
+  adminEmails: new Set<string>(),
+}));
+
+vi.mock("@/lib/db/repository", () => ({
+  ingestStreamerbotEvent: ingestStreamerbotEventMock,
+  claimViewerLinkCodeFromStreamerbot: claimViewerLinkCodeFromStreamerbotMock,
+  getViewerBalanceFromChatCommand: getViewerBalanceFromChatCommandMock,
+  placeBetFromChatCommand: placeBetFromChatCommandMock,
+  runStreamerbotCounterCommand: runStreamerbotCounterCommandMock,
+  runDeathCounterCommand: runDeathCounterCommandMock,
+  runQuoteCommandFromChat: runQuoteCommandFromChatMock,
+  getPipetzPricing: getPipetzPricingMock,
+}));
+
+vi.mock("@/lib/wheel", () => ({
+  triggerWheelSpin: triggerWheelSpinMock,
+}));
+
+import { buildSignature } from "@/lib/streamerbot/security";
+import { POST as eventsPost } from "@/app/api/internal/streamerbot/events/route";
+import { POST as linkPost } from "@/app/api/internal/streamerbot/link/route";
+import { POST as pointsPost } from "@/app/api/internal/streamerbot/points/route";
+import { POST as placeBetPost } from "@/app/api/internal/streamerbot/bets/place/route";
+import { POST as countersPost } from "@/app/api/internal/streamerbot/counters/route";
+import { POST as deathsPost } from "@/app/api/internal/streamerbot/deaths/route";
+import { POST as quotesPost } from "@/app/api/internal/streamerbot/quotes/route";
+import { POST as wheelPost } from "@/app/api/internal/streamerbot/wheel/route";
+
+function signedRequest(
+  body: unknown,
+  options: { secret?: string; timestamp?: number; includeSignature?: boolean; rawBody?: string } = {},
+) {
+  const raw = options.rawBody ?? JSON.stringify(body);
+  const timestamp = `${options.timestamp ?? Date.now()}`;
+  const headers = new Headers({
+    "content-type": "application/json",
+    "x-timestamp": timestamp,
+  });
+
+  if (options.includeSignature !== false) {
+    headers.set(
+      "x-signature",
+      buildSignature({
+        body: raw,
+        timestamp,
+        secret: options.secret ?? "test-streamerbot-secret",
+      }),
+    );
+  }
+
+  return new Request("http://localhost/api/internal/streamerbot", {
+    method: "POST",
+    headers,
+    body: raw,
+  });
+}
+
+describe("streamerbot route handlers", () => {
+  beforeEach(() => {
+    authMock.mockReset();
+    ingestStreamerbotEventMock.mockReset();
+    claimViewerLinkCodeFromStreamerbotMock.mockReset();
+    getViewerBalanceFromChatCommandMock.mockReset();
+    placeBetFromChatCommandMock.mockReset();
+    runStreamerbotCounterCommandMock.mockReset();
+    runDeathCounterCommandMock.mockReset();
+    runQuoteCommandFromChatMock.mockReset();
+    getPipetzPricingMock.mockReset();
+    triggerWheelSpinMock.mockReset();
+  });
+
+  it("rejects unsigned event requests", async () => {
+    const payload = {
+      eventId: "evt-1",
+      eventType: "presence_tick",
+      viewerExternalId: "yt-1",
+      amount: 5,
+      occurredAt: "2026-06-17T12:00:00.000Z",
+      payload: {},
+    };
+
+    const response = await eventsPost(signedRequest(payload, { includeSignature: false }));
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({ ok: false, error: "Invalid signature." });
+    expect(ingestStreamerbotEventMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts valid event requests", async () => {
+    const payload = {
+      eventId: "evt-1",
+      eventType: "presence_tick",
+      viewerExternalId: "yt-1",
+      amount: 5,
+      occurredAt: "2026-06-17T12:00:00.000Z",
+      payload: {},
+    };
+    ingestStreamerbotEventMock.mockResolvedValueOnce({ stored: true });
+
+    const response = await eventsPost(signedRequest(payload));
+
+    expect(ingestStreamerbotEventMock).toHaveBeenCalledWith(payload);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      data: { stored: true },
+    });
+  });
+
+  it("rejects unsigned link requests", async () => {
+    const response = await linkPost(
+      signedRequest({ linkCode: "abcd", viewerExternalId: "yt-1", youtubeDisplayName: "Ana" }, { includeSignature: false }),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({ ok: false, error: "Invalid signature." });
+    expect(claimViewerLinkCodeFromStreamerbotMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts valid link requests", async () => {
+    claimViewerLinkCodeFromStreamerbotMock.mockResolvedValueOnce({
+      viewer: { id: "viewer-1" },
+      googleAccountId: "google-1",
+      mergedSyntheticViewer: false,
+    });
+
+    const response = await linkPost(
+      signedRequest({ linkCode: "abcd", viewerExternalId: "yt-1", youtubeDisplayName: "Ana", youtubeHandle: "@ana" }),
+    );
+
+    expect(claimViewerLinkCodeFromStreamerbotMock).toHaveBeenCalledWith({
+      linkCode: "ABCD",
+      viewerExternalId: "yt-1",
+      youtubeDisplayName: "Ana",
+      youtubeHandle: "@ana",
+    });
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      data: {
+        viewerId: "viewer-1",
+        googleAccountId: "google-1",
+        mergedSyntheticViewer: false,
+        replyMessage: expect.any(String),
+      },
+    });
+  });
+
+  it("rejects unsigned points requests", async () => {
+    const response = await pointsPost(
+      signedRequest({ viewerExternalId: "yt-1", youtubeDisplayName: "Ana" }, { includeSignature: false }),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: "Invalid signature.",
+      replyMessage: expect.any(String),
+    });
+    expect(getViewerBalanceFromChatCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts valid points requests", async () => {
+    const payload = { viewerExternalId: "yt-1", youtubeDisplayName: "Ana", source: "streamerbot_chat" };
+    getViewerBalanceFromChatCommandMock.mockResolvedValueOnce({
+      viewer: { id: "viewer-1", youtubeChannelId: "yt-1", youtubeDisplayName: "Ana" },
+      balance: {
+        currentBalance: 120,
+        lifetimeEarned: 200,
+        lifetimeSpent: 80,
+        lastSyncedAt: "2026-06-17T12:00:00.000Z",
+      },
+    });
+
+    const response = await pointsPost(signedRequest({ viewerExternalId: "yt-1", youtubeDisplayName: "Ana" }));
+
+    expect(getViewerBalanceFromChatCommandMock).toHaveBeenCalledWith(payload);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      data: {
+        viewerId: "viewer-1",
+        viewerExternalId: "yt-1",
+        balance: 120,
+        lifetimeEarned: 200,
+        lifetimeSpent: 80,
+        lastSyncedAt: "2026-06-17T12:00:00.000Z",
+        replyMessage: expect.any(String),
+      },
+    });
+  });
+
+  it("returns a chat-friendly error when points lookup fails", async () => {
+    getViewerBalanceFromChatCommandMock.mockRejectedValueOnce(new Error("viewer_not_ready"));
+
+    const response = await pointsPost(signedRequest({ viewerExternalId: "yt-1", youtubeDisplayName: "Ana" }));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: "viewer_not_ready",
+      replyMessage: expect.any(String),
+    });
+  });
+
+  it("rejects unsigned bet requests", async () => {
+    const response = await placeBetPost(
+      signedRequest(
+        { viewerExternalId: "yt-1", youtubeDisplayName: "Ana", optionId: "opt-1", amount: 10 },
+        { includeSignature: false },
+      ),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: "Invalid signature.",
+      replyMessage: expect.any(String),
+    });
+    expect(placeBetFromChatCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts valid bet requests", async () => {
+    const payload = {
+      viewerExternalId: "yt-1",
+      youtubeDisplayName: "Ana",
+      optionId: "opt-1",
+      amount: 10,
+      source: "streamerbot_chat",
+    };
+    placeBetFromChatCommandMock.mockResolvedValueOnce({
+      bet: { id: "bet-1", question: "Vai dar certo?" },
+      option: { id: "opt-1", label: "Sim", sortOrder: 0 },
+      viewer: { id: "viewer-1", youtubeDisplayName: "Ana" },
+      entry: { amount: 10 },
+    });
+
+    const response = await placeBetPost(
+      signedRequest({ viewerExternalId: "yt-1", youtubeDisplayName: "Ana", optionId: "opt-1", amount: 10 }),
+    );
+
+    expect(placeBetFromChatCommandMock).toHaveBeenCalledWith(payload);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      data: {
+        betId: "bet-1",
+        optionId: "opt-1",
+        optionIndex: 1,
+        optionLabel: "Sim",
+        viewerId: "viewer-1",
+        viewerExternalId: "yt-1",
+        amount: 10,
+        replyMessage: expect.any(String),
+      },
+    });
+  });
+
+  it("rejects unsigned counter requests", async () => {
+    const response = await countersPost(
+      signedRequest(
+        { counterKey: "mortes", action: "increment", amount: 1, scopeType: "global", requestedBy: "Ana" },
+        { includeSignature: false },
+      ),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: "Invalid signature.",
+      replyMessage: expect.any(String),
+    });
+    expect(runStreamerbotCounterCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts valid counter requests", async () => {
+    const payload = {
+      counterKey: "mortes",
+      action: "increment",
+      amount: 1,
+      scopeType: "global",
+      requestedBy: "Ana",
+      source: "streamerbot_chat",
+      confirmReset: false,
+    };
+    runStreamerbotCounterCommandMock.mockResolvedValueOnce({
+      action: "increment",
+      count: 3,
+      mode: "demo",
+      counter: {
+        key: "mortes",
+        scopeType: "global",
+        scopeKey: null,
+        lastResetAt: null,
+        updatedAt: "2026-06-17T12:00:00.000Z",
+      },
+      replyMessage: "Ana, contador atualizado.",
+    });
+
+    const response = await countersPost(
+      signedRequest({ counterKey: "mortes", action: "increment", amount: 1, scopeType: "global", requestedBy: "Ana" }),
+    );
+
+    expect(runStreamerbotCounterCommandMock).toHaveBeenCalledWith(payload);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      data: {
+        action: "increment",
+        count: 3,
+        counterKey: "mortes",
+        scopeType: "global",
+        scopeKey: null,
+        lastResetAt: null,
+        updatedAt: "2026-06-17T12:00:00.000Z",
+        replyMessage: "Ana, contador atualizado.",
+      },
+    });
+  });
+
+  it("rejects unsigned death counter requests", async () => {
+    const response = await deathsPost(
+      signedRequest({ action: "increment", amount: 1, scopeType: "global", requestedBy: "Ana" }, { includeSignature: false }),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: "Invalid signature.",
+      replyMessage: expect.any(String),
+    });
+    expect(runDeathCounterCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts valid death counter requests", async () => {
+    const payload = {
+      action: "increment",
+      amount: 1,
+      scopeType: "global",
+      requestedBy: "Ana",
+      source: "streamerbot_chat",
+      confirmReset: false,
+    };
+    runDeathCounterCommandMock.mockResolvedValueOnce({
+      action: "increment",
+      count: 7,
+      mode: "demo",
+      counter: {
+        key: "death_counter",
+        scopeType: "global",
+        scopeKey: null,
+        lastResetAt: null,
+        updatedAt: "2026-06-17T12:00:00.000Z",
+      },
+      replyMessage: "Ana, mortes atualizadas.",
+    });
+
+    const response = await deathsPost(
+      signedRequest({ action: "increment", amount: 1, scopeType: "global", requestedBy: "Ana" }),
+    );
+
+    expect(runDeathCounterCommandMock).toHaveBeenCalledWith(payload);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      data: {
+        action: "increment",
+        count: 7,
+        counterKey: "death_counter",
+        scopeType: "global",
+        scopeKey: null,
+        lastResetAt: null,
+        updatedAt: "2026-06-17T12:00:00.000Z",
+        replyMessage: "Ana, mortes atualizadas.",
+      },
+    });
+  });
+
+  it("rejects unsigned quote requests", async () => {
+    const response = await quotesPost(signedRequest({ action: "get" }, { includeSignature: false }));
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: "Invalid signature.",
+      replyMessage: expect.any(String),
+    });
+    expect(runQuoteCommandFromChatMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts valid quote requests", async () => {
+    const payload = {
+      action: "get",
+      displayDurationSeconds: 12,
+      isModerator: false,
+      isBroadcaster: false,
+      isAdmin: false,
+      source: "streamerbot_chat",
+    };
+    runQuoteCommandFromChatMock.mockResolvedValueOnce({
+      action: "get",
+      quote: {
+        quoteNumber: 12,
+        body: "Teste de quote",
+      },
+    });
+
+    const response = await quotesPost(signedRequest({ action: "get" }));
+
+    expect(runQuoteCommandFromChatMock).toHaveBeenCalledWith(payload);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      replyMessage: 'Quote #12: "Teste de quote"',
+      data: {
+        action: "get",
+        quoteId: 12,
+        quote: {
+          quoteNumber: 12,
+          body: "Teste de quote",
+        },
+        overlay: null,
+        queued: null,
+        replyMessage: 'Quote #12: "Teste de quote"',
+      },
+    });
+  });
+
+  it("rejects unsigned wheel requests", async () => {
+    const response = await wheelPost(signedRequest({ requestedBy: "Ana" }, { includeSignature: false }));
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: "Invalid signature.",
+      replyMessage: expect.any(String),
+    });
+    expect(triggerWheelSpinMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts valid wheel requests", async () => {
+    triggerWheelSpinMock.mockResolvedValueOnce({
+      title: "Roleta",
+      spinDurationMs: 5200,
+      resultHoldSeconds: 30,
+      updatedAt: "2026-06-17T12:00:00.000Z",
+      updatedBy: null,
+      options: [],
+      lastSpin: {
+        spinId: "spin-1",
+        optionId: "opt-1",
+        label: "Prêmio",
+        color: "#41d1ff",
+        requestedBy: "Ana",
+        source: "streamerbot_chat",
+        startedAt: "2026-06-17T12:00:00.000Z",
+        spinDurationMs: 5200,
+        resultVisibleUntil: "2026-06-17T12:00:35.200Z",
+      },
+    });
+
+    const response = await wheelPost(signedRequest({ requestedBy: "Ana" }));
+
+    expect(triggerWheelSpinMock).toHaveBeenCalledWith({
+      requestedBy: "Ana",
+      source: "web",
+    });
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      data: {
+        config: expect.any(Object),
+        result: {
+          spinId: "spin-1",
+          optionId: "opt-1",
+          label: "Prêmio",
+        },
+        replyMessage: "Roleta girando: Prêmio.",
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add route-level tests for all internal bridge handlers covering missing signatures, invalid signatures, stale timestamps, and happy paths
- add route-level tests for Streamer.bot internal handlers, including the live `wheel` route and the `points` chat-reply error contract
- mark plan 003 as done in `plans/README.md`

## Why
These endpoints are the signed internal contracts used by the bridge daemon and Streamer.bot scripts. They previously had no route-level coverage, so regressions in signature verification or response shape could ship silently.

## Impact
The HTTP contract for the bridge and Streamer.bot internal routes is now characterized by tests, which reduces risk for follow-up work in plans 004 and 005.

## Validation
- `npx vitest run src/app/api/internal`
- `npm test`
- `npm run typecheck`
- `npx eslint src/app/api/internal/bridge/bridge-routes.test.ts src/app/api/internal/streamerbot/streamerbot-routes.test.ts`
- `npm run lint` currently fails because the existing untracked `.claude/.../.next/...` artifacts are being linted; this is unrelated to the committed changes

Closes #138