### PR TITLE
[codex] Polish game suggestions UI

### DIFF
--- a/src/app/(public)/jogos/page.tsx
+++ b/src/app/(public)/jogos/page.tsx
@@ -1,5 +1,4 @@
 import { auth } from "@/auth";
-import { GameSuggestForm } from "@/components/game-suggest-form";
 import { GameSuggestionList } from "@/components/game-suggestion-list";
 import { getPipetzPricing, getViewerDashboard, listGameSuggestions } from "@/lib/db/repository";
 import { adminEmails, isDemoMode } from "@/lib/env";
@@ -39,32 +38,15 @@ export default async function JogosPage() {
       </section>
 
       <section className="landing-plane landing-divider bg-[var(--color-paper-pink)] py-8 dark:bg-[var(--surface-card-alt)] sm:py-10">
-        <div className="mx-auto grid w-full max-w-[1500px] gap-8 px-4 sm:px-6 lg:grid-cols-[minmax(0,1.15fr)_minmax(360px,0.75fr)] lg:px-10">
-          <div>
-            <div className="mb-4 flex items-center gap-2">
-              <h2
-                className="text-2xl font-bold uppercase"
-                style={{ fontFamily: "var(--font-display)" }}
-              >
-                Sugestões da galera
-              </h2>
-            </div>
-            <GameSuggestionList
-              suggestions={suggestions}
-              loggedIn={Boolean(session?.user)}
-              canInteract={canInteract}
-              isAdmin={isAdmin}
-              viewerBalance={viewerBalance}
-            />
-          </div>
-          <div className="self-start lg:sticky lg:top-24">
-            <GameSuggestForm
-              loggedIn={Boolean(session?.user)}
-              canSuggest={canInteract}
-              viewerBalance={viewerBalance}
-              creationCost={pricing.gameSuggestionCost}
-            />
-          </div>
+        <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
+          <GameSuggestionList
+            suggestions={suggestions}
+            loggedIn={Boolean(session?.user)}
+            canInteract={canInteract}
+            isAdmin={isAdmin}
+            viewerBalance={viewerBalance}
+            creationCost={pricing.gameSuggestionCost}
+          />
         </div>
       </section>
     </div>

--- a/src/app/(public)/quotes/page.tsx
+++ b/src/app/(public)/quotes/page.tsx
@@ -40,11 +40,8 @@ export default async function QuotesPage() {
         <div className="bg-dots-light pointer-events-none absolute inset-0 opacity-20" />
         <div className="relative mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
           <div>
-            <p className="mono text-xs font-bold uppercase tracking-[0.32em] text-[var(--color-ink-soft)]">
-              Quotes da live
-            </p>
             <h1
-              className="mt-3 text-4xl uppercase sm:text-6xl lg:text-7xl"
+              className="text-4xl uppercase sm:text-6xl lg:text-7xl"
               style={{ fontFamily: "var(--font-display)" }}
             >
               Todas as frases registradas.

--- a/src/app/(public)/ranking/page.tsx
+++ b/src/app/(public)/ranking/page.tsx
@@ -10,11 +10,8 @@ export default async function RankingPage() {
         <div className="bg-dots-light pointer-events-none absolute inset-0 opacity-15" />
         <div className="relative mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
           <div>
-            <p className="mono text-xs font-bold uppercase tracking-[0.32em]">
-              🏆 Ranking de pipetz
-            </p>
             <h1
-              className="mt-3 text-4xl uppercase sm:text-6xl lg:text-7xl"
+              className="text-4xl uppercase sm:text-6xl lg:text-7xl"
               style={{ fontFamily: "var(--font-display)" }}
             >
               Quem ta mandando na live.

--- a/src/app/(public)/videos/page.tsx
+++ b/src/app/(public)/videos/page.tsx
@@ -23,11 +23,8 @@ export default async function VideosPage() {
       <section className="landing-plane surface-hero relative overflow-hidden py-8 sm:py-10">
         <div className="bg-dots-light pointer-events-none absolute inset-0 opacity-20" />
         <div className="relative mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
-          <p className="mono text-xs font-bold uppercase tracking-[0.32em] text-[var(--color-ink-soft)]">
-            Sugestões de vídeos
-          </p>
           <h1
-            className="mt-3 text-4xl uppercase sm:text-6xl lg:text-7xl"
+            className="text-4xl uppercase sm:text-6xl lg:text-7xl"
             style={{ fontFamily: "var(--font-display)" }}
           >
             Me diz ao que reagir.

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -78,9 +78,8 @@ export default function PrivacyPage() {
       <section className="panel surface-hero p-6 sm:p-8">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div>
-            <span className="retro-label accent-chip">documento público</span>
             <h1
-              className="mt-4 text-4xl uppercase leading-[0.9] sm:text-5xl"
+              className="text-4xl uppercase leading-[0.9] sm:text-5xl"
               style={{ fontFamily: "var(--font-display)" }}
             >
               Política de privacidade
@@ -111,11 +110,8 @@ export default function PrivacyPage() {
                 : "bg-[var(--color-mint)] text-[var(--color-accent-ink)]"
           }`}
         >
-          <p className={`mono text-[11px] uppercase tracking-[0.24em] ${ index % 3 === 0 ? "text-[var(--color-ink-soft)]" : "text-[var(--color-accent-ink-soft)]" }`}>
-            seção {String(index + 1).padStart(2, "0")}
-          </p>
           <h2
-            className="mt-3 text-3xl uppercase leading-none sm:text-4xl"
+            className="text-3xl uppercase leading-none sm:text-4xl"
             style={{ fontFamily: "var(--font-display)" }}
           >
             {section.title}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -74,9 +74,8 @@ export default function TermsPage() {
       <section className="panel surface-hero p-6 sm:p-8">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div>
-            <span className="retro-label accent-chip">documento público</span>
             <h1
-              className="mt-4 text-4xl uppercase leading-[0.9] sm:text-5xl"
+              className="text-4xl uppercase leading-[0.9] sm:text-5xl"
               style={{ fontFamily: "var(--font-display)" }}
             >
               Termos de serviço
@@ -106,15 +105,8 @@ export default function TermsPage() {
                 : "bg-[var(--color-mint)] text-[var(--color-accent-ink)]"
           }`}
         >
-          <p
-            className={`mono text-[11px] uppercase tracking-[0.24em] ${
-              index % 3 === 0 ? "text-[var(--color-ink-soft)]" : "text-[var(--color-accent-ink-soft)]"
-            }`}
-          >
-            seção {String(index + 1).padStart(2, "0")}
-          </p>
           <h2
-            className="mt-3 text-3xl uppercase leading-none sm:text-4xl"
+            className="text-3xl uppercase leading-none sm:text-4xl"
             style={{ fontFamily: "var(--font-display)" }}
           >
             {section.title}

--- a/src/components/admin-game-suggestions-panel.tsx
+++ b/src/components/admin-game-suggestions-panel.tsx
@@ -9,7 +9,9 @@ import type {
   GameSuggestionBoostSettingsRecord,
   GameSuggestionWithMeta,
 } from "@/lib/types";
-import { formatDateTime, formatPipetz } from "@/lib/utils";
+import { cn, formatDateTime, formatPipetz } from "@/lib/utils";
+
+type GameSuggestionStatus = GameSuggestionWithMeta["status"];
 
 type BoostSettingField = keyof Pick<
   GameSuggestionBoostSettingsRecord,
@@ -44,6 +46,15 @@ const statusLabels: Record<GameSuggestionWithMeta["status"], string> = {
   played: "Jogada",
   rejected: "Rejeitada",
 };
+
+const statusFilterOptions: Array<{ status: GameSuggestionStatus; label: string }> = [
+  { status: "open", label: "Abertas" },
+  { status: "accepted", label: "Aceitas" },
+  { status: "played", label: "Já jogadas" },
+  { status: "rejected", label: "Recusadas" },
+];
+
+const DEFAULT_VISIBLE_STATUSES: GameSuggestionStatus[] = ["open", "accepted"];
 
 const statusBgMap: Record<GameSuggestionWithMeta["status"], string> = {
   open: "var(--color-sky)",
@@ -93,10 +104,21 @@ export function AdminGameSuggestionsPanel({
   const [boostForm, setBoostForm] = useState(toBoostFormState(initialBoostSettings));
   const [isPending, startTransition] = useTransition();
   const [showAllSuggestions, setShowAllSuggestions] = useState(false);
+  const [visibleStatuses, setVisibleStatuses] = useState<GameSuggestionStatus[]>(DEFAULT_VISIBLE_STATUSES);
+  const filteredSuggestions = suggestions.filter((suggestion) => visibleStatuses.includes(suggestion.status));
   const visibleSuggestions = showAllSuggestions
-    ? suggestions
-    : suggestions.slice(0, INITIAL_VISIBLE_GAME_SUGGESTIONS);
-  const hiddenSuggestionCount = Math.max(suggestions.length - visibleSuggestions.length, 0);
+    ? filteredSuggestions
+    : filteredSuggestions.slice(0, INITIAL_VISIBLE_GAME_SUGGESTIONS);
+  const hiddenSuggestionCount = Math.max(filteredSuggestions.length - visibleSuggestions.length, 0);
+
+  function toggleStatusFilter(status: GameSuggestionStatus) {
+    setShowAllSuggestions(false);
+    setVisibleStatuses((currentStatuses) =>
+      currentStatuses.includes(status)
+        ? currentStatuses.filter((currentStatus) => currentStatus !== status)
+        : [...currentStatuses, status]
+    );
+  }
 
   function updateBoostField(field: BoostSettingField, value: string) {
     setBoostForm((current) => ({
@@ -192,11 +214,8 @@ export function AdminGameSuggestionsPanel({
         <div className="mt-6 panel surface-section p-5">
           <div className="flex flex-wrap items-start justify-between gap-4">
             <div>
-              <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
-                Boosts automáticos
-              </p>
               <h3
-                className="mt-2 text-2xl font-bold uppercase"
+                className="text-2xl font-bold uppercase"
                 style={{ fontFamily: "var(--font-display)" }}
               >
                 Multiplicadores
@@ -247,10 +266,52 @@ export function AdminGameSuggestionsPanel({
           </div>
         </div>
 
+        <div className="mt-6 panel surface-section p-5">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <h3
+                className="text-2xl font-bold uppercase"
+                style={{ fontFamily: "var(--font-display)" }}
+              >
+                Status das sugestões
+              </h3>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {statusFilterOptions.map((option) => {
+                const isChecked = visibleStatuses.includes(option.status);
+                const statusCount = suggestions.filter((suggestion) => suggestion.status === option.status).length;
+
+                return (
+                  <label
+                    key={option.status}
+                    className={cn(
+                      "badge-brutal flex cursor-pointer items-center gap-2 px-3 py-2 text-xs text-[var(--color-ink)] transition hover:-translate-y-0.5",
+                      isChecked ? "bg-[var(--color-mint)]" : "bg-[var(--color-paper)] opacity-70"
+                    )}
+                  >
+                    <input
+                      type="checkbox"
+                      className="size-4 accent-[var(--color-mint)]"
+                      checked={isChecked}
+                      onChange={() => toggleStatusFilter(option.status)}
+                    />
+                    <span>{option.label}</span>
+                    <span className="mono text-[10px]">({statusCount})</span>
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
         <div className="mt-6 grid gap-3">
           {suggestions.length === 0 ? (
             <div className="card-brutal-static p-4 text-sm font-bold text-[var(--color-ink-soft)]">
               Nenhuma sugestão cadastrada.
+            </div>
+          ) : filteredSuggestions.length === 0 ? (
+            <div className="card-brutal-static p-4 text-sm font-bold text-[var(--color-ink-soft)]">
+              Nenhuma sugestão corresponde aos filtros selecionados.
             </div>
           ) : null}
 

--- a/src/components/admin-streamerbot-scripts-panel.tsx
+++ b/src/components/admin-streamerbot-scripts-panel.tsx
@@ -73,11 +73,8 @@ export function AdminStreamerbotScriptsPanel({
     <div className="panel surface-section p-6">
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
-          <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
-            Streamer.bot
-          </p>
           <h2
-            className="mt-2 text-2xl font-bold uppercase"
+            className="text-2xl font-bold uppercase"
             style={{ fontFamily: "var(--font-display)" }}
           >
             Códigos C# da integração

--- a/src/components/current-game-spotlight.tsx
+++ b/src/components/current-game-spotlight.tsx
@@ -33,10 +33,7 @@ export function CurrentGameSpotlight({
           </div>
 
           <div className="flex flex-col justify-center p-6 sm:p-8">
-            <p className="mono text-[11px] font-black uppercase tracking-[0.28em] text-[var(--color-ink-soft)]">
-              jogando agora
-            </p>
-            <h2 className="mt-3 text-4xl uppercase leading-[0.9] sm:text-5xl" style={{ fontFamily: "var(--font-display)" }}>
+            <h2 className="text-4xl uppercase leading-[0.9] sm:text-5xl" style={{ fontFamily: "var(--font-display)" }}>
               {game.name}
             </h2>
             {metadata ? (

--- a/src/components/death-counter-game-panel.tsx
+++ b/src/components/death-counter-game-panel.tsx
@@ -100,11 +100,8 @@ export function DeathCounterGamePanel({
 
   return (
     <div className="panel surface-section p-6">
-      <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
-        Contador de mortes
-      </p>
       <h2
-        className="mt-2 text-2xl font-bold uppercase"
+        className="text-2xl font-bold uppercase"
         style={{ fontFamily: "var(--font-display)" }}
       >
         Jogo ativo

--- a/src/components/game-suggest-form.tsx
+++ b/src/components/game-suggest-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useTransition } from "react";
+import { XIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
@@ -8,7 +9,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { GAME_SUGGESTION_CREATION_COST } from "@/lib/game-suggestions/constants";
 import { validateGameSuggestionDraft } from "@/lib/game-suggestions/service";
-import { formatPipetz } from "@/lib/utils";
+import { cn, formatPipetz } from "@/lib/utils";
 
 type GameSearchResult = {
   igdbId: number;
@@ -37,11 +38,17 @@ export function GameSuggestForm({
   canSuggest = false,
   viewerBalance,
   creationCost = GAME_SUGGESTION_CREATION_COST,
+  titleId,
+  onRequestClose,
+  className,
 }: {
   loggedIn?: boolean;
   canSuggest?: boolean;
   viewerBalance?: number | null;
   creationCost?: number;
+  titleId?: string;
+  onRequestClose?: () => void;
+  className?: string;
 }) {
   const router = useRouter();
   const [name, setName] = useState("");
@@ -188,7 +195,10 @@ export function GameSuggestForm({
   return (
     <form
       onSubmit={handleSubmit}
-      className="panel surface-section relative overflow-hidden border-2 p-5 text-[var(--color-ink)] sm:p-6"
+      className={cn(
+        "panel surface-section relative overflow-hidden border-2 p-5 text-[var(--color-ink)] sm:p-6",
+        className,
+      )}
     >
       <div className="bg-dots-light pointer-events-none absolute inset-0 opacity-15" />
 
@@ -196,6 +206,7 @@ export function GameSuggestForm({
         <div className="flex items-center justify-between gap-3">
           <div>
             <h3
+              id={titleId}
               className="text-lg font-bold uppercase"
               style={{ fontFamily: "var(--font-display)" }}
             >
@@ -213,6 +224,17 @@ export function GameSuggestForm({
               <span className="retro-label neutral-chip !rounded-none !border !shadow-none">
                 saldo {formatPipetz(viewerBalance)}
               </span>
+            ) : null}
+            {onRequestClose ? (
+              <Button
+                type="button"
+                size="icon"
+                variant="neutral"
+                aria-label="Fechar popup de sugestão"
+                onClick={onRequestClose}
+              >
+                <XIcon className="size-4" aria-hidden="true" />
+              </Button>
             ) : null}
           </div>
         </div>
@@ -256,7 +278,7 @@ export function GameSuggestForm({
 
             {searchFailed ? (
               <p className="mt-2 text-xs font-bold uppercase tracking-[0.12em] text-[var(--color-ink-soft)]">
-                busca indisponivel; voce ainda pode enviar pelo nome
+                busca indisponível; você ainda pode enviar pelo nome
               </p>
             ) : null}
 

--- a/src/components/game-suggestion-card.tsx
+++ b/src/components/game-suggestion-card.tsx
@@ -6,7 +6,7 @@ import { BadgeDollarSign, Clock3 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import type { GameSuggestionWithMeta } from "@/lib/types";
-import { formatPipetz } from "@/lib/utils";
+import { cn, formatPipetz } from "@/lib/utils";
 
 type GameSearchResult = {
   igdbId: number;
@@ -16,6 +16,8 @@ type GameSearchResult = {
   platforms: string[];
   genres: string[];
 };
+
+export type GameSuggestionViewMode = "list" | "grid";
 
 function mapSuggestionError(message: string) {
   switch (message) {
@@ -111,6 +113,7 @@ function buildHowLongToBeatTooltip(suggestion: GameSuggestionWithMeta) {
 
 export function GameSuggestionCard({
   suggestion,
+  viewMode = "list",
   loggedIn = false,
   canBoost = false,
   canEditCatalog = false,
@@ -119,6 +122,7 @@ export function GameSuggestionCard({
 }: {
   suggestion: GameSuggestionWithMeta;
   index?: number;
+  viewMode?: GameSuggestionViewMode;
   loggedIn?: boolean;
   canBoost?: boolean;
   canEditCatalog?: boolean;
@@ -283,20 +287,44 @@ export function GameSuggestionCard({
   ]
     .filter(Boolean)
     .join(" / ");
+  const isGridMode = viewMode === "grid";
 
   return (
-    <article className="card-brutal relative overflow-hidden bg-[var(--color-paper)] p-0">
-      <div className="grid gap-0 md:grid-cols-[minmax(150px,190px)_1fr_auto]">
-        <div className="relative min-h-64 border-b-2 border-[var(--color-ink)] bg-[var(--color-paper)] md:min-h-0 md:border-b-0 md:border-r-1">
+    <article
+      className={cn(
+        "card-brutal relative overflow-hidden bg-[var(--color-paper)] p-0",
+        isGridMode && "self-start",
+      )}
+    >
+      <div
+        className={cn(
+          "grid gap-0",
+          !isGridMode && "md:grid-cols-[minmax(150px,190px)_1fr_auto]",
+        )}
+      >
+        <div
+          className={cn(
+            "relative border-b-2 border-[var(--color-ink)] bg-[var(--color-paper)]",
+            isGridMode ? "aspect-[4/3]" : "min-h-64 md:min-h-0 md:border-b-0 md:border-r-1",
+          )}
+        >
           {suggestion.coverImageUrl ? (
             // eslint-disable-next-line @next/next/no-img-element
             <img
               src={suggestion.coverImageUrl}
               alt={`Capa de ${displayName}`}
-              className="h-full min-h-64 w-full object-cover md:min-h-0"
+              className={cn(
+                "h-full w-full object-cover",
+                !isGridMode && "min-h-64 md:min-h-0",
+              )}
             />
           ) : (
-            <div className="flex h-full min-h-64 w-full items-center justify-center bg-[var(--color-lavender)] px-4 text-center md:min-h-0">
+            <div
+              className={cn(
+                "flex h-full w-full items-center justify-center bg-[var(--color-lavender)] px-4 text-center",
+                !isGridMode && "min-h-64 md:min-h-0",
+              )}
+            >
               <span
                 className="text-xl font-bold uppercase"
                 style={{ fontFamily: "var(--font-display)" }}
@@ -310,7 +338,10 @@ export function GameSuggestionCard({
         <div className="flex min-w-0 flex-col p-5 sm:p-6">
           <div className="min-w-0">
             <h3
-              className="text-2xl font-bold leading-none sm:text-3xl"
+              className={cn(
+                "font-bold leading-none",
+                isGridMode ? "text-xl sm:text-2xl" : "text-2xl sm:text-3xl",
+              )}
               style={{ fontFamily: "var(--font-display)" }}
             >
               {displayName}
@@ -496,7 +527,12 @@ export function GameSuggestionCard({
           ) : null}
         </div>
 
-        <aside className="flex items-start justify-between gap-4 border-t-2 border-[var(--color-ink)] bg-[var(--color-paper)] p-5 md:min-w-36 md:flex-col md:border-l-1 md:border-t-0">
+        <aside
+          className={cn(
+            "flex items-start justify-between gap-4 border-t-2 border-[var(--color-ink)] bg-[var(--color-paper)] p-5",
+            !isGridMode && "md:min-w-36 md:flex-col md:border-l-1 md:border-t-0",
+          )}
+        >
           <div>
             <p
               className="text-3xl font-bold leading-none text-[var(--color-purple-bold)] sm:text-4xl"

--- a/src/components/game-suggestion-list.tsx
+++ b/src/components/game-suggestion-list.tsx
@@ -1,10 +1,16 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { LayoutGridIcon, ListIcon, PlusIcon } from "lucide-react";
 
+import { GameSuggestForm } from "@/components/game-suggest-form";
 import { GameSuggestionCard } from "@/components/game-suggestion-card";
+import { Button } from "@/components/ui/button";
 import { getVisibleGameSuggestionSections } from "@/lib/game-suggestions/sections";
 import type { GameSuggestionWithMeta } from "@/lib/types";
+import { cn, formatPipetz } from "@/lib/utils";
+
+type ViewMode = "list" | "grid";
 
 export function GameSuggestionList({
   suggestions,
@@ -12,15 +18,19 @@ export function GameSuggestionList({
   canInteract = false,
   isAdmin = false,
   viewerBalance,
+  creationCost,
 }: {
   suggestions: GameSuggestionWithMeta[];
   loggedIn?: boolean;
   canInteract?: boolean;
   isAdmin?: boolean;
   viewerBalance?: number | null;
+  creationCost: number;
 }) {
   const [localSuggestions, setLocalSuggestions] = useState(suggestions);
   const [localBalance, setLocalBalance] = useState<number | null>(viewerBalance ?? null);
+  const [viewMode, setViewMode] = useState<ViewMode>("list");
+  const [isSuggestModalOpen, setIsSuggestModalOpen] = useState(false);
 
   useEffect(() => {
     setLocalSuggestions(suggestions);
@@ -52,28 +62,131 @@ export function GameSuggestionList({
 
   const { recommendedSuggestions, playedSuggestions, visibleCount } =
     getVisibleGameSuggestionSections(localSuggestions);
+  const openCount = recommendedSuggestions.filter((suggestion) => suggestion.status === "open").length;
+  const suggestionListClassName = cn("grid gap-4", viewMode === "grid" && "items-start");
+  const suggestionListStyle =
+    viewMode === "grid"
+      ? { gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 300px), 1fr))" }
+      : undefined;
+
+  function renderSuggestionCards(items: GameSuggestionWithMeta[], indexOffset = 0) {
+    return items.map((suggestion, index) => (
+      <GameSuggestionCard
+        key={suggestion.id}
+        suggestion={suggestion}
+        index={indexOffset + index}
+        viewMode={viewMode}
+        loggedIn={loggedIn}
+        canBoost={canInteract}
+        canEditCatalog={isAdmin}
+        viewerBalance={localBalance}
+        onBoostSuccess={handleBoostSuccess}
+        onCatalogUpdate={handleCatalogUpdate}
+      />
+    ));
+  }
 
   return (
-    <div className="grid gap-4">
+    <div className="grid gap-5">
+      <div className="panel surface-section p-4 sm:p-5">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="max-w-3xl">
+            <h2
+              className="text-2xl font-bold uppercase sm:text-3xl"
+              style={{ fontFamily: "var(--font-display)" }}
+            >
+              Sugestões da galera
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-[var(--color-ink-soft)]">
+              Enviar uma sugestão custa {formatPipetz(creationCost)}. A comunidade pode dar boost para aumentar a prioridade dos jogos na lista.
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center lg:justify-end">
+            <div className="grid grid-cols-2 border-2 border-[var(--color-ink)] bg-[var(--color-paper)] text-center">
+              <div className="border-r-2 border-[var(--color-ink)] px-4 py-2">
+                <p
+                  className="text-2xl font-bold"
+                  style={{ fontFamily: "var(--font-display)" }}
+                >
+                  {visibleCount}
+                </p>
+                <p className="mono text-[10px] font-bold uppercase tracking-[0.14em] text-[var(--color-ink-soft)]">
+                  visíveis
+                </p>
+              </div>
+              <div className="px-4 py-2">
+                <p
+                  className="text-2xl font-bold"
+                  style={{ fontFamily: "var(--font-display)" }}
+                >
+                  {openCount}
+                </p>
+                <p className="mono text-[10px] font-bold uppercase tracking-[0.14em] text-[var(--color-ink-soft)]">
+                  abertas
+                </p>
+              </div>
+            </div>
+
+            <div
+              className="inline-grid grid-cols-2 border-2 border-[var(--color-ink)] bg-[var(--color-paper)]"
+              aria-label="Modo de visualização"
+            >
+              <button
+                type="button"
+                aria-pressed={viewMode === "list"}
+                aria-label="Visualizar sugestões em lista"
+                onClick={() => setViewMode("list")}
+                className={cn(
+                  "inline-flex h-11 items-center justify-center gap-2 border-r-2 border-[var(--color-ink)] px-3 text-xs font-black uppercase outline-none focus-visible:outline-[3px] focus-visible:outline-[var(--color-purple-mid)]",
+                  viewMode === "list"
+                    ? "bg-[var(--color-ink)] text-[var(--color-accent-ink)]"
+                    : "text-[var(--color-ink)] hover:bg-[var(--color-sky)]",
+                )}
+              >
+                <ListIcon className="size-4" aria-hidden="true" />
+                Lista
+              </button>
+              <button
+                type="button"
+                aria-pressed={viewMode === "grid"}
+                aria-label="Visualizar sugestões em grade"
+                onClick={() => setViewMode("grid")}
+                className={cn(
+                  "inline-flex h-11 items-center justify-center gap-2 px-3 text-xs font-black uppercase outline-none focus-visible:outline-[3px] focus-visible:outline-[var(--color-purple-mid)]",
+                  viewMode === "grid"
+                    ? "bg-[var(--color-ink)] text-[var(--color-accent-ink)]"
+                    : "text-[var(--color-ink)] hover:bg-[var(--color-sky)]",
+                )}
+              >
+                <LayoutGridIcon className="size-4" aria-hidden="true" />
+                Grade
+              </button>
+            </div>
+
+            <Button
+              type="button"
+              onClick={() => setIsSuggestModalOpen(true)}
+              variant="accent"
+              size="lg"
+              className="gap-2"
+            >
+              <PlusIcon className="size-4" aria-hidden="true" />
+              Sugerir jogo
+            </Button>
+          </div>
+        </div>
+      </div>
+
       {visibleCount === 0 ? (
         <div className="card-brutal-static bg-[var(--color-paper)] p-4 text-sm font-bold text-[var(--color-ink-soft)]">
           Nenhuma sugestão disponível no momento.
         </div>
       ) : null}
 
-      {recommendedSuggestions.map((suggestion, index) => (
-        <GameSuggestionCard
-          key={suggestion.id}
-          suggestion={suggestion}
-          index={index}
-          loggedIn={loggedIn}
-          canBoost={canInteract}
-          canEditCatalog={isAdmin}
-          viewerBalance={localBalance}
-          onBoostSuccess={handleBoostSuccess}
-          onCatalogUpdate={handleCatalogUpdate}
-        />
-      ))}
+      <div className={suggestionListClassName} style={suggestionListStyle}>
+        {renderSuggestionCards(recommendedSuggestions)}
+      </div>
 
       {playedSuggestions.length > 0 ? (
         <section className="mt-6 grid gap-4 border-t-2 border-dashed border-[var(--color-ink)] pt-6">
@@ -86,20 +199,29 @@ export function GameSuggestionList({
             </h3>
           </div>
 
-          {playedSuggestions.map((suggestion, index) => (
-            <GameSuggestionCard
-              key={suggestion.id}
-              suggestion={suggestion}
-              index={recommendedSuggestions.length + index}
-              loggedIn={loggedIn}
-              canBoost={canInteract}
-              canEditCatalog={isAdmin}
-              viewerBalance={localBalance}
-              onBoostSuccess={handleBoostSuccess}
-              onCatalogUpdate={handleCatalogUpdate}
-            />
-          ))}
+          <div className={suggestionListClassName} style={suggestionListStyle}>
+            {renderSuggestionCards(playedSuggestions, recommendedSuggestions.length)}
+          </div>
         </section>
+      ) : null}
+
+      {isSuggestModalOpen ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--color-backdrop)] p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="game-suggestion-modal-title"
+        >
+          <GameSuggestForm
+            loggedIn={loggedIn}
+            canSuggest={canInteract}
+            viewerBalance={localBalance}
+            creationCost={creationCost}
+            titleId="game-suggestion-modal-title"
+            onRequestClose={() => setIsSuggestModalOpen(false)}
+            className="max-h-[calc(100vh-2rem)] w-full max-w-2xl overflow-y-auto"
+          />
+        </div>
       ) : null}
     </div>
   );

--- a/src/components/pipetz-balance-card.tsx
+++ b/src/components/pipetz-balance-card.tsx
@@ -16,11 +16,8 @@ export function PipetzBalanceCard({
       <div className="relative mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
         <div className="flex flex-wrap items-end justify-between gap-4">
           <div>
-            <p className="mono text-xs uppercase tracking-[0.3em] text-[var(--color-ink-soft)]">
-              Meus Pipetz
-            </p>
             <h1
-              className={`mt-2 uppercase text-[var(--color-ink)] ${compact ? "text-2xl" : "text-4xl sm:text-5xl"}`}
+              className={`uppercase text-[var(--color-ink)] ${compact ? "text-2xl" : "text-4xl sm:text-5xl"}`}
               style={{ fontFamily: "var(--font-display)" }}
             >
               {displayName}

--- a/src/components/pipetz-spending-history-card.tsx
+++ b/src/components/pipetz-spending-history-card.tsx
@@ -13,9 +13,6 @@ export function PipetzSpendingHistoryCard({
       <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
         <div className="mb-5 flex flex-wrap items-end justify-between gap-3">
           <div>
-            <p className="mono text-xs uppercase tracking-[0.24em] text-[var(--color-ink-soft)]">
-              Histórico
-            </p>
             <h2 className="text-2xl uppercase text-[var(--color-ink)]" style={{ fontFamily: "var(--font-display)" }}>
               Gastos de pipetz
             </h2>

--- a/src/components/redemption-grid.tsx
+++ b/src/components/redemption-grid.tsx
@@ -40,10 +40,7 @@ export function RedemptionGrid({
     <>
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div>
-          <p className="mono text-xs uppercase tracking-[0.32em] text-[var(--color-ink-soft)]">
-            Resgates disponíveis
-          </p>
-          <h2 className="mt-2 text-3xl font-bold uppercase" style={{ fontFamily: "var(--font-display)" }}>
+          <h2 className="text-3xl font-bold uppercase" style={{ fontFamily: "var(--font-display)" }}>
             {expanded ? "Todos os resgates" : "Resgates em destaque"}
           </h2>
         </div>

--- a/src/components/viewer-channel-list-card.tsx
+++ b/src/components/viewer-channel-list-card.tsx
@@ -14,10 +14,7 @@ export function ViewerChannelListCard({
     <section className="landing-plane landing-divider bg-[var(--color-paper)] py-8 sm:py-10">
       <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
         <div>
-          <p className="mono text-[10px] uppercase tracking-[0.28em] text-[var(--color-ink-soft)]">
-            Conta Google
-          </p>
-          <h2 className="mt-3 text-3xl uppercase" style={{ fontFamily: "var(--font-display)" }}>
+          <h2 className="text-3xl uppercase" style={{ fontFamily: "var(--font-display)" }}>
             Canais vinculados
           </h2>
           <p className="mt-3 max-w-3xl text-sm leading-7 text-[var(--color-ink-soft)]">

--- a/src/components/viewer-link-card.tsx
+++ b/src/components/viewer-link-card.tsx
@@ -93,10 +93,7 @@ export function ViewerLinkCard({
     <section className="landing-plane landing-divider bg-[var(--color-paper-pink)] py-8 sm:py-10">
       <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-10">
         <div className="card-brutal-static bg-[var(--color-paper)] p-6 sm:p-8">
-          <p className="mono text-[10px] uppercase tracking-[0.28em] text-[var(--color-ink-soft)]">
-            Vínculo da live
-          </p>
-          <h2 className="mt-3 text-3xl uppercase" style={{ fontFamily: "var(--font-display)" }}>
+          <h2 className="text-3xl uppercase" style={{ fontFamily: "var(--font-display)" }}>
             {alreadyLinked ? "Adicionar outro canal do YouTube." : "Vincule seu canal do YouTube."}
           </h2>
           <p className="mt-4 max-w-3xl text-sm leading-7 text-[var(--color-ink-soft)] sm:text-base">


### PR DESCRIPTION
## What changed
- Moved the game suggestion form into a modal and added list/grid view controls.
- Adjusted grid card sizing so cards keep a better format across viewport widths.
- Added admin status filters for game suggestions, with played and rejected hidden by default.
- Removed decorative eyebrow tags above page and section titles.

## Why
Issue #129 asks for a less intrusive game suggestion flow with list/grid views that remain usable on desktop and mobile. The follow-up UI changes keep the admin and public pages aligned with the same cleaner title treatment.

Closes #129

## Validation
- `npm.cmd run typecheck`
- `npx.cmd eslint -- src/app/(public)/jogos/page.tsx src/app/(public)/quotes/page.tsx src/app/(public)/ranking/page.tsx src/app/(public)/videos/page.tsx src/app/privacy/page.tsx src/app/terms/page.tsx src/components/admin-game-suggestions-panel.tsx src/components/admin-streamerbot-scripts-panel.tsx src/components/current-game-spotlight.tsx src/components/death-counter-game-panel.tsx src/components/game-suggest-form.tsx src/components/game-suggestion-card.tsx src/components/game-suggestion-list.tsx src/components/pipetz-balance-card.tsx src/components/pipetz-spending-history-card.tsx src/components/redemption-grid.tsx src/components/viewer-channel-list-card.tsx src/components/viewer-link-card.tsx`
- `npm.cmd test`
- `npm.cmd run build`