### PR TITLE
[codex] Add moderated product submissions

### DIFF
--- a/drizzle/0020_product_recommendation_moderation.sql
+++ b/drizzle/0020_product_recommendation_moderation.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "product_recommendations"
+  ADD COLUMN IF NOT EXISTS "moderation_status" varchar(32) DEFAULT 'approved' NOT NULL;
+
+CREATE INDEX IF NOT EXISTS "product_recommendations_moderation_status_idx"
+  ON "product_recommendations" USING btree ("moderation_status");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1781932800000,
       "tag": "0019_fk_hot_path_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1782019200000,
+      "tag": "0020_product_recommendation_moderation",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(public)/produtinhos/page.tsx
+++ b/src/app/(public)/produtinhos/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 import { ProductRecommendationCard } from "@/components/product-recommendation-card";
+import { ProductRecommendationSubmitDialog } from "@/components/product-recommendation-submit-form";
 import { listProductRecommendations } from "@/lib/db/repository";
 import {
   getRecommendationCategoryLabel,
@@ -50,6 +51,9 @@ export default async function ProdutinhosPage({ searchParams }: ProdutinhosPageP
             virar afiliado, isso aparece marcado no próprio item antes do
             clique.
           </p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <ProductRecommendationSubmitDialog />
+          </div>
         </div>
       </section>
 

--- a/src/app/api/admin/recommendations/[id]/route.ts
+++ b/src/app/api/admin/recommendations/[id]/route.ts
@@ -25,6 +25,7 @@ export async function PATCH(
       recommendationId: id,
       isActive: payload.isActive,
       category: payload.category,
+      moderationStatus: payload.moderationStatus,
     });
 
     return ok(updated);

--- a/src/app/api/recommendations/route.ts
+++ b/src/app/api/recommendations/route.ts
@@ -1,0 +1,32 @@
+import { ZodError } from "zod";
+
+import { fail, isTrustedAppMutationRequest, ok } from "@/lib/api";
+import { createProductRecommendationSubmission } from "@/lib/db/repository";
+import {
+  formatProductRecommendationSchemaError,
+  productRecommendationSubmissionSchema,
+} from "@/lib/recommendation-schemas";
+
+export async function POST(request: Request) {
+  if (!isTrustedAppMutationRequest(request)) {
+    return fail("Forbidden", 403);
+  }
+
+  try {
+    const payload = productRecommendationSubmissionSchema.parse(await request.json());
+    const recommendation = await createProductRecommendationSubmission(payload);
+
+    return ok(recommendation, { status: 201 });
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return fail(formatProductRecommendationSchemaError(error), 400);
+    }
+
+    if (error instanceof SyntaxError) {
+      return fail("Payload inválido.", 400);
+    }
+
+    const message = error instanceof Error ? error.message : "Falha ao enviar recomendação.";
+    return fail(message, 400);
+  }
+}

--- a/src/components/admin-recommendations-panel.tsx
+++ b/src/components/admin-recommendations-panel.tsx
@@ -17,6 +17,18 @@ import type { ProductRecommendationRecord } from "@/lib/types";
 
 const INITIAL_VISIBLE_RECOMMENDATIONS = 6;
 
+const moderationStatusLabels: Record<ProductRecommendationRecord["moderationStatus"], string> = {
+  pending: "Pendente",
+  approved: "Aprovado",
+  rejected: "Rejeitado",
+};
+
+const moderationStatusBgMap: Record<ProductRecommendationRecord["moderationStatus"], string> = {
+  pending: "var(--color-yellow)",
+  approved: "var(--color-mint)",
+  rejected: "var(--color-rose)",
+};
+
 function mapRecommendationError(message: string) {
   switch (message) {
     case "recommendation_slug_exists":
@@ -51,6 +63,25 @@ export function AdminRecommendationsPanel({
   const [pendingCategories, setPendingCategories] = useState<Record<string, string>>({});
   const [showAllRecommendations, setShowAllRecommendations] = useState(false);
   const [isPending, startTransition] = useTransition();
+  const sortedRecommendations = [...recommendations].sort((left, right) => {
+    if (left.moderationStatus !== right.moderationStatus) {
+      if (left.moderationStatus === "pending") {
+        return -1;
+      }
+      if (right.moderationStatus === "pending") {
+        return 1;
+      }
+    }
+
+    if (left.sortOrder !== right.sortOrder) {
+      return left.sortOrder - right.sortOrder;
+    }
+
+    return left.name.localeCompare(right.name, "pt-BR");
+  });
+  const pendingSubmissionCount = recommendations.filter(
+    (item) => item.moderationStatus === "pending",
+  ).length;
   const pendingCategoryChanges = recommendations
     .map((item) => ({
       item,
@@ -64,9 +95,9 @@ export function AdminRecommendationsPanel({
     ],
   );
   const visibleRecommendations = showAllRecommendations
-    ? recommendations
-    : recommendations.slice(0, INITIAL_VISIBLE_RECOMMENDATIONS);
-  const hiddenRecommendationCount = Math.max(recommendations.length - visibleRecommendations.length, 0);
+    ? sortedRecommendations
+    : sortedRecommendations.slice(0, INITIAL_VISIBLE_RECOMMENDATIONS);
+  const hiddenRecommendationCount = Math.max(sortedRecommendations.length - visibleRecommendations.length, 0);
 
   function resetForm() {
     setName("");
@@ -185,6 +216,33 @@ export function AdminRecommendationsPanel({
     });
   }
 
+  function updateModerationStatus(
+    item: ProductRecommendationRecord,
+    moderationStatus: ProductRecommendationRecord["moderationStatus"],
+  ) {
+    setFeedback(null);
+    startTransition(async () => {
+      try {
+        await runAction(`/api/admin/recommendations/${item.id}`, "PATCH", {
+          moderationStatus,
+          isActive: moderationStatus === "approved" ? true : false,
+        });
+        setFieldErrors({});
+        setConfirmingDeleteId(null);
+        setFeedback(
+          moderationStatus === "approved"
+            ? "Recomendação aprovada."
+            : "Recomendação rejeitada.",
+        );
+        router.refresh();
+      } catch (error) {
+        setFeedback(
+          error instanceof Error ? mapRecommendationError(error.message) : "Falha ao moderar recomendação.",
+        );
+      }
+    });
+  }
+
   function updatePendingCategory(item: ProductRecommendationRecord, nextCategory: string) {
     setFeedback(null);
     setPendingCategories((current) => {
@@ -266,6 +324,13 @@ export function AdminRecommendationsPanel({
           >
             Produtos recomendados
           </h2>
+        </div>
+        <div className="flex flex-wrap justify-end gap-2">
+          <span className="retro-label neutral-chip">
+            {pendingSubmissionCount === 1
+              ? "1 envio pendente"
+              : `${pendingSubmissionCount} envios pendentes`}
+          </span>
         </div>
         {feedback ? <div className="retro-label neutral-chip">{feedback}</div> : null}
       </div>
@@ -500,6 +565,12 @@ export function AdminRecommendationsPanel({
                           >
                             {item.isActive ? "Ativo" : "Inativo"}
                           </span>
+                          <span
+                            className="badge-brutal px-2 py-1 text-[10px] text-[var(--color-ink)]"
+                            style={{ backgroundColor: moderationStatusBgMap[item.moderationStatus] }}
+                          >
+                            {moderationStatusLabels[item.moderationStatus]}
+                          </span>
                         </div>
 
                         <p className="mt-2 text-sm text-[var(--color-ink-soft)]">{item.context}</p>
@@ -528,6 +599,28 @@ export function AdminRecommendationsPanel({
                       </div>
 
                       <div className="flex flex-col items-end gap-2">
+                        {item.moderationStatus !== "approved" ? (
+                          <button
+                            type="button"
+                            onClick={() => updateModerationStatus(item, "approved")}
+                            disabled={isPending}
+                            className="btn-brutal bg-[var(--color-mint)] px-3 py-2 text-xs disabled:opacity-60"
+                          >
+                            Aprovar
+                          </button>
+                        ) : null}
+
+                        {item.moderationStatus !== "rejected" ? (
+                          <button
+                            type="button"
+                            onClick={() => updateModerationStatus(item, "rejected")}
+                            disabled={isPending}
+                            className="btn-brutal bg-[var(--color-rose)] px-3 py-2 text-xs disabled:opacity-60"
+                          >
+                            Rejeitar
+                          </button>
+                        ) : null}
+
                         <button
                           type="button"
                           onClick={() => toggleStatus(item)}

--- a/src/components/product-recommendation-submit-form.tsx
+++ b/src/components/product-recommendation-submit-form.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+import { Plus, X } from "lucide-react";
+import { useEffect, useId, useState, useTransition } from "react";
+
+import {
+  flattenProductRecommendationSchemaErrors,
+  formatProductRecommendationSchemaError,
+  productRecommendationSubmissionSchema,
+} from "@/lib/recommendation-schemas";
+import { getRecommendationCategoryOptions } from "@/lib/recommendations";
+
+const categoryOptions = getRecommendationCategoryOptions([]);
+
+function mapSubmissionError(message: string) {
+  switch (message) {
+    case "invalid_slug":
+      return "Não consegui gerar um slug válido para esse produto.";
+    case "recommendation_slug_exists":
+      return "Já existe uma recomendação com esse nome. Tente detalhar o produto.";
+    default:
+      return message;
+  }
+}
+
+export function ProductRecommendationSubmitDialog() {
+  const titleId = useId();
+  const [isOpen, setIsOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [category, setCategory] = useState("videogames");
+  const [context, setContext] = useState("");
+  const [imageUrl, setImageUrl] = useState("");
+  const [href, setHref] = useState("");
+  const [storeLabel, setStoreLabel] = useState("");
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Partial<Record<string, string>>>({});
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    }
+
+    document.body.style.overflow = "hidden";
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = "";
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen]);
+
+  function resetForm() {
+    setName("");
+    setCategory("videogames");
+    setContext("");
+    setImageUrl("");
+    setHref("");
+    setStoreLabel("");
+    setFieldErrors({});
+  }
+
+  function clearFieldError(field: string) {
+    setFieldErrors((current) => {
+      if (!current[field]) {
+        return current;
+      }
+
+      const next = { ...current };
+      delete next[field];
+      return next;
+    });
+  }
+
+  function getFieldClass(field: string) {
+    return [
+      "rounded-[var(--radius)] border-[3px] bg-[var(--color-paper)] px-3 py-2 font-bold",
+      fieldErrors[field] ? "border-[var(--color-rose)]" : "border-[var(--color-ink)]",
+    ].join(" ");
+  }
+
+  function renderFieldError(field: string) {
+    if (!fieldErrors[field]) {
+      return null;
+    }
+
+    return <span className="text-xs font-bold text-[var(--color-rose)]">{fieldErrors[field]}</span>;
+  }
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const parsed = productRecommendationSubmissionSchema.safeParse({
+      name,
+      category,
+      context,
+      imageUrl,
+      href,
+      storeLabel,
+    });
+
+    if (!parsed.success) {
+      setFieldErrors(flattenProductRecommendationSchemaErrors(parsed.error));
+      setFeedback(formatProductRecommendationSchemaError(parsed.error));
+      return;
+    }
+
+    setFieldErrors({});
+    setFeedback(null);
+    startTransition(async () => {
+      const response = await fetch("/api/recommendations", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(parsed.data),
+      });
+
+      const payload = (await response.json()) as { ok?: boolean; error?: string };
+      if (!response.ok || !payload.ok) {
+        setFeedback(mapSubmissionError(payload.error ?? "Falha ao enviar recomendação."));
+        return;
+      }
+
+      resetForm();
+      setFeedback("Recomendação enviada para aprovação.");
+    });
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          setFeedback(null);
+          setIsOpen(true);
+        }}
+        className="btn-brutal ink-button inline-flex items-center gap-2 px-5 py-3 text-xs"
+      >
+        <Plus aria-hidden="true" className="h-4 w-4" />
+        Indicar produto
+      </button>
+
+      {isOpen ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/55 p-4"
+          role="presentation"
+          onMouseDown={(event) => {
+            if (event.target === event.currentTarget) {
+              setIsOpen(false);
+            }
+          }}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={titleId}
+            className="panel surface-section relative max-h-[calc(100vh-2rem)] w-full max-w-3xl overflow-y-auto p-5 text-[var(--color-ink)] shadow-[8px_8px_0_var(--color-ink)] sm:p-6"
+          >
+            <div className="bg-dots-light pointer-events-none absolute inset-0 opacity-15" />
+            <div className="relative">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="mono text-xs uppercase tracking-[0.24em] text-[var(--color-ink-soft)]">
+                    Envie sua indicação
+                  </p>
+                  <h2
+                    id={titleId}
+                    className="mt-2 text-2xl uppercase sm:text-3xl"
+                    style={{ fontFamily: "var(--font-display)" }}
+                  >
+                    Indique um produto para a Ludy avaliar
+                  </h2>
+                  <p className="mt-2 max-w-2xl text-sm leading-6 text-[var(--color-ink-soft)]">
+                    A sugestão entra como pendente e só aparece na página depois de aprovada.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setIsOpen(false)}
+                  aria-label="Fechar formulário"
+                  className="btn-brutal bg-[var(--color-paper)] p-2 text-[var(--color-ink)]"
+                >
+                  <X aria-hidden="true" className="h-4 w-4" />
+                </button>
+              </div>
+
+              <form onSubmit={handleSubmit} className="mt-5 grid gap-4 lg:grid-cols-2">
+                <label className="grid gap-2">
+                  <span className="text-sm font-black uppercase tracking-[0.14em]">Nome</span>
+                  <input
+                    value={name}
+                    onChange={(event) => {
+                      setName(event.target.value);
+                      clearFieldError("name");
+                    }}
+                    placeholder="Ex.: Controle, headset, luz..."
+                    aria-invalid={Boolean(fieldErrors.name)}
+                    className={getFieldClass("name")}
+                  />
+                  {renderFieldError("name")}
+                </label>
+
+                <label className="grid gap-2">
+                  <span className="text-sm font-black uppercase tracking-[0.14em]">Categoria</span>
+                  <input
+                    value={category}
+                    list="public-product-recommendation-category-options"
+                    onChange={(event) => {
+                      setCategory(event.target.value);
+                      clearFieldError("category");
+                    }}
+                    placeholder="Ex.: Casa"
+                    aria-invalid={Boolean(fieldErrors.category)}
+                    className={getFieldClass("category")}
+                  />
+                  <datalist id="public-product-recommendation-category-options">
+                    {categoryOptions.map((entry) => (
+                      <option key={entry.key} value={entry.key}>
+                        {entry.label}
+                      </option>
+                    ))}
+                  </datalist>
+                  {renderFieldError("category")}
+                </label>
+
+                <label className="grid gap-2 lg:col-span-2">
+                  <span className="text-sm font-black uppercase tracking-[0.14em]">Por que indicar?</span>
+                  <textarea
+                    value={context}
+                    onChange={(event) => {
+                      setContext(event.target.value);
+                      clearFieldError("context");
+                    }}
+                    rows={4}
+                    placeholder="Conta por que esse produto faz sentido para a comunidade."
+                    aria-invalid={Boolean(fieldErrors.context)}
+                    className={[
+                      "rounded-[var(--radius)] border-[3px] bg-[var(--color-paper)] px-3 py-2 text-sm font-bold",
+                      fieldErrors.context ? "border-[var(--color-rose)]" : "border-[var(--color-ink)]",
+                    ].join(" ")}
+                  />
+                  {renderFieldError("context")}
+                </label>
+
+                <label className="grid gap-2">
+                  <span className="text-sm font-black uppercase tracking-[0.14em]">Imagem</span>
+                  <input
+                    value={imageUrl}
+                    onChange={(event) => {
+                      setImageUrl(event.target.value);
+                      clearFieldError("imageUrl");
+                    }}
+                    placeholder="https://... ou /uploads/produto.jpg"
+                    aria-invalid={Boolean(fieldErrors.imageUrl)}
+                    className={getFieldClass("imageUrl")}
+                  />
+                  {renderFieldError("imageUrl")}
+                </label>
+
+                <label className="grid gap-2">
+                  <span className="text-sm font-black uppercase tracking-[0.14em]">Link do produto</span>
+                  <input
+                    value={href}
+                    onChange={(event) => {
+                      setHref(event.target.value);
+                      clearFieldError("href");
+                    }}
+                    placeholder="https://..."
+                    aria-invalid={Boolean(fieldErrors.href)}
+                    className={getFieldClass("href")}
+                  />
+                  {renderFieldError("href")}
+                </label>
+
+                <label className="grid gap-2">
+                  <span className="text-sm font-black uppercase tracking-[0.14em]">Loja</span>
+                  <input
+                    value={storeLabel}
+                    onChange={(event) => {
+                      setStoreLabel(event.target.value);
+                      clearFieldError("storeLabel");
+                    }}
+                    placeholder="Amazon, Mercado Livre, AliExpress..."
+                    aria-invalid={Boolean(fieldErrors.storeLabel)}
+                    className={getFieldClass("storeLabel")}
+                  />
+                  {renderFieldError("storeLabel")}
+                </label>
+
+                <div className="flex items-end">
+                  <button
+                    type="submit"
+                    disabled={isPending}
+                    className="btn-brutal ink-button w-full px-5 py-3 text-xs disabled:opacity-60 sm:w-fit"
+                  >
+                    {isPending ? "Enviando..." : "Enviar para análise"}
+                  </button>
+                </div>
+              </form>
+
+              {feedback ? (
+                <div className="sticker sticker-pop accent-chip mt-4 inline-flex px-3 py-1.5 text-sm">
+                  {feedback}
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/src/lib/db/repository.test.ts
+++ b/src/lib/db/repository.test.ts
@@ -72,6 +72,7 @@ import {
   createLiveLikeGoal,
   createVideoSuggestion,
   createProductRecommendationFromInput,
+  createProductRecommendationSubmission,
   deleteProductRecommendation,
   applyGoogleCrossAccountProtectionEvent,
   claimViewerLinkCodeFromStreamerbot,
@@ -87,6 +88,7 @@ import {
   ingestStreamerbotEvent,
   issueViewerLinkCode,
   listAdminProductRecommendations,
+  listProductRecommendations,
   listAdminViewerDirectory,
   listRecentSubscriberAlerts,
   listBets,
@@ -112,6 +114,7 @@ import {
   cancelQueuedQuoteOverlays,
   updateGameSuggestionStatus,
   updateGameSuggestionBoostSettings,
+  updateProductRecommendationStatus,
   updateVideoSuggestionStatus,
 } from "@/lib/db/repository";
 import { GOOGLE_RISC_EVENT_TYPES } from "@/lib/google/risc";
@@ -3587,6 +3590,61 @@ describe("product recommendations", () => {
 
     expect(deleted.id).toBe(created.id);
     expect(recommendations.some((entry) => entry.id === created.id)).toBe(false);
+  });
+
+  it("keeps public submissions pending and hidden until approval", async () => {
+    const submitted = await createProductRecommendationSubmission({
+      name: "Suporte de mesa",
+      category: "perifericos",
+      context: "Ajuda a organizar controles e acessórios no setup.",
+      imageUrl: "/uploads/suporte-mesa.jpg",
+      href: "https://example.com/suporte-mesa",
+      storeLabel: "Loja Teste",
+    });
+
+    expect(submitted.moderationStatus).toBe("pending");
+    expect(submitted.isActive).toBe(false);
+    expect(await listProductRecommendations()).not.toContainEqual(
+      expect.objectContaining({ id: submitted.id }),
+    );
+
+    await updateProductRecommendationStatus({
+      recommendationId: submitted.id,
+      moderationStatus: "approved",
+    });
+
+    expect(await listProductRecommendations()).toContainEqual(
+      expect.objectContaining({
+        id: submitted.id,
+        moderationStatus: "approved",
+        isActive: true,
+      }),
+    );
+  });
+
+  it("keeps rejected submissions hidden from the public list", async () => {
+    const submitted = await createProductRecommendationSubmission({
+      name: "Cabo USB-C",
+      category: "perifericos",
+      context: "Cabo resistente para carregar acessórios da mesa.",
+      imageUrl: "/uploads/cabo-usb-c.jpg",
+      href: "https://example.com/cabo-usb-c",
+      storeLabel: "Loja Teste",
+    });
+
+    const rejected = await updateProductRecommendationStatus({
+      recommendationId: submitted.id,
+      moderationStatus: "rejected",
+    });
+
+    expect(rejected.moderationStatus).toBe("rejected");
+    expect(rejected.isActive).toBe(false);
+    expect(await listAdminProductRecommendations()).toContainEqual(
+      expect.objectContaining({ id: submitted.id, moderationStatus: "rejected" }),
+    );
+    expect(await listProductRecommendations()).not.toContainEqual(
+      expect.objectContaining({ id: submitted.id }),
+    );
   });
 
   it("rejects deleting an unknown recommendation", async () => {

--- a/src/lib/db/repository.ts
+++ b/src/lib/db/repository.ts
@@ -2330,9 +2330,22 @@ function isQuoteOverlayActive(overlay: QuoteOverlayStateRecord | null, now = Dat
   return new Date(overlay.expiresAt).getTime() > now;
 }
 
-function serializeProductRecommendation(
-  row: typeof productRecommendations.$inferSelect,
-): ProductRecommendationRecord {
+type SerializableProductRecommendationRow = Omit<
+  typeof productRecommendations.$inferSelect,
+  "moderationStatus"
+> & {
+  moderationStatus?: string | null;
+};
+
+function normalizeProductRecommendationModerationStatus(
+  value: string | null | undefined,
+): ProductRecommendationRecord["moderationStatus"] {
+  return value === "pending" || value === "approved" || value === "rejected"
+    ? value
+    : "approved";
+}
+
+function serializeProductRecommendation(row: SerializableProductRecommendationRow): ProductRecommendationRecord {
   return {
     id: row.id,
     slug: row.slug,
@@ -2343,6 +2356,7 @@ function serializeProductRecommendation(
     href: row.href,
     storeLabel: row.storeLabel,
     linkKind: row.linkKind as ProductRecommendationRecord["linkKind"],
+    moderationStatus: normalizeProductRecommendationModerationStatus(row.moderationStatus),
     isActive: row.isActive,
     sortOrder: row.sortOrder,
     createdAt: row.createdAt.toISOString(),
@@ -6022,7 +6036,9 @@ export async function listProductRecommendations(options?: {
     const store = getDemoStore();
     const source = includeInactive
       ? store.productRecommendations
-      : store.productRecommendations.filter((entry) => entry.isActive);
+      : store.productRecommendations.filter(
+          (entry) => entry.isActive && (entry.moderationStatus ?? "approved") === "approved",
+        );
 
     return [...source].sort((a, b) => {
       if (a.sortOrder !== b.sortOrder) {
@@ -6041,23 +6057,79 @@ export async function listProductRecommendations(options?: {
       : await db
           .select()
           .from(productRecommendations)
-          .where(eq(productRecommendations.isActive, true))
+          .where(
+            and(
+              eq(productRecommendations.isActive, true),
+              eq(productRecommendations.moderationStatus, "approved"),
+            ),
+          )
           .orderBy(productRecommendations.sortOrder, productRecommendations.name);
 
     return rows.map(serializeProductRecommendation);
   } catch (error) {
     if (isMissingProductRecommendationSchemaError(error)) {
-      const store = getDemoStore();
-      const source = includeInactive
-        ? store.productRecommendations
-        : store.productRecommendations.filter((entry) => entry.isActive);
+      try {
+        const legacyRows = includeInactive
+          ? await db
+              .select({
+                id: productRecommendations.id,
+                slug: productRecommendations.slug,
+                name: productRecommendations.name,
+                category: productRecommendations.category,
+                context: productRecommendations.context,
+                imageUrl: productRecommendations.imageUrl,
+                href: productRecommendations.href,
+                storeLabel: productRecommendations.storeLabel,
+                linkKind: productRecommendations.linkKind,
+                isActive: productRecommendations.isActive,
+                sortOrder: productRecommendations.sortOrder,
+                createdAt: productRecommendations.createdAt,
+                updatedAt: productRecommendations.updatedAt,
+              })
+              .from(productRecommendations)
+              .orderBy(productRecommendations.sortOrder, productRecommendations.name)
+          : await db
+              .select({
+                id: productRecommendations.id,
+                slug: productRecommendations.slug,
+                name: productRecommendations.name,
+                category: productRecommendations.category,
+                context: productRecommendations.context,
+                imageUrl: productRecommendations.imageUrl,
+                href: productRecommendations.href,
+                storeLabel: productRecommendations.storeLabel,
+                linkKind: productRecommendations.linkKind,
+                isActive: productRecommendations.isActive,
+                sortOrder: productRecommendations.sortOrder,
+                createdAt: productRecommendations.createdAt,
+                updatedAt: productRecommendations.updatedAt,
+              })
+              .from(productRecommendations)
+              .where(eq(productRecommendations.isActive, true))
+              .orderBy(productRecommendations.sortOrder, productRecommendations.name);
 
-      return [...source].sort((a, b) => {
-        if (a.sortOrder !== b.sortOrder) {
-          return a.sortOrder - b.sortOrder;
+        return legacyRows.map((row) =>
+          serializeProductRecommendation({ ...row, moderationStatus: "approved" }),
+        );
+      } catch (legacyError) {
+        if (!isMissingProductRecommendationSchemaError(legacyError)) {
+          throw legacyError;
         }
-        return a.name.localeCompare(b.name);
-      });
+
+        const store = getDemoStore();
+        const source = includeInactive
+          ? store.productRecommendations
+          : store.productRecommendations.filter(
+              (entry) => entry.isActive && (entry.moderationStatus ?? "approved") === "approved",
+            );
+
+        return [...source].sort((a, b) => {
+          if (a.sortOrder !== b.sortOrder) {
+            return a.sortOrder - b.sortOrder;
+          }
+          return a.name.localeCompare(b.name);
+        });
+      }
     }
     throw error;
   }
@@ -8769,6 +8841,7 @@ export async function upsertProductRecommendation(input: ProductRecommendationRe
         href: input.href,
         storeLabel: input.storeLabel,
         linkKind: input.linkKind,
+        moderationStatus: input.moderationStatus,
         isActive: input.isActive,
         sortOrder: input.sortOrder,
         createdAt: new Date(input.createdAt),
@@ -8785,6 +8858,7 @@ export async function upsertProductRecommendation(input: ProductRecommendationRe
           href: input.href,
           storeLabel: input.storeLabel,
           linkKind: input.linkKind,
+          moderationStatus: input.moderationStatus,
           isActive: input.isActive,
           sortOrder: input.sortOrder,
           updatedAt: new Date(input.updatedAt),
@@ -8809,8 +8883,12 @@ export async function upsertProductRecommendation(input: ProductRecommendationRe
 }
 
 export async function createProductRecommendationFromInput(
-  input: Omit<ProductRecommendationRecord, "id" | "slug" | "createdAt" | "updatedAt"> & {
+  input: Omit<
+    ProductRecommendationRecord,
+    "id" | "slug" | "createdAt" | "updatedAt" | "moderationStatus"
+  > & {
     slug?: string;
+    moderationStatus?: ProductRecommendationRecord["moderationStatus"];
   },
 ) {
   const now = new Date().toISOString();
@@ -8824,6 +8902,7 @@ export async function createProductRecommendationFromInput(
     href: input.href.trim(),
     storeLabel: input.storeLabel.trim(),
     linkKind: input.linkKind,
+    moderationStatus: input.moderationStatus ?? "approved",
     isActive: input.isActive,
     sortOrder: input.sortOrder,
     createdAt: now,
@@ -8842,10 +8921,32 @@ export async function createProductRecommendationFromInput(
   return upsertProductRecommendation(item);
 }
 
+export async function createProductRecommendationSubmission(
+  input: Pick<
+    ProductRecommendationRecord,
+    "name" | "category" | "context" | "imageUrl" | "href" | "storeLabel"
+  >,
+) {
+  const baseSlug = slugify(input.name);
+  if (!baseSlug) {
+    throw new Error("invalid_slug");
+  }
+
+  return createProductRecommendationFromInput({
+    ...input,
+    slug: `${baseSlug}-${shortCode(6).toLowerCase()}`,
+    linkKind: "external",
+    moderationStatus: "pending",
+    isActive: false,
+    sortOrder: 0,
+  });
+}
+
 export async function updateProductRecommendationStatus(input: {
   recommendationId: string;
   isActive?: boolean;
   category?: ProductRecommendationRecord["category"];
+  moderationStatus?: ProductRecommendationRecord["moderationStatus"];
 }) {
   const db = getDb();
   const updatedAt = new Date();
@@ -8863,6 +8964,14 @@ export async function updateProductRecommendationStatus(input: {
     if (input.category !== undefined) {
       recommendation.category = input.category;
     }
+    if (input.moderationStatus !== undefined) {
+      recommendation.moderationStatus = input.moderationStatus;
+      if (input.moderationStatus === "approved" && input.isActive === undefined) {
+        recommendation.isActive = true;
+      } else if (input.moderationStatus === "rejected") {
+        recommendation.isActive = false;
+      }
+    }
     recommendation.updatedAt = updatedAt.toISOString();
     return recommendation;
   }
@@ -8876,6 +8985,14 @@ export async function updateProductRecommendationStatus(input: {
     }
     if (input.category !== undefined) {
       changes.category = input.category;
+    }
+    if (input.moderationStatus !== undefined) {
+      changes.moderationStatus = input.moderationStatus;
+      if (input.moderationStatus === "approved" && input.isActive === undefined) {
+        changes.isActive = true;
+      } else if (input.moderationStatus === "rejected") {
+        changes.isActive = false;
+      }
     }
 
     const [updated] = await db
@@ -8902,6 +9019,14 @@ export async function updateProductRecommendationStatus(input: {
       }
       if (input.category !== undefined) {
         recommendation.category = input.category;
+      }
+      if (input.moderationStatus !== undefined) {
+        recommendation.moderationStatus = input.moderationStatus;
+        if (input.moderationStatus === "approved" && input.isActive === undefined) {
+          recommendation.isActive = true;
+        } else if (input.moderationStatus === "rejected") {
+          recommendation.isActive = false;
+        }
       }
       recommendation.updatedAt = updatedAt.toISOString();
       return recommendation;

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -417,6 +417,7 @@ export const productRecommendations = pgTable(
     href: text("href").notNull(),
     storeLabel: varchar("store_label", { length: 120 }).notNull(),
     linkKind: varchar("link_kind", { length: 32 }).notNull(),
+    moderationStatus: varchar("moderation_status", { length: 32 }).default("approved").notNull(),
     isActive: boolean("is_active").default(true).notNull(),
     sortOrder: integer("sort_order").default(0).notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
@@ -424,6 +425,9 @@ export const productRecommendations = pgTable(
   },
   (table) => ({
     slugIdx: uniqueIndex("product_recommendations_slug_idx").on(table.slug),
+    moderationStatusIdx: index("product_recommendations_moderation_status_idx").on(
+      table.moderationStatus,
+    ),
   }),
 );
 

--- a/src/lib/recommendation-schemas.test.ts
+++ b/src/lib/recommendation-schemas.test.ts
@@ -4,6 +4,8 @@ import {
   flattenProductRecommendationSchemaErrors,
   formatProductRecommendationSchemaError,
   productRecommendationSchema,
+  productRecommendationStatusSchema,
+  productRecommendationSubmissionSchema,
 } from "@/lib/recommendation-schemas";
 
 describe("productRecommendationSchema", () => {
@@ -21,6 +23,34 @@ describe("productRecommendationSchema", () => {
     });
 
     expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.moderationStatus).toBe("approved");
+    }
+  });
+
+  it("accepts public recommendation submissions without admin-only fields", () => {
+    const parsed = productRecommendationSubmissionSchema.safeParse({
+      name: "Produto da comunidade",
+      category: "perifericos",
+      context: "Produto útil para organizar o setup da live.",
+      imageUrl: "https://example.com/produto.jpg",
+      href: "https://example.com/produto",
+      storeLabel: "Loja Teste",
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it("accepts moderation status updates", () => {
+    expect(productRecommendationStatusSchema.safeParse({ moderationStatus: "approved" }).success).toBe(
+      true,
+    );
+    expect(productRecommendationStatusSchema.safeParse({ moderationStatus: "rejected" }).success).toBe(
+      true,
+    );
+    expect(productRecommendationStatusSchema.safeParse({ moderationStatus: "published" }).success).toBe(
+      false,
+    );
   });
 
   it("returns friendly field errors for invalid form data", () => {

--- a/src/lib/recommendation-schemas.ts
+++ b/src/lib/recommendation-schemas.ts
@@ -15,6 +15,12 @@ const productRecommendationCategorySchema = z
   .min(2, "Digite pelo menos 2 caracteres na categoria.")
   .max(32, "Use no máximo 32 caracteres na categoria.");
 
+export const productRecommendationModerationStatusSchema = z.enum([
+  "pending",
+  "approved",
+  "rejected",
+]);
+
 export const productRecommendationSchema = z.object({
   name: z
     .string()
@@ -54,6 +60,7 @@ export const productRecommendationSchema = z.object({
     .min(2, "Digite pelo menos 2 caracteres no nome da loja.")
     .max(120, "Use no máximo 120 caracteres no nome da loja."),
   linkKind: z.enum(["external", "affiliate"]).default("external"),
+  moderationStatus: productRecommendationModerationStatusSchema.default("approved"),
   isActive: z.boolean().default(true),
   sortOrder: z
     .number()
@@ -62,12 +69,30 @@ export const productRecommendationSchema = z.object({
     .default(0),
 });
 
-export const productRecommendationStatusSchema = z.object({
-  isActive: z.boolean().optional(),
-  category: productRecommendationCategorySchema.optional(),
-}).refine((value) => value.isActive !== undefined || value.category !== undefined, {
-  message: "Informe ao menos um campo para atualizar.",
+export const productRecommendationSubmissionSchema = productRecommendationSchema.pick({
+  name: true,
+  category: true,
+  context: true,
+  imageUrl: true,
+  href: true,
+  storeLabel: true,
 });
+
+export const productRecommendationStatusSchema = z
+  .object({
+    isActive: z.boolean().optional(),
+    category: productRecommendationCategorySchema.optional(),
+    moderationStatus: productRecommendationModerationStatusSchema.optional(),
+  })
+  .refine(
+    (value) =>
+      value.isActive !== undefined ||
+      value.category !== undefined ||
+      value.moderationStatus !== undefined,
+    {
+      message: "Informe ao menos um campo para atualizar.",
+    },
+  );
 
 export function formatProductRecommendationSchemaError(error: z.ZodError) {
   return error.issues[0]?.message ?? "Payload inválido.";

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -76,6 +76,11 @@ export type ProductRecommendationLinkKind =
   | "external"
   | "affiliate";
 
+export type ProductRecommendationModerationStatus =
+  | "pending"
+  | "approved"
+  | "rejected";
+
 export interface ViewerRecord {
   id: string;
   googleUserId: string | null;
@@ -673,6 +678,7 @@ export interface ProductRecommendationRecord {
   href: string;
   storeLabel: string;
   linkKind: ProductRecommendationLinkKind;
+  moderationStatus: ProductRecommendationModerationStatus;
   isActive: boolean;
   sortOrder: number;
   createdAt: string;


### PR DESCRIPTION
## Summary
- Add public product recommendation submissions from the `produtinhos` page through a modal form.
- Store submitted recommendations as inactive `pending` rows until admin moderation.
- Add admin approve/reject actions and keep public listings limited to active approved products.
- Add a manual Drizzle migration for `product_recommendations.moderation_status`.

## Migration note
This adds `moderation_status varchar(32) DEFAULT 'approved' NOT NULL` plus an index for moderation filtering. Existing products default to approved. The migration is generated but not applied.

## Validation
- `npm run typecheck`
- `npx eslint . --ignore-pattern .claude/**`
- `npx vitest run src/lib/recommendation-schemas.test.ts src/lib/db/repository.test.ts`
- `npm test`
- `npm run build`
- `git diff --check`
- Browser smoke on `http://localhost:3001/produtinhos`: button visible, form absent before click, dialog opens after click.

Closes #148