### PR TITLE
Guard bridge redemption transitions

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -14,7 +14,7 @@ Verification baseline at `06f0792`: `npm run lint`, `npx tsc --noEmit`, `npm tes
 | 001  | CI verification baseline (lint, typecheck, tests, build) | P1 | S | — | [#136](https://github.com/ludmila-omlopes/ludylops-live/issues/136) | DONE (PR #143) |
 | 002  | Fail closed in production when auth-critical env vars missing | P1 | S | 001 | [#137](https://github.com/ludmila-omlopes/ludylops-live/issues/137) | DONE |
 | 003  | Route-level tests for bridge + Streamer.bot endpoints | P1 | M | 001 | [#138](https://github.com/ludmila-omlopes/ludylops-live/issues/138) | DONE |
-| 004  | Bridge redemption claim/complete/fail idempotency | P1 | M | 003 | [#139](https://github.com/ludmila-omlopes/ludylops-live/issues/139) | TODO |
+| 004  | Bridge redemption claim/complete/fail idempotency | P1 | M | 003 | [#139](https://github.com/ludmila-omlopes/ludylops-live/issues/139) | DONE |
 | 005  | redeemItem balance overdraw + stock oversell guards | P1 | S | 001 | [#140](https://github.com/ludmila-omlopes/ludylops-live/issues/140) | TODO |
 | 006  | Hardening batch: timing-safe sync auth, dep vulns, FK indexes | P2 | M | 001 | [#141](https://github.com/ludmila-omlopes/ludylops-live/issues/141) | TODO |
 

--- a/src/lib/db/repository-bridge.test.ts
+++ b/src/lib/db/repository-bridge.test.ts
@@ -1,0 +1,309 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getDbMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/db/client", () => ({
+  getDb: getDbMock,
+}));
+
+vi.mock("@/lib/env", () => ({
+  isDemoMode: false,
+  adminEmails: new Set(["admin@example.com"]),
+  env: {},
+}));
+
+import { pointLedger, redemptions, viewerBalances } from "@/lib/db/schema";
+import { bridgeClaim, bridgeComplete, bridgeFail } from "@/lib/db/repository";
+import type { RedemptionRecord } from "@/lib/types";
+
+function redemption(overrides: Partial<RedemptionRecord> = {}): RedemptionRecord {
+  return {
+    id: "red-1",
+    viewerId: "viewer-1",
+    catalogItemId: "item-1",
+    status: "queued",
+    costAtPurchase: 250,
+    requestSource: "web",
+    idempotencyKey: "idem-red-1",
+    bridgeAttemptCount: 0,
+    claimedByBridgeId: null,
+    queuedAt: "2026-06-19T10:00:00.000Z",
+    executedAt: null,
+    failedAt: null,
+    failureReason: null,
+    ...overrides,
+  };
+}
+
+function createBridgeDb({
+  updateRows = [],
+  selectRows = [],
+}: {
+  updateRows?: unknown[][];
+  selectRows?: unknown[][];
+} = {}) {
+  const updateQueue = [...updateRows];
+  const selectQueue = [...selectRows];
+  const balanceUpdateWhere = vi.fn(async () => undefined);
+  const ledgerInsertValues = vi.fn(async () => undefined);
+
+  const updateBuilder = (table: unknown) => ({
+    set: () => {
+      if (table === redemptions) {
+        return {
+          where: () => ({
+            returning: async () => updateQueue.shift() ?? [],
+          }),
+        };
+      }
+
+      if (table === viewerBalances) {
+        return {
+          where: balanceUpdateWhere,
+        };
+      }
+
+      throw new Error("Unexpected update table in bridge db stub.");
+    },
+  });
+
+  const tx = {
+    update: updateBuilder,
+    insert(table: unknown) {
+      if (table !== pointLedger) {
+        throw new Error("Unexpected insert table in bridge db stub.");
+      }
+
+      return {
+        values: ledgerInsertValues,
+      };
+    },
+  };
+
+  const db = {
+    select() {
+      return {
+        from() {
+          return {
+            where() {
+              return {
+                limit: async () => selectQueue.shift() ?? [],
+              };
+            },
+          };
+        },
+      };
+    },
+    update: updateBuilder,
+    async transaction<T>(callback: (txArg: typeof tx) => Promise<T>) {
+      return callback(tx);
+    },
+  };
+
+  return {
+    db,
+    balanceUpdateWhere,
+    ledgerInsertValues,
+  };
+}
+
+describe("bridgeClaim", () => {
+  beforeEach(() => {
+    getDbMock.mockReset();
+  });
+
+  it("returns null when no queued redemption is claimed", async () => {
+    const { db } = createBridgeDb({ updateRows: [[]] });
+    getDbMock.mockReturnValue(db);
+
+    await expect(bridgeClaim("red-1", "bridge-1")).resolves.toBeNull();
+  });
+
+  it("returns the claimed executing redemption", async () => {
+    const row = redemption({
+      status: "executing",
+      claimedByBridgeId: "bridge-1",
+      bridgeAttemptCount: 1,
+    });
+    const { db } = createBridgeDb({ updateRows: [[row]] });
+    getDbMock.mockReturnValue(db);
+
+    await expect(bridgeClaim("red-1", "bridge-1")).resolves.toEqual(row);
+  });
+});
+
+describe("bridgeComplete", () => {
+  beforeEach(() => {
+    getDbMock.mockReset();
+  });
+
+  it("returns null when a failed redemption is not completed", async () => {
+    const { db } = createBridgeDb({
+      updateRows: [[]],
+      selectRows: [[redemption({ status: "failed" })]],
+    });
+    getDbMock.mockReturnValue(db);
+
+    await expect(bridgeComplete("red-1")).resolves.toBeNull();
+  });
+
+  it("returns null when a cancelled redemption is not completed", async () => {
+    const { db } = createBridgeDb({
+      updateRows: [[]],
+      selectRows: [[redemption({ status: "cancelled" })]],
+    });
+    getDbMock.mockReturnValue(db);
+
+    await expect(bridgeComplete("red-1")).resolves.toBeNull();
+  });
+
+  it("returns an already completed redemption for idempotent retries", async () => {
+    const row = redemption({ status: "completed" });
+    const { db } = createBridgeDb({
+      updateRows: [[]],
+      selectRows: [[row]],
+    });
+    getDbMock.mockReturnValue(db);
+
+    await expect(bridgeComplete("red-1")).resolves.toEqual(row);
+  });
+
+  it("returns the completed redemption after a guarded transition", async () => {
+    const row = redemption({
+      status: "completed",
+      executedAt: "2026-06-19T10:05:00.000Z",
+    });
+    const { db } = createBridgeDb({ updateRows: [[row]] });
+    getDbMock.mockReturnValue(db);
+
+    await expect(bridgeComplete("red-1")).resolves.toEqual(row);
+  });
+});
+
+describe("bridgeFail", () => {
+  beforeEach(() => {
+    getDbMock.mockReset();
+  });
+
+  it("does not refund when the status transition does not happen", async () => {
+    const row = redemption({ status: "failed" });
+    const { db, balanceUpdateWhere, ledgerInsertValues } = createBridgeDb({
+      updateRows: [[]],
+      selectRows: [[row], [row]],
+    });
+    getDbMock.mockReturnValue(db);
+
+    await expect(bridgeFail("red-1", "Timed out")).resolves.toEqual(row);
+    expect(balanceUpdateWhere).not.toHaveBeenCalled();
+    expect(ledgerInsertValues).not.toHaveBeenCalled();
+  });
+
+  it("does not refund a cancelled redemption", async () => {
+    const row = redemption({ status: "cancelled" });
+    const { db, balanceUpdateWhere, ledgerInsertValues } = createBridgeDb({
+      updateRows: [[]],
+      selectRows: [[row], [row]],
+    });
+    getDbMock.mockReturnValue(db);
+
+    await expect(bridgeFail("red-1", "Timed out")).resolves.toEqual(row);
+    expect(balanceUpdateWhere).not.toHaveBeenCalled();
+    expect(ledgerInsertValues).not.toHaveBeenCalled();
+  });
+
+  it("refunds once when the guarded failure transition succeeds", async () => {
+    const initial = redemption({ status: "executing" });
+    const failed = redemption({
+      status: "failed",
+      failedAt: "2026-06-19T10:05:00.000Z",
+      failureReason: "Timed out",
+    });
+    const { db, balanceUpdateWhere, ledgerInsertValues } = createBridgeDb({
+      updateRows: [[failed]],
+      selectRows: [[initial], [failed]],
+    });
+    getDbMock.mockReturnValue(db);
+
+    await expect(bridgeFail("red-1", "Timed out")).resolves.toEqual(failed);
+    expect(balanceUpdateWhere).toHaveBeenCalledTimes(1);
+    expect(ledgerInsertValues).toHaveBeenCalledTimes(1);
+    expect(ledgerInsertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        externalEventId: "redemption_refund:red-1",
+      }),
+    );
+  });
+});
+
+describe("demo bridge transitions", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    getDbMock.mockReset();
+    getDbMock.mockReturnValue(null);
+    delete (globalThis as typeof globalThis & { __lojaDemoStore?: unknown }).__lojaDemoStore;
+  });
+
+  it("refunds a failed redemption exactly once", async () => {
+    vi.doMock("@/lib/env", () => ({
+      isDemoMode: true,
+      adminEmails: new Set(["admin@example.com"]),
+      env: {},
+    }));
+
+    const { bridgeFail: demoBridgeFail } = await import("@/lib/db/repository");
+
+    const first = await demoBridgeFail("red_2", "Timed out");
+    const storeAfterFirst = (globalThis as typeof globalThis & {
+      __lojaDemoStore?: {
+        balances: Array<{ viewerId: string; currentBalance: number }>;
+        ledger: Array<{ kind: string; externalEventId: string | null }>;
+      };
+    }).__lojaDemoStore;
+    const balanceAfterFirst =
+      storeAfterFirst?.balances.find((entry) => entry.viewerId === "viewer_caio")?.currentBalance;
+    const refundCountAfterFirst =
+      storeAfterFirst?.ledger.filter((entry) => entry.kind === "redemption_refund").length ?? 0;
+
+    const second = await demoBridgeFail("red_2", "Timed out again");
+    const storeAfterSecond = (globalThis as typeof globalThis & {
+      __lojaDemoStore?: {
+        balances: Array<{ viewerId: string; currentBalance: number }>;
+        ledger: Array<{ kind: string; externalEventId: string | null }>;
+      };
+    }).__lojaDemoStore;
+    const balanceAfterSecond =
+      storeAfterSecond?.balances.find((entry) => entry.viewerId === "viewer_caio")?.currentBalance;
+    const refundEntries =
+      storeAfterSecond?.ledger.filter((entry) => entry.kind === "redemption_refund") ?? [];
+
+    expect(first?.status).toBe("failed");
+    expect(second?.status).toBe("failed");
+    expect(balanceAfterSecond).toBe(balanceAfterFirst);
+    expect(refundEntries).toHaveLength(refundCountAfterFirst);
+    expect(refundEntries[0]?.externalEventId).toBe("redemption_refund:red_2");
+  });
+
+  it("does not complete a failed redemption", async () => {
+    vi.doMock("@/lib/env", () => ({
+      isDemoMode: true,
+      adminEmails: new Set(["admin@example.com"]),
+      env: {},
+    }));
+
+    const {
+      bridgeComplete: demoBridgeComplete,
+      bridgeFail: demoBridgeFail,
+    } = await import("@/lib/db/repository");
+
+    await demoBridgeFail("red_2", "Timed out");
+    await expect(demoBridgeComplete("red_2")).resolves.toBeNull();
+
+    const store = (globalThis as typeof globalThis & {
+      __lojaDemoStore?: {
+        redemptions: Array<{ id: string; status: string }>;
+      };
+    }).__lojaDemoStore;
+
+    expect(store?.redemptions.find((entry) => entry.id === "red_2")?.status).toBe("failed");
+  });
+});

--- a/src/lib/db/repository.ts
+++ b/src/lib/db/repository.ts
@@ -9928,17 +9928,17 @@ export async function bridgeClaim(redemptionId: string, bridgeId: string) {
     return redemption;
   }
 
-  await db
+  const [claimed] = await db
     .update(redemptions)
     .set({
       status: "executing",
       claimedByBridgeId: bridgeId,
       bridgeAttemptCount: sql`${redemptions.bridgeAttemptCount} + 1`,
     })
-    .where(eq(redemptions.id, redemptionId));
+    .where(and(eq(redemptions.id, redemptionId), eq(redemptions.status, "queued")))
+    .returning();
 
-  const [redemption] = await db.select().from(redemptions).where(eq(redemptions.id, redemptionId)).limit(1);
-  return redemption ?? null;
+  return claimed ?? null;
 }
 
 export async function bridgeComplete(redemptionId: string) {
@@ -9949,21 +9949,31 @@ export async function bridgeComplete(redemptionId: string) {
     if (!redemption) {
       return null;
     }
+    if (redemption.status === "completed") {
+      return redemption;
+    }
+    if (redemption.status !== "executing") {
+      return null;
+    }
     redemption.status = "completed";
     redemption.executedAt = new Date().toISOString();
     return redemption;
   }
 
-  await db
+  const [completed] = await db
     .update(redemptions)
     .set({
       status: "completed",
       executedAt: new Date(),
     })
-    .where(eq(redemptions.id, redemptionId));
+    .where(and(eq(redemptions.id, redemptionId), eq(redemptions.status, "executing")))
+    .returning();
 
+  if (completed) {
+    return completed;
+  }
   const [redemption] = await db.select().from(redemptions).where(eq(redemptions.id, redemptionId)).limit(1);
-  return redemption ?? null;
+  return redemption?.status === "completed" ? redemption : null;
 }
 
 export async function bridgeFail(redemptionId: string, failureReason: string) {
@@ -9973,6 +9983,11 @@ export async function bridgeFail(redemptionId: string, failureReason: string) {
     const redemption = store.redemptions.find((entry) => entry.id === redemptionId);
     if (!redemption) {
       return null;
+    }
+    if (!["queued", "executing"].includes(redemption.status)) {
+      return redemption.status === "failed" || redemption.status === "completed" || redemption.status === "cancelled"
+        ? redemption
+        : null;
     }
 
     redemption.status = "failed";
@@ -9988,7 +10003,7 @@ export async function bridgeFail(redemptionId: string, failureReason: string) {
       kind: "redemption_refund",
       amount: redemption.costAtPurchase,
       source: "bridge",
-      externalEventId: null,
+      externalEventId: `redemption_refund:${redemptionId}`,
       metadata: { redemptionId, failureReason },
     });
     return redemption;
@@ -10000,14 +10015,24 @@ export async function bridgeFail(redemptionId: string, failureReason: string) {
   }
 
   await db.transaction(async (tx) => {
-    await tx
+    const [failed] = await tx
       .update(redemptions)
       .set({
         status: "failed",
         failedAt: new Date(),
         failureReason,
       })
-      .where(eq(redemptions.id, redemptionId));
+      .where(
+        and(
+          eq(redemptions.id, redemptionId),
+          inArray(redemptions.status, ["queued", "executing"]),
+        ),
+      )
+      .returning();
+
+    if (!failed) {
+      return;
+    }
 
     await tx
       .update(viewerBalances)
@@ -10023,7 +10048,7 @@ export async function bridgeFail(redemptionId: string, failureReason: string) {
       kind: "redemption_refund",
       amount: redemption.costAtPurchase,
       source: "bridge",
-      externalEventId: null,
+      externalEventId: `redemption_refund:${redemptionId}`,
       metadata: { redemptionId, failureReason },
     });
   });


### PR DESCRIPTION
## Summary
- Guard bridge claim, complete, and fail updates with redemption status conditions.
- Make bridge fail refunds run only when the redemption actually transitions to failed.
- Add deterministic refund ledger external event ids and focused bridge repository tests, including cancelled as a terminal status.
- Mark plan 004 complete in the plan index.

## Validation
- npx vitest run src/lib/db/repository-bridge.test.ts
- npm test
- npm run typecheck
- npx eslint . --ignore-pattern .claude/**

Note: exact npm run lint timed out locally because ESLint traversed pre-existing untracked .claude/worktrees/**/.next output.

Closes #139