### PR TITLE
[codex] redesign betting page

### DIFF
--- a/src/app/(public)/apostas/page.tsx
+++ b/src/app/(public)/apostas/page.tsx
@@ -1,6 +1,48 @@
-﻿import { auth } from "@/auth";
+import Image from "next/image";
+import Link from "next/link";
+import type { LucideIcon } from "lucide-react";
+import { Coins, Radio, Trophy, WalletCards } from "lucide-react";
+
+import { auth } from "@/auth";
+import { AuthButtons } from "@/components/auth-buttons";
 import { BetList } from "@/components/bet-list";
+import { StickerBadge } from "@/components/sticker-badge";
 import { getViewerDashboard, listBets } from "@/lib/db/repository";
+import { formatPipetz } from "@/lib/utils";
+
+const LUDYLOPS_PROFILE_IMAGE = "/selfie2.png";
+
+type BetMetric = {
+  label: string;
+  value: string;
+  note: string;
+  Icon: LucideIcon;
+  className: string;
+};
+
+function MetricTile({ metric }: { metric: BetMetric }) {
+  const Icon = metric.Icon;
+
+  return (
+    <div className={`border border-[var(--color-ink)] p-4 text-[var(--color-accent-ink)] ${metric.className}`}>
+      <div className="flex items-center justify-between gap-3">
+        <p className="mono text-[10px] font-black uppercase tracking-[0.22em] text-[var(--color-accent-ink-soft)]">
+          {metric.label}
+        </p>
+        <Icon className="size-5 shrink-0" aria-hidden="true" />
+      </div>
+      <p
+        className="mt-3 text-3xl uppercase leading-none sm:text-4xl"
+        style={{ fontFamily: "var(--font-display)" }}
+      >
+        {metric.value}
+      </p>
+      <p className="mt-2 text-sm font-bold leading-5 text-[var(--color-accent-ink-soft)]">
+        {metric.note}
+      </p>
+    </div>
+  );
+}
 
 export default async function ApostasPage() {
   const session = await auth();
@@ -9,35 +51,149 @@ export default async function ApostasPage() {
     listBets(activeViewerId),
     activeViewerId ? getViewerDashboard(activeViewerId) : Promise.resolve(null),
   ]);
-  const activeBets = bets.filter((b) => b.status === "open" || b.status === "locked");
-  const resolvedBets = bets.filter((b) => b.status === "resolved" || b.status === "cancelled");
+
+  const openBets = bets.filter((bet) => bet.status === "open");
+  const activeBets = bets.filter((bet) => bet.status === "open" || bet.status === "locked");
+  const resolvedBets = bets.filter((bet) => bet.status === "resolved" || bet.status === "cancelled");
+  const totalActivePool = activeBets.reduce((sum, bet) => sum + bet.totalPool, 0);
+  const viewerBalance = dashboard?.balance.currentBalance ?? null;
+  const loggedIn = Boolean(session?.user);
   const canBet = Boolean(activeViewerId && dashboard?.viewer.isLinked);
+  const viewerName = dashboard?.viewer.youtubeDisplayName ?? session?.user?.name ?? null;
+
+  const metrics: BetMetric[] = [
+    {
+      label: "abertas",
+      value: formatPipetz(openBets.length),
+      note: "pools aceitando entrada agora",
+      Icon: Radio,
+      className: "bg-[var(--color-pink)]",
+    },
+    {
+      label: "em jogo",
+      value: formatPipetz(totalActivePool),
+      note: "pipetz nos pools ativos",
+      Icon: Coins,
+      className: "bg-[var(--color-blue)]",
+    },
+    {
+      label: "saldo",
+      value: typeof viewerBalance === "number" ? formatPipetz(viewerBalance) : "--",
+      note: canBet ? "disponível para apostar" : "entre e vincule o chat",
+      Icon: WalletCards,
+      className: "bg-[var(--color-mint)]",
+    },
+    {
+      label: "histórico",
+      value: formatPipetz(resolvedBets.length),
+      note: "apostas encerradas",
+      Icon: Trophy,
+      className: "bg-[var(--color-purple)]",
+    },
+  ];
+
+  const statusTitle = canBet
+    ? viewerName
+      ? `${viewerName}, você está liberada para apostar.`
+      : "Você está liberada para apostar."
+    : loggedIn
+      ? "Falta vincular sua conta ao chat."
+      : "Entre com Google para apostar pelo site.";
+  const statusBody = canBet
+    ? "Escolha uma opção aberta, informe o valor e acompanhe o pool mudar ao vivo."
+    : loggedIn
+      ? "A vinculação confirma qual viewer do chat recebe débitos, retornos e reembolsos."
+      : "Depois do login, vincule seu canal do YouTube para conectar saldo, chat e apostas.";
 
   return (
-    <div className="flex w-full flex-col">
-      <section className="landing-plane surface-hero relative overflow-hidden py-8 sm:py-10">
-        <div className="bg-dots-light pointer-events-none absolute inset-0 opacity-20" />
-        <div className="relative mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
-          <div>
+    <div className="flex w-full max-w-[100vw] flex-col overflow-x-hidden">
+      <section className="landing-plane surface-hero relative overflow-hidden py-5 sm:py-6">
+        <div className="bg-micro-grid pointer-events-none absolute inset-0 opacity-30" />
+        <StickerBadge
+          variant="spark"
+          className="absolute right-5 top-5 hidden size-16 rotate-[10deg] lg:inline-flex"
+          label="brilho decorativo"
+        />
+
+        <div className="relative mx-auto grid w-full max-w-[100vw] gap-8 px-4 sm:px-6 lg:max-w-[1520px] lg:grid-cols-[1.08fr_0.92fr] lg:items-center lg:px-10">
+          <div className="min-w-0 max-w-[22rem] sm:max-w-none">
             <h1
-              className="text-4xl uppercase sm:text-6xl lg:text-7xl"
+              className="max-w-3xl break-words text-balance text-4xl uppercase leading-[0.9] sm:text-6xl lg:text-[4.45rem]"
               style={{ fontFamily: "var(--font-display)" }}
             >
-              Aposte pipetz nos desafios da live.
+              Entre no pool da live.
             </h1>
-            <p className="mt-4 max-w-3xl text-sm leading-7 text-[var(--color-ink-soft)] sm:text-base">
-              Escolha um lado, coloque seus pipetz e torça. Se acertar, leva uma parte do pool!
+
+            <p className="mt-5 max-w-2xl break-words text-pretty text-base leading-8 text-[var(--color-ink-soft)] sm:text-lg">
+              Palpite junto com o chat usando os pipetz da sua conta. Se vencer, o retorno é
+              calculado pelo pool encerrado; se a rodada for cancelada, os valores voltam para os viewers.
             </p>
+
+            <div className="mt-4 border-l-[6px] border-[var(--color-ink)] bg-[var(--color-paper)] p-4">
+              <p className="text-base font-black uppercase leading-6">{statusTitle}</p>
+              <p className="mt-2 max-w-xl text-sm font-bold leading-6 text-[var(--color-ink-soft)]">
+                {statusBody}
+              </p>
+            </div>
+
+            <div className="mt-5 flex flex-wrap items-center gap-3">
+              {canBet ? (
+                <Link href="/me" className="btn-brutal ink-button px-6 py-3 text-sm">
+                  <WalletCards className="size-4" aria-hidden="true" />
+                  Meus Pipetz
+                </Link>
+              ) : loggedIn ? (
+                <Link href="/me" className="btn-brutal accent-button px-6 py-3 text-sm">
+                  <WalletCards className="size-4" aria-hidden="true" />
+                  Vincular Conta
+                </Link>
+              ) : (
+                <AuthButtons />
+              )}
+              <Link href="#apostas-abertas" className="btn-brutal bg-[var(--color-paper)] px-6 py-3 text-sm">
+                <Radio className="size-4" aria-hidden="true" />
+                Ver Pools
+              </Link>
+            </div>
+          </div>
+
+          <div className="relative mx-auto min-h-[260px] w-full max-w-[22rem] sm:min-h-[330px] sm:max-w-none">
+            <StickerBadge
+              variant="heart"
+              className="absolute -left-2 top-6 z-20 size-20 rotate-[-10deg] sm:left-2"
+              label="coração decorativo"
+            />
+            <div className="absolute inset-x-8 bottom-0 top-8 border-[3px] border-[var(--color-ink)] bg-[var(--color-pink)] shadow-[8px_8px_0_var(--shadow-color)] sm:inset-x-16" />
+            <div className="absolute inset-x-0 bottom-0 mx-auto w-[72%] max-w-[360px]">
+              <Image
+                src={LUDYLOPS_PROFILE_IMAGE}
+                alt="Foto da Ludylops"
+                width={1100}
+                height={1100}
+                className="h-auto w-full contrast-125"
+                preload
+              />
+            </div>
           </div>
         </div>
       </section>
 
+      <section className="landing-plane landing-divider bg-[var(--color-paper)] py-6">
+        <div className="mx-auto grid w-full max-w-[100vw] gap-3 px-4 sm:grid-cols-2 sm:px-6 lg:max-w-[1520px] lg:grid-cols-4 lg:px-10">
+          {metrics.map((metric) => (
+            <MetricTile key={metric.label} metric={metric} />
+          ))}
+        </div>
+      </section>
+
       <BetList
+        id="apostas-abertas"
         bets={activeBets}
-        title="Apostas abertas"
-        emptyMessage="Nenhuma aposta rolando agora. Aguarde a proxima live!"
-        viewerBalance={dashboard?.balance.currentBalance}
-        loggedIn={Boolean(session?.user)}
+        title="Pools da live"
+        subtitle="Apostas abertas aceitam entrada pelo site; travadas ficam aguardando resultado."
+        emptyMessage="Nenhuma aposta rolando agora. Aguarde a próxima live!"
+        viewerBalance={viewerBalance}
+        loggedIn={loggedIn}
         canBet={canBet}
         fullWidth
         sectionClassName="bg-[var(--color-paper-pink)]"
@@ -46,10 +202,11 @@ export default async function ApostasPage() {
       {resolvedBets.length > 0 ? (
         <BetList
           bets={resolvedBets}
-          title="Apostas encerradas"
+          title="Histórico recente"
+          subtitle="Resultados, reembolsos e retornos ficam visíveis depois que a rodada fecha."
           emptyMessage=""
-          viewerBalance={dashboard?.balance.currentBalance}
-          loggedIn={Boolean(session?.user)}
+          viewerBalance={viewerBalance}
+          loggedIn={loggedIn}
           canBet={canBet}
           fullWidth
           sectionClassName="bg-[var(--color-sky)]"
@@ -58,4 +215,3 @@ export default async function ApostasPage() {
     </div>
   );
 }
-

--- a/src/components/bet-card.tsx
+++ b/src/components/bet-card.tsx
@@ -1,49 +1,117 @@
 "use client";
 
-import { useEffect, useState, useTransition } from "react";
+import { type FormEvent, useEffect, useId, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
+import type { LucideIcon } from "lucide-react";
+import { Ban, CheckCircle2, Clock3, Lock, Radio, Send, Trophy, WalletCards } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import type { BetWithOptionsRecord } from "@/lib/types";
-import { formatPipetz } from "@/lib/utils";
+import type { BetStatus, BetWithOptionsRecord } from "@/lib/types";
+import { cn, formatPipetz } from "@/lib/utils";
 
 function mapError(message: string) {
   switch (message) {
     case "saldo_insuficiente":
-      return "Saldo insuficiente.";
+      return "Saldo insuficiente. Aposte um valor menor ou junte mais pipetz.";
     case "aposta_ja_registrada":
       return "Você já apostou nesta rodada.";
     case "bet_not_open":
-      return "A aposta não está aberta.";
+      return "A aposta não está aberta. Atualize a página para ver o estado mais recente.";
     case "bet_closed":
-      return "A janela de aposta ja fechou.";
+      return "A janela de aposta já fechou. Atualize a página para ver o resultado.";
     case "invalid_option":
-      return "Opção inválida.";
+      return "Opção inválida. Escolha uma opção disponível.";
     case "invalid_amount":
-      return "Valor inválido.";
+      return "Valor inválido. Digite um número inteiro de pipetz.";
     default:
       return message;
   }
 }
 
-const optionBgs = [
-  "surface-card",
-  "surface-card-alt",
-  "surface-card-accent",
-  "bg-[var(--color-paper)]",
-  "surface-card",
-  "surface-card-alt",
-];
+type StatusMeta = {
+  label: string;
+  Icon: LucideIcon;
+  className: string;
+};
 
-const barColors = [
-  "var(--color-purple)",
+const statusMeta: Record<BetStatus, StatusMeta> = {
+  draft: {
+    label: "Rascunho",
+    Icon: Clock3,
+    className: "bg-[var(--color-paper)] text-[var(--color-ink)]",
+  },
+  open: {
+    label: "Aberta",
+    Icon: Radio,
+    className: "bg-[var(--color-mint)] text-[var(--color-accent-ink)]",
+  },
+  locked: {
+    label: "Travada",
+    Icon: Lock,
+    className: "bg-[var(--color-yellow)] text-[var(--color-accent-ink)]",
+  },
+  resolved: {
+    label: "Resolvida",
+    Icon: Trophy,
+    className: "bg-[var(--color-purple)] text-[var(--color-accent-ink)]",
+  },
+  cancelled: {
+    label: "Cancelada",
+    Icon: Ban,
+    className: "bg-[var(--color-rose)] text-[var(--color-ink)]",
+  },
+};
+
+const closedStatusMeta: StatusMeta = {
+  label: "Fechada",
+  Icon: Lock,
+  className: "bg-[var(--color-yellow)] text-[var(--color-accent-ink)]",
+};
+
+const optionColors = [
   "var(--color-blue)",
+  "var(--color-purple)",
   "var(--color-pink)",
   "var(--color-mint)",
   "var(--color-periwinkle)",
   "var(--color-yellow)",
 ];
+
+const optionBackgrounds = [
+  "bg-[var(--color-paper)]",
+  "bg-[var(--surface-card-alt)]",
+  "bg-[var(--surface-card-accent)]",
+  "bg-[var(--color-sky)]",
+];
+
+function formatBetDeadline(value: string) {
+  return new Intl.DateTimeFormat("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: "America/Sao_Paulo",
+  }).format(new Date(value));
+}
+
+function formatRemaining(closesAt: string, nowMs: number | null) {
+  if (nowMs === null) {
+    return "Atualizando…";
+  }
+
+  const remainingMinutes = Math.ceil((new Date(closesAt).getTime() - nowMs) / 60_000);
+  if (remainingMinutes <= 0) {
+    return "Janela fechada";
+  }
+  if (remainingMinutes < 60) {
+    return `${remainingMinutes} min restantes`;
+  }
+
+  const hours = Math.floor(remainingMinutes / 60);
+  const minutes = remainingMinutes % 60;
+  return minutes > 0 ? `${hours} h ${minutes} min restantes` : `${hours} h restantes`;
+}
 
 export function BetCard({
   bet,
@@ -57,10 +125,12 @@ export function BetCard({
   canBet?: boolean;
 }) {
   const router = useRouter();
+  const amountId = useId();
+  const feedbackId = `${amountId}-feedback`;
   const [draftSelectedOption, setDraftSelectedOption] = useState<string | null>(null);
   const [amount, setAmount] = useState("");
   const [feedback, setFeedback] = useState<string | null>(null);
-  const [nowMs, setNowMs] = useState(() => Date.now());
+  const [nowMs, setNowMs] = useState<number | null>(null);
   const [isPending, startTransition] = useTransition();
 
   useEffect(() => {
@@ -68,226 +138,329 @@ export function BetCard({
       return;
     }
 
-    const intervalId = window.setInterval(() => {
+    const updateNow = () => {
       setNowMs(Date.now());
-    }, 60_000);
+    };
+    const timeoutId = window.setTimeout(updateNow, 0);
+    const intervalId = window.setInterval(updateNow, 30_000);
 
     return () => {
+      window.clearTimeout(timeoutId);
       window.clearInterval(intervalId);
     };
   }, [bet.status]);
 
-  const isOpen = bet.status === "open" && new Date(bet.closesAt).getTime() > nowMs;
+  const closesAtMs = new Date(bet.closesAt).getTime();
+  const isOpen = bet.status === "open" && (nowMs === null || closesAtMs > nowMs);
   const isResolved = bet.status === "resolved";
+  const isCancelled = bet.status === "cancelled";
   const hasViewerBet = Boolean(bet.viewerPosition);
   const selectedOption = bet.viewerPosition?.optionId ?? draftSelectedOption;
   const selectedOptionLabel =
     bet.options.find((option) => option.id === selectedOption)?.label ?? "opção selecionada";
-  function handlePlace() {
-    const parsed = Number.parseInt(amount, 10);
-    if (!selectedOption || !Number.isInteger(parsed) || parsed <= 0) {
-      setFeedback("Digite um valor valido.");
+  const viewerPositionLabel =
+    bet.options.find((option) => option.id === bet.viewerPosition?.optionId)?.label ?? "opção";
+  const totalPool = bet.totalPool || bet.options.reduce((sum, option) => sum + option.poolAmount, 0);
+  const displayStatus = bet.status === "open" && !isOpen ? closedStatusMeta : statusMeta[bet.status];
+  const StatusIcon = displayStatus.Icon;
+  const canSelectOption = isOpen && canBet && !hasViewerBet;
+  const canAddToExistingBet = isOpen && canBet && hasViewerBet;
+  const showAmountForm = isOpen && canBet && Boolean(selectedOption);
+  const cardBackground = isCancelled
+    ? "var(--color-rose)"
+    : isResolved
+      ? "var(--color-lilac)"
+      : "var(--color-paper)";
+
+  function handlePlace(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const normalizedAmount = amount.trim();
+    const parsed = Number.parseInt(normalizedAmount, 10);
+    if (!selectedOption) {
+      setFeedback("Escolha uma opção antes de apostar.");
+      return;
+    }
+    if (!/^\d+$/.test(normalizedAmount) || !Number.isInteger(parsed) || parsed <= 0) {
+      setFeedback("Digite um número inteiro de pipetz.");
+      return;
+    }
+    if (typeof viewerBalance === "number" && parsed > viewerBalance) {
+      setFeedback(`Seu saldo atual é ${formatPipetz(viewerBalance)} pipetz. Aposte um valor menor.`);
       return;
     }
 
     setFeedback(null);
     startTransition(async () => {
-      const response = await fetch(`/api/me/bets/${bet.id}`, {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({
-          optionId: selectedOption,
-          amount: parsed,
-          source: "web",
-        }),
-      });
+      try {
+        const response = await fetch(`/api/me/bets/${bet.id}`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            optionId: selectedOption,
+            amount: parsed,
+            source: "web",
+          }),
+        });
 
-      const payload = (await response.json()) as { ok: boolean; error?: string };
-      if (!response.ok || !payload.ok) {
-        setFeedback(mapError(payload.error ?? "Falha ao registrar aposta."));
-        return;
+        const payload = (await response.json()) as { ok: boolean; error?: string };
+        if (!response.ok || !payload.ok) {
+          setFeedback(mapError(payload.error ?? "Falha ao registrar aposta."));
+          return;
+        }
+
+        setAmount("");
+        setFeedback(hasViewerBet ? "Valor adicionado à sua aposta." : "Aposta registrada.");
+        router.refresh();
+      } catch {
+        setFeedback("Não consegui registrar a aposta agora. Tente novamente.");
       }
-
-      setAmount("");
-      setFeedback(hasViewerBet ? "Aposta reforcada." : "Aposta registrada.");
-      router.refresh();
     });
   }
 
   return (
-    <div
-      className="panel-inset p-5"
+    <article
+      className="panel-inset flex h-full flex-col p-5"
       style={{
-        backgroundColor: isResolved ? "var(--color-lilac)" : "var(--color-paper)",
+        backgroundColor: cardBackground,
       }}
     >
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div>
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className={cn(
+                "inline-flex items-center gap-2 border border-[var(--color-ink)] px-3 py-1.5 text-xs font-black uppercase tracking-[0.12em]",
+                displayStatus.className,
+              )}
+            >
+              <StatusIcon className="size-4" aria-hidden="true" />
+              {displayStatus.label}
+            </span>
+            <span className="mono text-[11px] font-black uppercase tracking-[0.18em] text-[var(--color-ink-soft)]">
+              fecha {formatBetDeadline(bet.closesAt)} BRT
+            </span>
+          </div>
+
           <h3
-            className="text-xl font-bold"
+            className="mt-3 text-pretty break-words text-2xl uppercase leading-[1.05]"
             style={{ fontFamily: "var(--font-display)" }}
           >
             {bet.question}
           </h3>
         </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <div className="px-3 py-1.5 text-xs font-bold uppercase tracking-[0.06em] text-[var(--color-ink)]">
-            Pool: {formatPipetz(bet.totalPool)}
+
+        <div className="grid shrink-0 grid-cols-2 gap-2 sm:min-w-44 sm:grid-cols-1">
+          <div className="border border-[var(--color-ink)] bg-[var(--color-paper)] px-3 py-2">
+            <p className="mono text-[10px] font-black uppercase tracking-[0.16em] text-[var(--color-ink-soft)]">
+              pool
+            </p>
+            <p className="mt-1 text-lg font-black leading-none">{formatPipetz(totalPool)}</p>
           </div>
           {typeof viewerBalance === "number" ? (
-            <div className="retro-label neutral-chip">
-              saldo {formatPipetz(viewerBalance)}
+            <div className="border border-[var(--color-ink)] bg-[var(--color-paper)] px-3 py-2">
+              <p className="mono flex items-center gap-1 text-[10px] font-black uppercase tracking-[0.16em] text-[var(--color-ink-soft)]">
+                <WalletCards className="size-3.5" aria-hidden="true" />
+                saldo
+              </p>
+              <p className="mt-1 text-lg font-black leading-none">{formatPipetz(viewerBalance)}</p>
             </div>
           ) : null}
         </div>
-      </div>
+      </header>
 
-      {bet.options.length > 0 && bet.totalPool > 0 ? (
-        <div className="mt-4 flex h-4 overflow-hidden rounded-full border-2 border-[var(--color-ink)]">
-          {bet.options.map((opt, i) => {
-            const pct = Math.max((opt.poolAmount / bet.totalPool) * 100, 2);
-            return (
-              <div
-                key={opt.id}
-                className="relative flex items-center justify-center overflow-hidden transition-all duration-300"
-                style={{
-                  width: `${pct}%`,
-                  backgroundColor: barColors[i % barColors.length],
-                }}
-              >
-                {pct > 15 ? (
-                  <span className="mono text-[9px] font-bold text-[var(--color-ink)]">
-                    {Math.round(pct)}%
-                  </span>
-                ) : null}
-              </div>
-            );
-          })}
+      {isOpen ? (
+        <div className="mt-4 flex flex-wrap items-center gap-2 text-[var(--color-ink-soft)]">
+          <Clock3 className="size-4 shrink-0" aria-hidden="true" />
+          <span className="text-sm font-black uppercase tracking-[0.08em]">
+            {formatRemaining(bet.closesAt, nowMs)}
+          </span>
+        </div>
+      ) : bet.status === "locked" ? (
+        <p className="mt-4 text-sm font-bold leading-6 text-[var(--color-ink-soft)]">
+          A rodada está travada e aguardando resultado.
+        </p>
+      ) : null}
+
+      {bet.options.length > 0 && totalPool > 0 ? (
+        <div className="mt-5 h-3 overflow-hidden border border-[var(--color-ink)] bg-[var(--color-paper)]" aria-hidden="true">
+          <div className="flex h-full">
+            {bet.options.map((option, index) => {
+              const percentage = Math.max((option.poolAmount / totalPool) * 100, 2);
+              return (
+                <div
+                  key={option.id}
+                  className="h-full transition-[width,background-color] duration-300"
+                  style={{
+                    width: `${percentage}%`,
+                    backgroundColor: optionColors[index % optionColors.length],
+                  }}
+                />
+              );
+            })}
+          </div>
         </div>
       ) : null}
 
-      <div className="mt-3 grid gap-1.5">
-        {bet.options.map((opt, i) => {
-          const isWinner = isResolved && bet.winningOptionId === opt.id;
-          const isViewerPick = bet.viewerPosition?.optionId === opt.id;
-          const bgClass = optionBgs[i % optionBgs.length];
-          const selectable = isOpen && canBet && !hasViewerBet;
-
-          return (
-            <button
-              key={opt.id}
-              type="button"
-              disabled={!selectable}
-              onClick={() => setDraftSelectedOption(selectedOption === opt.id ? null : opt.id)}
-              className={`card-flat relative flex items-center justify-between overflow-hidden !border !border-[1px] p-3 text-left ${
-                isWinner
-                  ? "!border-[var(--color-ink)] bg-[var(--color-mint)] text-[var(--color-accent-ink)] ring-1 ring-[var(--color-ink)]"
-                  : selectedOption === opt.id || isViewerPick
-                    ? "!border-[var(--color-purple-bold)] bg-[var(--color-lavender)] ring-1 ring-[var(--color-purple-bold)]"
-                    : bgClass
-              } ${selectable ? "cursor-pointer" : "cursor-default"}`}
-            >
-              <div className="relative flex items-center gap-2">
-                <span className="rounded-[var(--radius)] border-2 border-[var(--color-ink)] bg-transparent px-2 py-0.5 text-[10px] font-black uppercase">
-                  #{i + 1}
+      <div className="mt-4 grid gap-2">
+        {bet.options.map((option, index) => {
+          const isWinner = isResolved && bet.winningOptionId === option.id;
+          const isViewerPick = bet.viewerPosition?.optionId === option.id;
+          const isSelected = selectedOption === option.id || isViewerPick;
+          const percentage = totalPool > 0 ? Math.round((option.poolAmount / totalPool) * 100) : 0;
+          const baseClassName = cn(
+            "relative flex min-h-16 items-center justify-between gap-4 border border-[var(--color-ink)] px-3 py-3 text-left text-[var(--color-ink)] transition-[background-color,box-shadow,filter,transform] duration-[var(--snap)]",
+            isWinner
+              ? "bg-[var(--color-mint)] text-[var(--color-accent-ink)]"
+              : isSelected
+                ? "bg-[var(--color-lavender)]"
+                : optionBackgrounds[index % optionBackgrounds.length],
+            canSelectOption &&
+              "hover:shadow-[3px_3px_0_var(--shadow-color)] hover:brightness-95 focus-visible:outline-[3px] focus-visible:outline-offset-2 focus-visible:outline-[var(--color-purple-mid)]",
+          );
+          const rowContent = (
+            <>
+              <div className="flex min-w-0 items-center gap-3">
+                <span className="mono shrink-0 border border-[var(--color-ink)] bg-[var(--color-paper)] px-2 py-1 text-[10px] font-black uppercase text-[var(--color-ink)]">
+                  #{index + 1}
                 </span>
                 <span
-                  className="inline-block h-3 w-3 shrink-0 rounded-full border-2 border-[var(--color-ink)]"
+                  className="size-4 shrink-0 border border-[var(--color-ink)]"
                   style={{
-                    backgroundColor: barColors[i % barColors.length],
+                    backgroundColor: optionColors[index % optionColors.length],
                   }}
+                  aria-hidden="true"
                 />
-                <span className="font-bold">
+                <span className="min-w-0 break-words text-base font-black leading-5">
                   {isWinner ? "Venceu: " : ""}
-                  {opt.label}
+                  {option.label}
                 </span>
               </div>
 
-              <div className="relative flex items-center gap-2">
+              <div className="flex shrink-0 flex-col items-end gap-1 text-right">
+                <span className="mono text-[10px] font-black uppercase tracking-[0.14em] text-[var(--color-ink-soft)]">
+                  {percentage}%
+                </span>
+                <span className="text-sm font-black">{formatPipetz(option.poolAmount)}</span>
                 {isViewerPick ? (
-                  <span className="mono text-[10px] uppercase tracking-[0.16em] text-[var(--color-ink-soft)]">
+                  <span className="inline-flex items-center gap-1 text-[10px] font-black uppercase tracking-[0.12em] text-[var(--color-ink-soft)]">
+                    <CheckCircle2 className="size-3.5" aria-hidden="true" />
                     sua aposta
                   </span>
                 ) : null}
-                <span className="text-xs font-bold">
-                  {formatPipetz(opt.poolAmount)}
-                </span>
               </div>
+            </>
+          );
+
+          return canSelectOption ? (
+            <button
+              key={option.id}
+              type="button"
+              onClick={() => setDraftSelectedOption(selectedOption === option.id ? null : option.id)}
+              className={baseClassName}
+              aria-pressed={selectedOption === option.id}
+              aria-label={`Escolher opção ${index + 1}: ${option.label}`}
+            >
+              {rowContent}
             </button>
+          ) : (
+            <div key={option.id} className={baseClassName}>
+              {rowContent}
+            </div>
           );
         })}
       </div>
 
       {isOpen ? (
-        <p className="mono mt-3 text-[11px] uppercase tracking-[0.14em] text-[var(--color-ink-soft)]">
-          chat: !bet &lt;opção&gt; &lt;valor&gt; ex.: !bet 1 100
-        </p>
+        <div className="mt-4 flex flex-wrap items-center gap-2 text-[var(--color-ink-soft)]">
+          <span className="mono text-[10px] font-black uppercase tracking-[0.18em]">
+            também no chat
+          </span>
+          <code
+            className="border border-[var(--color-ink)] bg-[var(--color-paper)] px-2 py-1 text-xs font-black text-[var(--color-ink)]"
+            translate="no"
+          >
+            !bet 1 100
+          </code>
+        </div>
       ) : null}
 
       {bet.viewerPosition ? (
-        <div className="surface-card mt-4 rounded-[var(--radius)] p-3 text-sm text-[var(--color-ink)]">
-          <p className="font-bold uppercase">Sua posicao</p>
-          <p className="mt-1">
-            {formatPipetz(bet.viewerPosition.amount)} em{" "}
-            {bet.options.find((option) => option.id === bet.viewerPosition?.optionId)?.label ?? "opção"}
+        <div className="mt-5 border-t border-dashed border-[var(--color-ink)] pt-4 text-sm text-[var(--color-ink)]">
+          <p className="font-black uppercase tracking-[0.08em]">Sua posição</p>
+          <p className="mt-2 font-bold leading-6">
+            {formatPipetz(bet.viewerPosition.amount)} pipetz em {viewerPositionLabel}
           </p>
-          {isOpen && canBet ? (
-            <p className="mt-1 text-[var(--color-ink-soft)]">
+          {canAddToExistingBet ? (
+            <p className="mt-1 leading-6 text-[var(--color-ink-soft)]">
               Você pode adicionar mais pipetz nessa mesma opção até a janela fechar.
             </p>
           ) : null}
           {bet.viewerPosition.payoutAmount !== null ? (
-            <p className="mt-1 text-[var(--color-ink-soft)]">
-              retorno: {formatPipetz(bet.viewerPosition.payoutAmount)}
+            <p className="mt-1 leading-6 text-[var(--color-ink-soft)]">
+              Retorno: {formatPipetz(bet.viewerPosition.payoutAmount)} pipetz
             </p>
           ) : null}
           {bet.viewerPosition.refundedAt ? (
-            <p className="mt-1 text-[var(--color-ink-soft)]">aposta reembolsada</p>
+            <p className="mt-1 leading-6 text-[var(--color-ink-soft)]">Aposta reembolsada.</p>
           ) : null}
         </div>
       ) : null}
 
-      {isOpen && selectedOption && canBet ? (
-        <div className="surface-card mt-4 flex flex-wrap items-center gap-3 rounded-[var(--radius)] border-2 border-dashed border-[var(--color-ink)] p-3">
-          <span className="text-xs font-bold uppercase tracking-wide text-[var(--color-ink-soft)]">
-            {hasViewerBet ? `Adicionar em ${selectedOptionLabel}?` : "Quanto apostar?"}
-          </span>
-          <Input
-            type="number"
-            min="1"
-            placeholder="Pipetz"
-            value={amount}
-            onChange={(e) => setAmount(e.target.value)}
-            className="w-28 px-3 py-2"
-          />
-          <Button
-            type="button"
-            onClick={handlePlace}
-            disabled={isPending}
-            size="sm"
-          >
-            {isPending ? "Enviando..." : hasViewerBet ? "Adicionar mais" : "Apostar"}
-          </Button>
-        </div>
+      {showAmountForm ? (
+        <form
+          onSubmit={handlePlace}
+          className="mt-5 border-t border-dashed border-[var(--color-ink)] pt-4"
+        >
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+            <label htmlFor={amountId} className="flex min-w-0 flex-1 flex-col gap-2">
+              <span className="text-xs font-black uppercase tracking-[0.12em] text-[var(--color-ink-soft)]">
+                {hasViewerBet ? `Adicionar em ${selectedOptionLabel}` : "Valor em pipetz"}
+              </span>
+              <Input
+                id={amountId}
+                name={`bet-${bet.id}-amount`}
+                type="number"
+                min="1"
+                inputMode="numeric"
+                autoComplete="off"
+                placeholder="100…"
+                value={amount}
+                onChange={(event) => setAmount(event.target.value)}
+                aria-describedby={feedback ? feedbackId : undefined}
+                className="max-w-40 px-3 py-2"
+              />
+            </label>
+            <Button type="submit" disabled={isPending} size="sm">
+              <Send className="size-4" aria-hidden="true" />
+              {isPending ? "Enviando…" : hasViewerBet ? "Adicionar" : "Apostar"}
+            </Button>
+          </div>
+        </form>
       ) : null}
 
-      {!loggedIn ? (
-        <p className="mt-3 text-xs font-bold uppercase tracking-[0.16em] text-[var(--color-ink-soft)]">
-          faça login para apostar
+      {isOpen && !loggedIn ? (
+        <p className="mt-4 border-t border-dashed border-[var(--color-ink)] pt-4 text-xs font-black uppercase leading-5 tracking-[0.14em] text-[var(--color-ink-soft)]">
+          Entre com Google para apostar pelo site.
         </p>
       ) : null}
-      {loggedIn && !canBet && !bet.viewerPosition ? (
-        <p className="mt-3 text-xs font-bold uppercase tracking-[0.16em] text-[var(--color-ink-soft)]">
-          vincule sua conta ao chat para apostar
+      {isOpen && loggedIn && !canBet && !bet.viewerPosition ? (
+        <p className="mt-4 border-t border-dashed border-[var(--color-ink)] pt-4 text-xs font-black uppercase leading-5 tracking-[0.14em] text-[var(--color-ink-soft)]">
+          Vincule sua conta ao chat para apostar.
         </p>
       ) : null}
       {feedback ? (
-        <div className="sticker sticker-pop accent-chip mt-3 inline-flex px-3 py-1.5 text-xs">
+        <div
+          id={feedbackId}
+          role="status"
+          aria-live="polite"
+          className="mt-4 inline-flex w-fit border border-[var(--color-ink)] bg-[var(--color-purple)] px-3 py-2 text-xs font-black uppercase tracking-[0.08em] text-[var(--color-accent-ink)]"
+        >
           {feedback}
         </div>
       ) : null}
-    </div>
+    </article>
   );
 }

--- a/src/components/bet-list.tsx
+++ b/src/components/bet-list.tsx
@@ -4,6 +4,7 @@ import type { BetWithOptionsRecord } from "@/lib/types";
 export function BetList({
   bets,
   title,
+  subtitle,
   emptyMessage,
   accentBg,
   viewerBalance,
@@ -11,9 +12,11 @@ export function BetList({
   canBet = false,
   fullWidth = false,
   sectionClassName,
+  id,
 }: {
   bets: BetWithOptionsRecord[];
   title: string;
+  subtitle?: string;
   emptyMessage: string;
   accentBg?: string;
   viewerBalance?: number | null;
@@ -21,35 +24,58 @@ export function BetList({
   canBet?: boolean;
   fullWidth?: boolean;
   sectionClassName?: string;
+  id?: string;
 }) {
   if (bets.length === 0 && emptyMessage) {
+    const emptyState = (
+      <div className="border-l-[6px] border-[var(--color-ink)] bg-[var(--color-paper)] p-5">
+        <p className="text-base font-black uppercase leading-6 text-[var(--color-ink)]">
+          {emptyMessage}
+        </p>
+        <p className="mt-2 max-w-xl text-sm font-bold leading-6 text-[var(--color-ink-soft)]">
+          Quando uma aposta abrir, ela aparece aqui com opções, pool e estado de participação.
+        </p>
+      </div>
+    );
+
     if (fullWidth) {
       return (
         <section
-          className={`landing-plane landing-divider py-8 sm:py-10 ${sectionClassName ?? accentBg ?? "bg-[var(--color-lilac)]"}`}
+          id={id}
+          className={`landing-plane landing-divider scroll-mt-28 py-8 sm:py-10 ${sectionClassName ?? accentBg ?? "bg-[var(--color-lilac)]"}`}
         >
-          <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
-            <p className="text-sm font-bold text-[var(--color-ink-soft)]">{emptyMessage}</p>
-          </div>
+          <div className="mx-auto w-full max-w-[1520px] px-4 sm:px-6 lg:px-10">{emptyState}</div>
         </section>
       );
     }
 
-    return (
-      <div className={`panel p-6 text-center ${accentBg ?? "bg-[var(--color-lilac)]"}`}>
-        <p className="text-sm font-bold text-[var(--color-ink-soft)]">{emptyMessage}</p>
-      </div>
-    );
+    return <div className={`p-6 ${accentBg ?? "bg-[var(--color-lilac)]"}`}>{emptyState}</div>;
   }
 
   if (bets.length === 0) return null;
 
   const header = (
     <>
-      <h2 className="text-2xl font-bold uppercase" style={{ fontFamily: "var(--font-display)" }}>
-        {title}
-      </h2>
-      <div className="mt-5 grid gap-4">
+      <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+        <div className="min-w-0">
+          <h2
+            className="text-balance text-3xl uppercase leading-none sm:text-4xl"
+            style={{ fontFamily: "var(--font-display)" }}
+          >
+            {title}
+          </h2>
+          {subtitle ? (
+            <p className="mt-3 max-w-2xl text-sm font-bold leading-6 text-[var(--color-ink-soft)]">
+              {subtitle}
+            </p>
+          ) : null}
+        </div>
+        <span className="mono w-fit border border-[var(--color-ink)] bg-[var(--color-paper)] px-3 py-2 text-[10px] font-black uppercase tracking-[0.2em] text-[var(--color-ink)]">
+          {bets.length} {bets.length === 1 ? "rodada" : "rodadas"}
+        </span>
+      </div>
+
+      <div className="mt-6 grid gap-4 xl:grid-cols-2">
         {bets.map((bet) => (
           <BetCard
             key={bet.id}
@@ -65,11 +91,14 @@ export function BetList({
 
   if (fullWidth) {
     return (
-      <section className={`landing-plane landing-divider py-8 sm:py-10 ${sectionClassName ?? "surface-section"}`}>
-        <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">{header}</div>
+      <section
+        id={id}
+        className={`landing-plane landing-divider scroll-mt-28 py-8 sm:py-10 ${sectionClassName ?? "surface-section"}`}
+      >
+        <div className="mx-auto w-full max-w-[1520px] px-4 sm:px-6 lg:px-10">{header}</div>
       </section>
     );
   }
 
-  return <section className="panel surface-section p-6 sm:p-8">{header}</section>;
+  return <section className="surface-section p-6 sm:p-8">{header}</section>;
 }


### PR DESCRIPTION
## O que mudou

- Redesenha a página pública de apostas com hero mais claro, imagem da Ludylops, métricas de pools e estado de login/vínculo.
- Reorganiza a lista de apostas com subtítulo, contador, empty state mais útil e âncora para os pools.
- Reestrutura o cartão de aposta com estados visuais, opções estáticas quando não são interativas, formulário com label/feedback acessível e copy em português corrigida.

## Impacto

A página `/apostas` fica mais legível no desktop e no mobile, com menos ambiguidade sobre saldo, vínculo e ações disponíveis. A lógica de dados e endpoints de apostas não foi alterada.

## Validação

- `npx eslint "src/app/(public)/apostas/page.tsx" "src/components/bet-list.tsx" "src/components/bet-card.tsx"`
- `npm run typecheck`
- Verificação visual com Chrome headless em desktop e mobile
