### PR TITLE
Guard redeemItem balance and stock updates

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -15,7 +15,7 @@ Verification baseline at `06f0792`: `npm run lint`, `npx tsc --noEmit`, `npm tes
 | 002  | Fail closed in production when auth-critical env vars missing | P1 | S | 001 | [#137](https://github.com/ludmila-omlopes/ludylops-live/issues/137) | DONE |
 | 003  | Route-level tests for bridge + Streamer.bot endpoints | P1 | M | 001 | [#138](https://github.com/ludmila-omlopes/ludylops-live/issues/138) | DONE |
 | 004  | Bridge redemption claim/complete/fail idempotency | P1 | M | 003 | [#139](https://github.com/ludmila-omlopes/ludylops-live/issues/139) | DONE |
-| 005  | redeemItem balance overdraw + stock oversell guards | P1 | S | 001 | [#140](https://github.com/ludmila-omlopes/ludylops-live/issues/140) | TODO |
+| 005  | redeemItem balance overdraw + stock oversell guards | P1 | S | 001 | [#140](https://github.com/ludmila-omlopes/ludylops-live/issues/140) | DONE |
 | 006  | Hardening batch: timing-safe sync auth, dep vulns, FK indexes | P2 | M | 001 | [#141](https://github.com/ludmila-omlopes/ludylops-live/issues/141) | TODO |
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJECTED (with one-line rationale)

--- a/src/lib/db/repository-redeem.test.ts
+++ b/src/lib/db/repository-redeem.test.ts
@@ -1,0 +1,243 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getDbMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/db/client", () => ({
+  getDb: getDbMock,
+}));
+
+vi.mock("@/lib/env", () => ({
+  isDemoMode: false,
+  adminEmails: new Set(["admin@example.com"]),
+  env: {},
+}));
+
+import { catalogItems, pointLedger, redemptions, users, viewerBalances } from "@/lib/db/schema";
+import { redeemItem } from "@/lib/db/repository";
+import type { CatalogItemRecord } from "@/lib/types";
+
+const viewerRow = {
+  id: "viewer-1",
+  googleUserId: null,
+  email: null,
+  youtubeChannelId: "yt-viewer-1",
+  youtubeDisplayName: "Viewer Teste",
+  youtubeHandle: "@viewerteste",
+  avatarUrl: null,
+  isLinked: true,
+  excludeFromRanking: false,
+  createdAt: new Date("2026-06-19T10:00:00.000Z"),
+};
+
+const balanceRow = {
+  viewerId: viewerRow.id,
+  currentBalance: 500,
+  lifetimeEarned: 500,
+  lifetimeSpent: 0,
+  lastSyncedAt: new Date("2026-06-19T10:00:00.000Z"),
+};
+
+function catalogItem(overrides: Partial<CatalogItemRecord> = {}) {
+  return {
+    id: "item-1",
+    slug: "item-1",
+    name: "Item Teste",
+    description: "Item usado em testes.",
+    type: "generic_streamerbot_action",
+    cost: 250,
+    isActive: true,
+    globalCooldownSeconds: 0,
+    viewerCooldownSeconds: 0,
+    stock: 1,
+    previewImageUrl: null,
+    accentColor: "#ff00aa",
+    isFeatured: false,
+    streamerbotActionRef: "test.action",
+    streamerbotArgsTemplate: {},
+    ...overrides,
+  } satisfies CatalogItemRecord;
+}
+
+function createRedeemDb({
+  item = catalogItem(),
+  debitRows = [{ viewerId: viewerRow.id }],
+  stockRows = [{ id: item.id }],
+}: {
+  item?: CatalogItemRecord;
+  debitRows?: unknown[];
+  stockRows?: unknown[];
+} = {}) {
+  const redemptionInsertValues = vi.fn(async () => undefined);
+  const ledgerInsertValues = vi.fn(async () => undefined);
+  const balanceUpdateReturning = vi.fn(async () => debitRows);
+  const stockUpdateReturning = vi.fn(async () => stockRows);
+  const catalogUpdateSet = vi.fn(() => ({
+    where: vi.fn(() => ({
+      returning: stockUpdateReturning,
+    })),
+  }));
+
+  function selectFrom(table: unknown) {
+    if (table === users) {
+      return {
+        where: () => ({
+          limit: async () => [viewerRow],
+        }),
+      };
+    }
+
+    if (table === viewerBalances) {
+      return {
+        where: () => ({
+          limit: async () => [balanceRow],
+        }),
+      };
+    }
+
+    if (table === redemptions) {
+      return {
+        where: () => ({
+          orderBy: async () => [],
+        }),
+      };
+    }
+
+    if (table === pointLedger) {
+      return {
+        where: () => ({
+          orderBy: async () => [],
+        }),
+      };
+    }
+
+    if (table === catalogItems) {
+      return {
+        orderBy: async () => [item],
+      };
+    }
+
+    throw new Error("Unexpected select table in redeem db stub.");
+  }
+
+  const tx = {
+    insert(table: unknown) {
+      if (table === redemptions) {
+        return {
+          values: redemptionInsertValues,
+        };
+      }
+
+      if (table === pointLedger) {
+        return {
+          values: ledgerInsertValues,
+        };
+      }
+
+      throw new Error("Unexpected insert table in redeem tx stub.");
+    },
+    update(table: unknown) {
+      if (table === viewerBalances) {
+        return {
+          set: () => ({
+            where: () => ({
+              returning: balanceUpdateReturning,
+            }),
+          }),
+        };
+      }
+
+      if (table === catalogItems) {
+        return {
+          set: catalogUpdateSet,
+        };
+      }
+
+      throw new Error("Unexpected update table in redeem tx stub.");
+    },
+  };
+
+  const db = {
+    select: () => ({
+      from: selectFrom,
+    }),
+    async transaction<T>(callback: (txArg: typeof tx) => Promise<T>) {
+      return callback(tx);
+    },
+  };
+
+  return {
+    db,
+    redemptionInsertValues,
+    ledgerInsertValues,
+    balanceUpdateReturning,
+    catalogUpdateSet,
+    stockUpdateReturning,
+  };
+}
+
+describe("redeemItem database guards", () => {
+  beforeEach(() => {
+    getDbMock.mockReset();
+  });
+
+  it("rejects and skips later writes when the guarded debit does not match", async () => {
+    const { db, ledgerInsertValues, catalogUpdateSet } = createRedeemDb({
+      debitRows: [],
+    });
+    getDbMock.mockReturnValue(db);
+
+    await expect(
+      redeemItem({ viewerId: viewerRow.id, itemId: "item-1", source: "web" }),
+    ).rejects.toThrow("saldo_insuficiente");
+
+    expect(ledgerInsertValues).not.toHaveBeenCalled();
+    expect(catalogUpdateSet).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the guarded stock decrement does not match", async () => {
+    const { db, stockUpdateReturning } = createRedeemDb({
+      stockRows: [],
+    });
+    getDbMock.mockReturnValue(db);
+
+    await expect(
+      redeemItem({ viewerId: viewerRow.id, itemId: "item-1", source: "web" }),
+    ).rejects.toThrow("sem_estoque");
+
+    expect(stockUpdateReturning).toHaveBeenCalledTimes(1);
+  });
+
+  it("creates a queued redemption and debit ledger entry when both guards match", async () => {
+    const { db, ledgerInsertValues } = createRedeemDb();
+    getDbMock.mockReturnValue(db);
+
+    const result = await redeemItem({ viewerId: viewerRow.id, itemId: "item-1", source: "web" });
+
+    expect(result).toMatchObject({
+      viewerId: viewerRow.id,
+      catalogItemId: "item-1",
+      status: "queued",
+      costAtPurchase: 250,
+    });
+    expect(ledgerInsertValues).toHaveBeenCalledTimes(1);
+    expect(ledgerInsertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "redemption_debit",
+        amount: -250,
+      }),
+    );
+  });
+
+  it("does not update stock for unlimited items", async () => {
+    const { db, catalogUpdateSet } = createRedeemDb({
+      item: catalogItem({ stock: null }),
+    });
+    getDbMock.mockReturnValue(db);
+
+    await expect(
+      redeemItem({ viewerId: viewerRow.id, itemId: "item-1", source: "web" }),
+    ).resolves.toMatchObject({ status: "queued" });
+
+    expect(catalogUpdateSet).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/db/repository.ts
+++ b/src/lib/db/repository.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import { and, desc, eq, gte, inArray, lt, sql } from "drizzle-orm";
+import { and, desc, eq, gt, gte, inArray, lt, sql } from "drizzle-orm";
 
 import {
   calculateHouseBetEntries,
@@ -8642,14 +8642,24 @@ export async function redeemItem({
       queuedAt: new Date(redemption.queuedAt),
     });
 
-    await tx
+    const [debited] = await tx
       .update(viewerBalances)
       .set({
         currentBalance: sql`${viewerBalances.currentBalance} - ${item.cost}`,
         lifetimeSpent: sql`${viewerBalances.lifetimeSpent} + ${item.cost}`,
         lastSyncedAt: new Date(),
       })
-      .where(eq(viewerBalances.viewerId, dashboard.viewer.id));
+      .where(
+        and(
+          eq(viewerBalances.viewerId, dashboard.viewer.id),
+          gte(viewerBalances.currentBalance, item.cost),
+        ),
+      )
+      .returning({ viewerId: viewerBalances.viewerId });
+
+    if (!debited) {
+      throw new Error("saldo_insuficiente");
+    }
 
     await tx.insert(pointLedger).values({
       id: randomUUID(),
@@ -8662,12 +8672,17 @@ export async function redeemItem({
     });
 
     if (item.stock !== null) {
-      await tx
+      const [stocked] = await tx
         .update(catalogItems)
         .set({
-          stock: item.stock - 1,
+          stock: sql`${catalogItems.stock} - 1`,
         })
-        .where(eq(catalogItems.id, item.id));
+        .where(and(eq(catalogItems.id, item.id), gt(catalogItems.stock, 0)))
+        .returning({ id: catalogItems.id });
+
+      if (!stocked) {
+        throw new Error("sem_estoque");
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
- Guard redeemItem balance debits with an in-transaction current-balance condition.
- Replace stale stock writes with an atomic guarded stock decrement.
- Add focused DB-path tests for debit races, stock races, happy path, and unlimited stock.
- Mark plan 005 complete in the plan index.

## Validation
- npx vitest run src/lib/db/repository-redeem.test.ts
- npm test
- npm run typecheck
- npx eslint . --ignore-pattern .claude/**
- git diff --check

Note: exact npm run lint was not used because the pre-existing untracked .claude/worktrees/**/.next output makes ESLint traverse generated files locally.

Closes #140