### PR TITLE
Add hot path FK indexes

### DIFF
--- a/drizzle/0019_fk_hot_path_indexes.sql
+++ b/drizzle/0019_fk_hot_path_indexes.sql
@@ -1,0 +1,10 @@
+CREATE INDEX IF NOT EXISTS "point_ledger_viewer_created_idx" ON "point_ledger" USING btree ("viewer_id","created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "bet_entries_viewer_id_idx" ON "bet_entries" USING btree ("viewer_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "game_suggestion_boosts_suggestion_id_idx" ON "game_suggestion_boosts" USING btree ("suggestion_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "game_suggestion_boosts_viewer_id_idx" ON "game_suggestion_boosts" USING btree ("viewer_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "video_suggestion_boosts_suggestion_id_idx" ON "video_suggestion_boosts" USING btree ("suggestion_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "video_suggestion_boosts_viewer_id_idx" ON "video_suggestion_boosts" USING btree ("viewer_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "creator_suggestion_boosts_suggestion_id_idx" ON "creator_suggestion_boosts" USING btree ("suggestion_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "creator_suggestion_boosts_viewer_id_idx" ON "creator_suggestion_boosts" USING btree ("viewer_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "redemptions_viewer_id_idx" ON "redemptions" USING btree ("viewer_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "redemptions_status_queued_at_idx" ON "redemptions" USING btree ("status","queued_at");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1780704000000,
       "tag": "0018_game_suggestion_steam_prices",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1781932800000,
+      "tag": "0019_fk_hot_path_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/plans/README.md
+++ b/plans/README.md
@@ -16,7 +16,7 @@ Verification baseline at `06f0792`: `npm run lint`, `npx tsc --noEmit`, `npm tes
 | 003  | Route-level tests for bridge + Streamer.bot endpoints | P1 | M | 001 | [#138](https://github.com/ludmila-omlopes/ludylops-live/issues/138) | DONE |
 | 004  | Bridge redemption claim/complete/fail idempotency | P1 | M | 003 | [#139](https://github.com/ludmila-omlopes/ludylops-live/issues/139) | DONE |
 | 005  | redeemItem balance overdraw + stock oversell guards | P1 | S | 001 | [#140](https://github.com/ludmila-omlopes/ludylops-live/issues/140) | DONE |
-| 006  | Hardening batch: timing-safe sync auth, dep vulns, FK indexes | P2 | M | 001 | [#141](https://github.com/ludmila-omlopes/ludylops-live/issues/141) | BLOCKED (migration generation includes unrelated historical schema changes) |
+| 006  | Hardening batch: timing-safe sync auth, dep vulns, FK indexes | P2 | M | 001 | [#141](https://github.com/ludmila-omlopes/ludylops-live/issues/141) | DONE (manual index migration generated; not applied) |
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJECTED (with one-line rationale)
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -143,6 +143,7 @@ export const pointLedger = pgTable(
   },
   (table) => ({
     eventIdx: uniqueIndex("point_ledger_external_event_idx").on(table.externalEventId),
+    viewerCreatedIdx: index("point_ledger_viewer_created_idx").on(table.viewerId, table.createdAt),
   }),
 );
 
@@ -191,6 +192,7 @@ export const betEntries = pgTable(
   },
   (table) => ({
     betViewerIdx: uniqueIndex("bet_entries_bet_viewer_idx").on(table.betId, table.viewerId),
+    viewerIdx: index("bet_entries_viewer_id_idx").on(table.viewerId),
   }),
 );
 
@@ -273,17 +275,24 @@ export const gameSuggestions = pgTable("game_suggestions", {
   updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
 });
 
-export const gameSuggestionBoosts = pgTable("game_suggestion_boosts", {
-  id: varchar("id", { length: 64 }).primaryKey(),
-  suggestionId: varchar("suggestion_id", { length: 64 })
-    .references(() => gameSuggestions.id)
-    .notNull(),
-  viewerId: varchar("viewer_id", { length: 64 })
-    .references(() => users.id)
-    .notNull(),
-  amount: integer("amount").notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
-});
+export const gameSuggestionBoosts = pgTable(
+  "game_suggestion_boosts",
+  {
+    id: varchar("id", { length: 64 }).primaryKey(),
+    suggestionId: varchar("suggestion_id", { length: 64 })
+      .references(() => gameSuggestions.id)
+      .notNull(),
+    viewerId: varchar("viewer_id", { length: 64 })
+      .references(() => users.id)
+      .notNull(),
+    amount: integer("amount").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => ({
+    suggestionIdx: index("game_suggestion_boosts_suggestion_id_idx").on(table.suggestionId),
+    viewerIdx: index("game_suggestion_boosts_viewer_id_idx").on(table.viewerId),
+  }),
+);
 
 export const psPlusCatalogItems = pgTable(
   "ps_plus_catalog_items",
@@ -341,17 +350,24 @@ export const videoSuggestions = pgTable("video_suggestions", {
   updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
 });
 
-export const videoSuggestionBoosts = pgTable("video_suggestion_boosts", {
-  id: varchar("id", { length: 64 }).primaryKey(),
-  suggestionId: varchar("suggestion_id", { length: 64 })
-    .references(() => videoSuggestions.id)
-    .notNull(),
-  viewerId: varchar("viewer_id", { length: 64 })
-    .references(() => users.id)
-    .notNull(),
-  amount: integer("amount").notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
-});
+export const videoSuggestionBoosts = pgTable(
+  "video_suggestion_boosts",
+  {
+    id: varchar("id", { length: 64 }).primaryKey(),
+    suggestionId: varchar("suggestion_id", { length: 64 })
+      .references(() => videoSuggestions.id)
+      .notNull(),
+    viewerId: varchar("viewer_id", { length: 64 })
+      .references(() => users.id)
+      .notNull(),
+    amount: integer("amount").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => ({
+    suggestionIdx: index("video_suggestion_boosts_suggestion_id_idx").on(table.suggestionId),
+    viewerIdx: index("video_suggestion_boosts_viewer_id_idx").on(table.viewerId),
+  }),
+);
 
 export const creatorSuggestions = pgTable("creator_suggestions", {
   id: varchar("id", { length: 64 }).primaryKey(),
@@ -370,17 +386,24 @@ export const creatorSuggestions = pgTable("creator_suggestions", {
   updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
 });
 
-export const creatorSuggestionBoosts = pgTable("creator_suggestion_boosts", {
-  id: varchar("id", { length: 64 }).primaryKey(),
-  suggestionId: varchar("suggestion_id", { length: 64 })
-    .references(() => creatorSuggestions.id)
-    .notNull(),
-  viewerId: varchar("viewer_id", { length: 64 })
-    .references(() => users.id)
-    .notNull(),
-  amount: integer("amount").notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
-});
+export const creatorSuggestionBoosts = pgTable(
+  "creator_suggestion_boosts",
+  {
+    id: varchar("id", { length: 64 }).primaryKey(),
+    suggestionId: varchar("suggestion_id", { length: 64 })
+      .references(() => creatorSuggestions.id)
+      .notNull(),
+    viewerId: varchar("viewer_id", { length: 64 })
+      .references(() => users.id)
+      .notNull(),
+    amount: integer("amount").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => ({
+    suggestionIdx: index("creator_suggestion_boosts_suggestion_id_idx").on(table.suggestionId),
+    viewerIdx: index("creator_suggestion_boosts_viewer_id_idx").on(table.viewerId),
+  }),
+);
 
 export const productRecommendations = pgTable(
   "product_recommendations",
@@ -404,25 +427,32 @@ export const productRecommendations = pgTable(
   }),
 );
 
-export const redemptions = pgTable("redemptions", {
-  id: varchar("id", { length: 64 }).primaryKey(),
-  viewerId: varchar("viewer_id", { length: 64 })
-    .references(() => users.id)
-    .notNull(),
-  catalogItemId: varchar("catalog_item_id", { length: 64 })
-    .references(() => catalogItems.id)
-    .notNull(),
-  status: varchar("status", { length: 32 }).notNull(),
-  costAtPurchase: integer("cost_at_purchase").notNull(),
-  requestSource: varchar("request_source", { length: 32 }).default("web").notNull(),
-  idempotencyKey: varchar("idempotency_key", { length: 128 }).notNull(),
-  bridgeAttemptCount: integer("bridge_attempt_count").default(0).notNull(),
-  claimedByBridgeId: varchar("claimed_by_bridge_id", { length: 64 }),
-  queuedAt: timestamp("queued_at", { withTimezone: true }).defaultNow().notNull(),
-  executedAt: timestamp("executed_at", { withTimezone: true }),
-  failedAt: timestamp("failed_at", { withTimezone: true }),
-  failureReason: text("failure_reason"),
-});
+export const redemptions = pgTable(
+  "redemptions",
+  {
+    id: varchar("id", { length: 64 }).primaryKey(),
+    viewerId: varchar("viewer_id", { length: 64 })
+      .references(() => users.id)
+      .notNull(),
+    catalogItemId: varchar("catalog_item_id", { length: 64 })
+      .references(() => catalogItems.id)
+      .notNull(),
+    status: varchar("status", { length: 32 }).notNull(),
+    costAtPurchase: integer("cost_at_purchase").notNull(),
+    requestSource: varchar("request_source", { length: 32 }).default("web").notNull(),
+    idempotencyKey: varchar("idempotency_key", { length: 128 }).notNull(),
+    bridgeAttemptCount: integer("bridge_attempt_count").default(0).notNull(),
+    claimedByBridgeId: varchar("claimed_by_bridge_id", { length: 64 }),
+    queuedAt: timestamp("queued_at", { withTimezone: true }).defaultNow().notNull(),
+    executedAt: timestamp("executed_at", { withTimezone: true }),
+    failedAt: timestamp("failed_at", { withTimezone: true }),
+    failureReason: text("failure_reason"),
+  },
+  (table) => ({
+    viewerIdx: index("redemptions_viewer_id_idx").on(table.viewerId),
+    statusQueuedIdx: index("redemptions_status_queued_at_idx").on(table.status, table.queuedAt),
+  }),
+);
 
 export const bridgeClients = pgTable(
   "bridge_clients",


### PR DESCRIPTION
## Summary
- Add schema declarations for the FK/query hot-path indexes called out in plan 006.
- Add a manual Drizzle SQL migration with `CREATE INDEX IF NOT EXISTS` statements only.
- Mark plan 006 complete with the migration generated but not applied.

## Migration note
`drizzle-kit generate` currently tries to regenerate stale historical table/column changes because the migration metadata is missing older snapshots. I checked the repo migrations and the live database catalog before writing this manually: the planned indexes are absent, and the migration contains only 10 idempotent `CREATE INDEX IF NOT EXISTS` statements.

## Validation
- `npm run typecheck`
- `npx eslint . --ignore-pattern .claude/**`
- `git diff --check origin/master...HEAD`
- `npm test`

Closes #141