### PR TITLE
Redesign home page around the live and current game

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,13 @@ This version has breaking changes — APIs, conventions, and file structure may 
 - If a file already contains mojibake such as `IndicaÃ§Ãµes`, `vocÃª`, or `Ã¡`, fix the affected copy instead of copying the corrupted text forward.
 - When using `apply_patch`, write Portuguese copy with the intended accents directly in the patch and verify the rendered page or relevant source after editing.
 
+# Website Voice (No Self-Reference)
+
+The website must never refer to itself or describe its own interface, and it is not selling or promoting itself to the user.
+
+- Write user-facing copy about the viewer, the streamer, and what happens in the live — never about the site, its pages, panels, dashboards, navigation, or how it compares to other tools or interfaces.
+- Avoid self-referential or self-marketing phrasing such as `sem atravessar um painel cheio de números`, `a página inicial mostra...`, or `o que move a página`. Speak directly to the viewer and the live experience instead.
+
 # GitHub PR Linking
 
 When creating a GitHub PR, explicitly state which issue it closes in the PR description so GitHub links it automatically.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,17 @@
-import type { ReactNode } from "react";
+import type { CSSProperties } from "react";
 import Link from "next/link";
-import Image from "next/image";
+import {
+  ArrowRight,
+  CirclePlay,
+  Gamepad2,
+  Sparkles,
+  Ticket,
+  type LucideIcon,
+} from "lucide-react";
 
 import { auth } from "@/auth";
 import { AuthButtons } from "@/components/auth-buttons";
-import { CurrentGameSpotlight } from "@/components/current-game-spotlight";
 import { LivestreamIndicator } from "@/components/livestream-indicator";
-import { QuickNavGrid } from "@/components/quick-nav-grid";
-import { StickerBadge } from "@/components/sticker-badge";
 import { GOOGLE_ACCOUNT_SWITCH_HINT } from "@/lib/auth/google";
 import {
   getAccountProtectionStatusFromSearchParams,
@@ -15,47 +19,49 @@ import {
   hasUsableAppSession,
   type AccountProtectionStatus,
 } from "@/lib/auth/session-state";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { getCatalog, getLeaderboard, getViewerDashboard, listBets } from "@/lib/db/repository";
 import { getCurrentGame } from "@/lib/current-game";
+import { listBets } from "@/lib/db/repository";
 import { isStreamerbotLivestreamActive } from "@/lib/streamerbot/live-status";
-import type { BetWithOptionsRecord } from "@/lib/types";
-import { cn, formatPipetz } from "@/lib/utils";
+import type { BetWithOptionsRecord, CurrentGameRecord } from "@/lib/types";
+import { cn } from "@/lib/utils";
 
-type HomeMetric = {
-  label: string;
-  value: string;
-  note: string;
-  bg: string;
-};
+const LUDYLOPS_PROFILE_IMAGE = "/selfie2.png";
 
-type SpotlightProps = {
-  activeBet: BetWithOptionsRecord | undefined;
-  loggedIn?: boolean;
-};
-
-type FeatureCard = {
-  symbol: string;
-  eyebrow: string;
+type HomeAction = {
+  href: string;
   title: string;
   body: string;
+  cta: string;
+  icon: LucideIcon;
   bg: string;
 };
 
-const LUDYLOPS_PROFILE_IMAGE =
-  "/selfie2.png";
+type HomePageProps = {
+  searchParams: Promise<{ googleAccountProtection?: string | string[] | undefined }>;
+};
 
-function usesPastelSurface(bgClass: string) {
-  return ["--color-blue", "--color-purple", "--color-pink", "--color-yellow", "--color-mint"].some((token) =>
-    bgClass.includes(token),
-  );
+function getGameMetadataParts(game: CurrentGameRecord | null) {
+  if (!game) {
+    return [];
+  }
+
+  return [game.releaseYear, ...game.platforms.slice(0, 2), ...game.genres.slice(0, 2)]
+    .filter(Boolean)
+    .map(String);
+}
+
+function getHeroBackgroundStyle(game: CurrentGameRecord | null): CSSProperties {
+  const imageUrl = game?.coverImageUrl ?? LUDYLOPS_PROFILE_IMAGE;
+
+  return {
+    backgroundImage: [
+      "linear-gradient(90deg, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0.45) 48%, rgba(0, 0, 0, 0.05) 100%)",
+      "linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.5) 100%)",
+      `url(${JSON.stringify(imageUrl)})`,
+    ].join(", "),
+    backgroundPosition: game?.coverImageUrl ? "center" : "center 22%",
+    backgroundSize: "cover",
+  };
 }
 
 function AccountProtectionNotice({ status }: { status: AccountProtectionStatus }) {
@@ -73,8 +79,10 @@ function AccountProtectionNotice({ status }: { status: AccountProtectionStatus }
       : "Se estiver tudo certo na sua conta Google, você pode entrar novamente agora.";
 
   return (
-    <div className="card-poster mt-6 border-[3px] border-[var(--color-ink)] bg-[var(--color-blue)] p-4 text-[var(--color-accent-ink)]">
-      <p className="mono text-[10px] uppercase tracking-[0.24em]">segurança da conta</p>
+    <div className="mt-6 max-w-2xl border-[3px] border-white bg-white/92 p-4 text-black shadow-[5px_5px_0_rgba(255,255,255,0.28)]">
+      <p className="mono text-[10px] uppercase tracking-[0.24em] text-black/70">
+        segurança da conta
+      </p>
       <p className="mt-2 text-lg font-black uppercase leading-tight">{title}</p>
       <p className="mt-3 text-sm font-bold leading-6">{body}</p>
       <p className="mt-3 text-sm font-medium leading-6">{nextStep}</p>
@@ -83,467 +91,331 @@ function AccountProtectionNotice({ status }: { status: AccountProtectionStatus }
   );
 }
 
-function MetricCard({ metric, className }: { metric: HomeMetric; className?: string }) {
-  const usesPastelInk = usesPastelSurface(metric.bg);
+function HeroGameLabel({ game }: { game: CurrentGameRecord | null }) {
+  const metadata = getGameMetadataParts(game);
 
   return (
-    <Card
-      variant="poster"
-      className={cn("p-4", metric.bg, usesPastelInk && "text-[var(--color-accent-ink)]", className)}
-    >
-      <CardHeader className="gap-0">
-        <CardDescription
-          className={cn(
-            "mono text-[10px] uppercase tracking-[0.24em]",
-            usesPastelInk ? "text-[var(--color-accent-ink-soft)]" : "text-[var(--color-ink-soft)]",
-          )}
-        >
-          {metric.label}
-        </CardDescription>
-        <CardTitle
-          className="mt-2 text-3xl uppercase leading-none"
-          style={{ fontFamily: "var(--font-display)" }}
-        >
-          {metric.value}
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="mt-2">
-        <p
-          className={cn(
-            "text-sm font-bold leading-6",
-            usesPastelInk ? "text-[var(--color-accent-ink-soft)]" : "text-[var(--color-ink-soft)]",
-          )}
-        >
-          {metric.note}
-        </p>
-      </CardContent>
-    </Card>
-  );
-}
-
-function FeatureStoryCard({ feature }: { feature: FeatureCard }) {
-  const usesPastelInk = usesPastelSurface(feature.bg);
-
-  return (
-    <Card
-      variant="poster"
-      className={cn(
-        "flex-row gap-4 p-4 sm:p-5 md:flex-col md:gap-3 lg:flex-row lg:gap-4",
-        feature.bg,
-        usesPastelInk && "text-[var(--color-accent-ink)]",
-      )}
-    >
-      <CardContent className="flex h-14 w-14 shrink-0 items-center justify-center">
-        <div className="card-brutal micro-flat flex h-14 w-14 items-center justify-center bg-[var(--color-paper)] text-xl font-black text-[var(--color-ink)]">
-          {feature.symbol}
+    <div className="mt-8 w-full max-w-[calc(100vw-2rem)] border-l-[6px] border-[var(--color-pink)] bg-white/90 p-4 text-black shadow-[5px_5px_0_rgba(255,255,255,0.22)] backdrop-blur dark:bg-black/70 dark:text-white dark:shadow-[5px_5px_0_rgba(0,0,0,0.45)] sm:max-w-2xl">
+      <p className="mono text-[10px] font-black uppercase tracking-[0.24em] text-black/65 dark:text-white/65">
+        {game ? "jogando agora" : "ao vivo"}
+      </p>
+      <h2
+        className="mt-2 break-words text-3xl uppercase leading-[0.9] sm:text-4xl"
+        style={{ fontFamily: "var(--font-display)" }}
+      >
+        {game?.name ?? "Live da Ludylops"}
+      </h2>
+      {metadata.length > 0 ? (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {metadata.map((item) => (
+            <span
+              key={item}
+              className="mono max-w-full border border-black/20 px-2 py-1 text-[10px] font-bold uppercase leading-4 tracking-[0.1em] text-black/65 dark:border-white/20 dark:text-white/65 [overflow-wrap:anywhere]"
+            >
+              {item}
+            </span>
+          ))}
         </div>
-      </CardContent>
-      <CardHeader className="gap-0">
-        <CardDescription
-          className={cn(
-            "mono text-[10px] uppercase tracking-[0.28em]",
-            usesPastelInk ? "text-[var(--color-accent-ink-soft)]" : "text-[var(--color-ink-soft)]",
-          )}
-        >
-          {feature.eyebrow}
-        </CardDescription>
-        <CardTitle
-          className="mt-2 text-xl uppercase leading-none lg:text-2xl"
-          style={{ fontFamily: "var(--font-display)" }}
-        >
-          {feature.title}
-        </CardTitle>
-        <CardContent className="mt-3">
-          <p
-            className={cn(
-              "text-sm leading-6",
-              usesPastelInk ? "text-[var(--color-accent-ink-soft)]" : "text-[var(--color-ink-soft)]",
-            )}
-          >
-            {feature.body}
-          </p>
-        </CardContent>
-      </CardHeader>
-    </Card>
+      ) : null}
+    </div>
   );
 }
 
-function RankingLeaderCard({
-  index,
-  bgClass,
+function HeroActions({ hasUsableSession }: { hasUsableSession: boolean }) {
+  if (hasUsableSession) {
+    return (
+      <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
+        <Link href="/apostas" className="btn-brutal accent-button px-6 py-3 text-sm">
+          <Ticket className="size-4" aria-hidden="true" />
+          Abrir Apostas
+        </Link>
+        <Link href="/me" className="btn-brutal ink-button px-6 py-3 text-sm">
+          <Sparkles className="size-4" aria-hidden="true" />
+          Minha Área
+        </Link>
+        <Link href="/jogos" className="btn-brutal bg-[var(--color-mint)] px-6 py-3 text-sm text-[var(--color-accent-ink)]">
+          <Gamepad2 className="size-4" aria-hidden="true" />
+          Sugerir Jogo
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
+      <AuthButtons />
+      <Link href="/apostas" className="btn-brutal accent-button px-6 py-3 text-sm">
+        <Ticket className="size-4" aria-hidden="true" />
+        Ver Apostas
+      </Link>
+      <Link href="/jogos" className="btn-brutal bg-[var(--color-mint)] px-6 py-3 text-sm text-[var(--color-accent-ink)]">
+        <Gamepad2 className="size-4" aria-hidden="true" />
+        Ver Jogos
+      </Link>
+    </div>
+  );
+}
+
+function HomeHero({
+  accountProtectionStatus,
+  currentGame,
+  hasUsableSession,
+  isLive,
   viewerName,
-  balance,
 }: {
-  index: number;
-  bgClass: string;
-  viewerName: string;
-  balance: number;
+  accountProtectionStatus: AccountProtectionStatus | null;
+  currentGame: CurrentGameRecord | null;
+  hasUsableSession: boolean;
+  isLive: boolean;
+  viewerName: string | null;
 }) {
-  const usesPastelInk = usesPastelSurface(bgClass);
+  const title = hasUsableSession
+    ? "Você já está na live da Ludylops."
+    : "A live da Ludylops começa aqui.";
+  const description = accountProtectionStatus
+    ? accountProtectionStatus === "google_signin_blocked"
+      ? "Seu acesso com Google foi colocado em espera por segurança. Você ainda pode acompanhar a live enquanto revisa a conta."
+      : "Sua sessão local foi encerrada por segurança. Quando você entrar de novo, os caminhos da live voltam para a sua conta."
+    : hasUsableSession
+      ? "Entre nas apostas, acione resgates e leve suas sugestões para o que acontece ao vivo."
+      : "Faça login para participar das apostas, resgatar efeitos e sugerir os jogos que movem a stream.";
 
   return (
-    <Card
-      variant="poster"
-      className={cn(
-        "flex-row items-center justify-between gap-3 px-4 py-4",
-        bgClass,
-        usesPastelInk && "text-[var(--color-accent-ink)]",
-      )}
-    >
-      <CardContent className="flex min-w-0 items-center gap-3">
-        <div className="card-brutal micro-flat flex min-w-[52px] items-center justify-center bg-[var(--color-paper)] px-3 py-2 text-sm font-black text-[var(--color-ink)]">
-          #{index + 1}
-        </div>
-        <CardHeader className="min-w-0 gap-0">
-          <CardDescription
-            className={cn(
-              "mono text-[10px] uppercase tracking-[0.24em]",
-              usesPastelInk ? "text-[var(--color-accent-ink-soft)]" : "text-[var(--color-ink-soft)]",
-            )}
+    <section className="landing-plane relative isolate overflow-hidden bg-black text-white">
+      <div className="absolute inset-0 -z-20 bg-black" />
+      <div
+        className="absolute inset-0 -z-10 scale-[1.02] bg-cover bg-center"
+        style={getHeroBackgroundStyle(currentGame)}
+        aria-hidden="true"
+      />
+
+      <svg
+        className="pointer-events-none absolute inset-x-0 bottom-0 -z-10 h-[56px] w-full sm:h-[104px]"
+        viewBox="0 0 1440 104"
+        preserveAspectRatio="none"
+        aria-hidden="true"
+      >
+        <path d="M0,104 V52 C240,28 480,76 720,52 C960,28 1200,76 1440,52 V104 Z" style={{ fill: "var(--color-paper)" }} />
+      </svg>
+
+      <div className="mx-auto flex min-h-[min(760px,calc(100svh-9rem))] w-full max-w-[1520px] items-center px-4 py-12 sm:px-6 sm:py-16 lg:px-10 lg:py-18">
+        <div className="w-full min-w-0 max-w-[calc(100vw-2rem)] sm:max-w-4xl">
+          <div className="flex flex-wrap items-center gap-3">
+            <LivestreamIndicator isLive={isLive} />
+            {viewerName ? (
+              <span className="mono border border-white/40 bg-black/45 px-3 py-2 text-[10px] font-black uppercase tracking-[0.22em] text-white">
+                {viewerName}
+              </span>
+            ) : null}
+          </div>
+
+          <h1
+            className="mt-6 max-w-4xl break-words text-5xl leading-[0.88] text-pretty [overflow-wrap:anywhere] sm:text-6xl lg:text-[5.8rem]"
+            style={{ fontFamily: "var(--font-display)" }}
           >
-            viewer
-          </CardDescription>
-          <CardTitle className="truncate text-base font-black uppercase tracking-[0.04em]">
-            {viewerName}
-          </CardTitle>
-        </CardHeader>
-      </CardContent>
-      <CardFooter className="shrink-0">
-        <span
-          className={cn(
-            "mono text-xs font-black uppercase tracking-[0.18em]",
-            usesPastelInk ? "text-[var(--color-accent-ink)]" : "text-[var(--color-ink)]",
-          )}
-        >
-          {formatPipetz(balance)}
-        </span>
-      </CardFooter>
-    </Card>
+            {title}
+          </h1>
+
+          <p className="mt-5 max-w-2xl break-words text-base font-medium leading-8 text-white/88 [overflow-wrap:anywhere] sm:text-lg">
+            {description}
+          </p>
+
+          {accountProtectionStatus ? (
+            <AccountProtectionNotice status={accountProtectionStatus} />
+          ) : null}
+
+          <HeroActions hasUsableSession={hasUsableSession} />
+          <HeroGameLabel game={currentGame} />
+        </div>
+      </div>
+    </section>
   );
 }
 
-function SpotlightOptionCard({
-  optionLabel,
-  poolAmount,
-  index,
+function ActionTile({ action }: { action: HomeAction }) {
+  const Icon = action.icon;
+
+  return (
+    <article className={cn("flex h-full min-w-0 flex-col justify-between border-[3px] border-[var(--color-ink)] p-5", action.bg)}>
+      <div>
+        <div className="flex size-12 items-center justify-center border-[3px] border-[var(--color-ink)] bg-[var(--color-paper)] text-[var(--color-ink)]">
+          <Icon className="size-6" aria-hidden="true" />
+        </div>
+        <h3
+          className="mt-5 text-3xl uppercase leading-[0.9]"
+          style={{ fontFamily: "var(--font-display)" }}
+        >
+          {action.title}
+        </h3>
+        <p className="mt-4 text-sm font-medium leading-7 text-[var(--color-accent-ink-soft)]">
+          {action.body}
+        </p>
+      </div>
+      <Link href={action.href} className="mt-6 inline-flex items-center gap-2 text-sm font-black uppercase tracking-[0.08em] underline decoration-[3px] underline-offset-4">
+        {action.cta}
+        <ArrowRight className="size-4" aria-hidden="true" />
+      </Link>
+    </article>
+  );
+}
+
+function LiveActionSection({
+  activeBet,
+  hasUsableSession,
 }: {
-  optionLabel: string;
-  poolAmount: number;
+  activeBet: BetWithOptionsRecord | undefined;
+  hasUsableSession: boolean;
+}) {
+  const actions: HomeAction[] = hasUsableSession
+    ? [
+        {
+          href: "/apostas",
+          title: activeBet ? "Aposta aberta" : "Apostas da live",
+          body: activeBet
+            ? activeBet.question
+            : "Quando a live abre um palpite, esse é o caminho direto para entrar na disputa.",
+          cta: "Abrir Apostas",
+          icon: Ticket,
+          bg: "bg-[var(--color-pink)] text-[var(--color-accent-ink)]",
+        },
+        {
+          href: "/me",
+          title: "Minha área",
+          body: "Resgates, vínculo com o YouTube e histórico ficam juntos para você agir rápido durante a stream.",
+          cta: "Abrir Minha Área",
+          icon: Sparkles,
+          bg: "bg-[var(--color-blue)] text-[var(--color-accent-ink)]",
+        },
+        {
+          href: "/jogos",
+          title: "Próximo jogo",
+          body: "Sugira jogos e fortaleça as ideias da comunidade para as próximas lives.",
+          cta: "Ver Jogos",
+          icon: Gamepad2,
+          bg: "bg-[var(--color-mint)] text-[var(--color-accent-ink)]",
+        },
+      ]
+    : [
+        {
+          href: "/apostas",
+          title: "Apostas ao vivo",
+          body: "Veja os palpites que aparecem quando a live vira desafio para o chat.",
+          cta: "Ver Apostas",
+          icon: Ticket,
+          bg: "bg-[var(--color-pink)] text-[var(--color-accent-ink)]",
+        },
+        {
+          href: "/jogos",
+          title: "Jogos do chat",
+          body: "Conheça a fila de sugestões que ajuda a puxar o próximo jogo da stream.",
+          cta: "Ver Jogos",
+          icon: Gamepad2,
+          bg: "bg-[var(--color-blue)] text-[var(--color-accent-ink)]",
+        },
+        {
+          href: "/videos",
+          title: "Pautas da live",
+          body: "Vídeos, indicações e ideias entram como combustível para conversas com a comunidade.",
+          cta: "Ver Vídeos",
+          icon: CirclePlay,
+          bg: "bg-[var(--color-purple)] text-[var(--color-accent-ink)]",
+        },
+      ];
+
+  return (
+    <section className="landing-plane bg-[var(--color-paper)] py-9 sm:py-12">
+      <div className="mx-auto w-full max-w-[1520px] px-4 sm:px-6 lg:px-10">
+        <div className="max-w-3xl">
+          <p className="mono text-[11px] font-black uppercase tracking-[0.28em] text-[var(--color-ink-soft)]">
+            caminhos principais
+          </p>
+          <h2
+            className="mt-3 text-4xl uppercase leading-[0.9] text-pretty sm:text-5xl"
+            style={{ fontFamily: "var(--font-display)" }}
+          >
+            {hasUsableSession ? "Seu próximo lance na live." : "O que move a live."}
+          </h2>
+        </div>
+
+        <div className="mt-7 grid gap-4 md:grid-cols-3">
+          {actions.map((action) => (
+            <ActionTile key={action.href} action={action} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function BetOptionCard({
+  index,
+  optionLabel,
+}: {
   index: number;
+  optionLabel: string;
 }) {
   const colors = [
     "bg-[var(--color-blue)]",
     "bg-[var(--color-purple)]",
     "bg-[var(--color-pink)]",
-    "bg-[var(--color-paper)]",
+    "bg-[var(--color-mint)]",
   ];
-  const bgClass = colors[index % colors.length];
-  const usesPastelInk = usesPastelSurface(bgClass);
 
   return (
-    <Card
-      variant="poster"
-      className={cn(
-        "flex-row items-center justify-between gap-3 px-4 py-4",
-        bgClass,
-        usesPastelInk && "text-[var(--color-accent-ink)]",
-      )}
-    >
-      <CardHeader className="min-w-0 gap-0">
-        <CardDescription
-          className={cn(
-            "mono text-[10px] uppercase tracking-[0.24em]",
-            usesPastelInk ? "text-[var(--color-accent-ink-soft)]" : "text-[var(--color-ink-soft)]",
-          )}
-        >
-          opção 0{index + 1}
-        </CardDescription>
-        <CardTitle className="mt-1 text-lg font-black uppercase leading-tight">{optionLabel}</CardTitle>
-      </CardHeader>
-      <CardFooter className="shrink-0">
-        <span
-          className={cn(
-            "mono text-xs font-black uppercase tracking-[0.18em]",
-            usesPastelInk ? "text-[var(--color-accent-ink)]" : "text-[var(--color-ink)]",
-          )}
-        >
-          {formatPipetz(poolAmount)}
-        </span>
-      </CardFooter>
-    </Card>
-  );
-}
-
-function HeroPoster({
-  heading,
-  description,
-  loggedIn = false,
-  metrics,
-}: {
-  heading: string;
-  description: string;
-  loggedIn?: boolean;
-  metrics: HomeMetric[];
-}) {
-  const rotations = ["rotate-[-2deg]", "rotate-[1.5deg]", "rotate-[-1deg]"];
-
-  return (
-    <div className="relative min-h-[420px]">
-
-      <StickerBadge
-        variant="star"
-        className="absolute -right-2 bottom-4 hidden h-20 w-20 rotate-[10deg] lg:inline-flex"
-        label="decorative star"
-      />
-
-      <div
-        className={cn(
-          "landing-plane relative z-10 mt-10 overflow-visible p-6 lg:ml-10 lg:mt-12 lg:p-8",
-          loggedIn ? "bg-[var(--color-paper)]" : "bg-transparent",
-        )}
-      >
-        {loggedIn ? (
-          <>
-            <div>
-              <h2
-                className="text-4xl uppercase leading-[0.88] sm:text-5xl"
-                style={{ fontFamily: "var(--font-display)" }}
-              >
-                {heading}
-              </h2>
-              <p className="mt-4 max-w-md text-sm font-medium leading-7 text-[var(--color-ink-soft)] sm:text-base">
-                {description}
-              </p>
-            </div>
-
-            <div className="mt-8 grid gap-4 sm:grid-cols-2">
-              {metrics.slice(0, 4).map((metric, index) => (
-                <MetricCard
-                  key={metric.label}
-                  metric={metric}
-                  className={rotations[index % rotations.length]}
-                />
-              ))}
-            </div>
-          </>
-        ) : (
-          <div>
-            <StickerBadge
-              variant="star"
-              className="absolute left-4 top-6 h-[4.5rem] w-[4.5rem] rotate-[-8deg] sm:left-6 sm:top-8 sm:h-20 sm:w-20"
-              label="estrela decorativa"
-            />
-            <StickerBadge
-              variant="heart"
-              className="absolute right-4 top-6 h-[4.5rem] w-[4.5rem] rotate-[14deg] sm:right-6 sm:top-8 sm:h-20 sm:w-20"
-              label="coração decorativo"
-            />
-            <div className="relative min-h-[340px] overflow-visible sm:min-h-[400px]">
-              <div className="mx-auto w-[72%] max-w-[420px] pt-[4.75rem] sm:pt-[5.5rem]">
-                <div className="relative aspect-video border-[4px] border-[var(--color-ink)] bg-[var(--color-purple)] shadow-[7px_7px_0_var(--shadow-color)]">
-                  <div className="absolute bottom-0 left-1/2 z-10 w-[118%] -translate-x-1/2 sm:w-[122%]">
-                  <Image
-                    src={LUDYLOPS_PROFILE_IMAGE}
-                    alt="Foto da Ludylops"
-                    className="h-auto w-full contrast-125"
-                    width={1100}
-                    height={1100}
-                    preload
-                  />
-                  </div>
-                </div>
-              </div>
-
-              <div className="absolute bottom-3 right-3 z-20 flex h-20 w-20 items-center justify-center rounded-full border-[4px] border-[var(--color-ink)] bg-[var(--color-pink-hot)] shadow-[5px_5px_0_var(--shadow-color)] sm:bottom-5 sm:right-5 sm:h-24 sm:w-24">
-                <div className="flex rotate-[20deg] h-11 w-11 items-center justify-center rounded-full bg-[var(--color-yellow)] text-xl font-black text-[var(--color-accent-ink)]">
-                =D
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
-      </div>
+    <div className={cn("min-w-0 border-[3px] border-[var(--color-ink)] p-4", colors[index % colors.length])}>
+      <p className="mono text-[10px] font-black uppercase tracking-[0.24em] text-[var(--color-accent-ink-soft)]">
+        opção 0{index + 1}
+      </p>
+      <p className="mt-2 break-words text-lg font-black uppercase leading-tight text-[var(--color-accent-ink)] [overflow-wrap:anywhere]">
+        {optionLabel}
+      </p>
     </div>
   );
 }
 
-function FeatureShowcase({
-  features,
+function LiveBetSpotlight({
+  activeBet,
+  loggedIn,
 }: {
-  features: FeatureCard[];
+  activeBet: BetWithOptionsRecord | undefined;
+  loggedIn: boolean;
 }) {
-  return (
-    <section className="landing-plane landing-divider bg-[var(--color-paper-pink)] py-8 sm:py-10">
-      <div className="mx-auto w-full max-w-[1520px] px-4 sm:px-6 lg:px-10">
-        <div>
-          <h2
-            className="max-w-xl text-4xl uppercase leading-[0.9] sm:text-5xl"
-            style={{ fontFamily: "var(--font-display)" }}
-          >
-            Você participa da minha live de verdade.
-          </h2>
-          <p className="mt-4 max-w-xl text-base leading-7 text-[var(--color-ink-soft)]">
-            Eu abro a live, você junta pipetz, entra nas apostas e ainda solta resgates
-            que aparecem comigo ao vivo.
-          </p>
-
-          <div className="mt-8 grid gap-4 md:grid-cols-3">
-            {features.map((feature) => (
-              <FeatureStoryCard key={feature.title} feature={feature} />
-            ))}
-          </div>
-        </div>
-      </div>
-    </section>
-  );
-}
-
-function LiveThermometerSection({
-  metrics,
-  loggedIn = false,
-}: {
-  metrics: HomeMetric[];
-  loggedIn?: boolean;
-}) {
-  const metricRotations = ["rotate-[1deg]", "rotate-[-1deg]", "rotate-[1.5deg]", "rotate-[-1.5deg]"];
-
-  return (
-    <section className="landing-plane landing-divider bg-[var(--color-sky)] py-8 sm:py-10">
-      <div className="mx-auto w-full max-w-[1520px] px-4 sm:px-6 lg:px-10">
-        <h2
-          className="max-w-md text-3xl uppercase leading-[0.92] sm:text-4xl"
-          style={{ fontFamily: "var(--font-display)" }}
-        >
-          O que vocês estão aprontando comigo agora.
-        </h2>
-
-        <div className="mt-6 grid gap-4 sm:grid-cols-2">
-          {metrics.map((metric, index) => (
-            <MetricCard
-              key={metric.label}
-              metric={metric}
-              className={metricRotations[index % metricRotations.length]}
-            />
-          ))}
-        </div>
-
-        <div className="mt-6">
-          <Link
-            href={loggedIn ? "/apostas" : "/jogos"}
-            className="btn-brutal accent-button px-5 py-3 text-xs"
-          >
-            {loggedIn ? "Entrar em apostas ->" : "Explorar a comunidade ->"}
-          </Link>
-        </div>
-      </div>
-    </section>
-  );
-}
-
-function RankingHeroCard({
-  leaderboard,
-  viewerRank,
-}: {
-  leaderboard: Awaited<ReturnType<typeof getLeaderboard>>;
-  viewerRank?: number | null;
-}) {
-  const leaders = leaderboard.slice(0, 3);
-  const rowColors = ["bg-[var(--color-blue)]", "bg-[var(--color-purple)]", "bg-[var(--color-pink)]"];
-
-  return (
-    <aside className="p-6 sm:p-7">
-      <h2
-        className="max-w-[10ch] text-4xl uppercase leading-[0.88] sm:text-5xl"
-        style={{ fontFamily: "var(--font-display)" }}
-      >
-        Liderando agora
-      </h2>
-
-      <div className="mt-6 space-y-4">
-        {leaders.map((entry, index) => {
-          const viewer = "viewer" in entry ? entry.viewer : entry;
-          const balance = "balance" in entry ? entry.balance : entry;
-
-          return (
-            <RankingLeaderCard
-              key={viewer.id}
-              index={index}
-              bgClass={rowColors[index]}
-              viewerName={viewer.youtubeDisplayName}
-              balance={balance.currentBalance}
-            />
-          );
-        })}
-      </div>
-
-      <div className="mt-6 flex flex-wrap items-center gap-3">
-        <Link href="/ranking" className="btn-brutal ink-button px-5 py-3 text-xs">
-          Ver ranking completo {"->"}
-        </Link>
-        {typeof viewerRank === "number" && viewerRank > 0 ? (
-          <span className="mono text-[11px] uppercase tracking-[0.24em] text-[var(--color-ink-soft)]">
-            você está em #{viewerRank}
-          </span>
-        ) : null}
-      </div>
-    </aside>
-  );
-}
-
-function LiveSpotlight({ activeBet, loggedIn = false }: SpotlightProps) {
   if (!activeBet) {
     return null;
   }
 
   return (
-      <div className="p-6 sm:p-8">
-        <div className="grid gap-6 lg:grid-cols-[1.05fr_0.95fr] lg:items-start">
-          <div>
-            <p className="mono text-[11px] uppercase tracking-[0.28em] text-[var(--color-ink-soft)]">
-              ao vivo . {activeBet.options.length} opções abertas
-            </p>
+    <section className="landing-plane landing-divider bg-[var(--color-paper-pink)] py-9 sm:py-12">
+      <div className="mx-auto grid w-full max-w-[1520px] gap-6 px-4 sm:px-6 lg:grid-cols-[1.05fr_0.95fr] lg:px-10">
+        <div>
+          <p className="mono text-[11px] font-black uppercase tracking-[0.28em] text-[var(--color-ink-soft)]">
+            aposta aberta
+          </p>
+          <h2
+            className="mt-4 max-w-3xl break-words text-4xl uppercase leading-[0.9] text-pretty sm:text-5xl"
+            style={{ fontFamily: "var(--font-display)" }}
+          >
+            {activeBet.question}
+          </h2>
+          <p className="mt-5 max-w-2xl text-base font-medium leading-7 text-[var(--color-ink-soft)]">
+            Veja o que importa para entrar no clima da live: a pergunta, as opções e o
+            caminho para participar.
+          </p>
+          <Link href="/apostas" className="btn-brutal accent-button mt-7 px-5 py-3 text-xs">
+            <Ticket className="size-4" aria-hidden="true" />
+            {loggedIn ? "Entrar na Aposta" : "Ver Aposta"}
+          </Link>
+        </div>
 
-            <h2
-              className="mt-4 max-w-2xl text-4xl uppercase leading-[0.9] sm:text-5xl"
-              style={{ fontFamily: "var(--font-display)" }}
-            >
-              {activeBet.question}
-            </h2>
-
-            <p className="mt-4 max-w-xl text-base leading-7 text-[var(--color-ink-soft)]">
-              Quando eu abro uma aposta, vocês escolhem um lado, entram no pool e tentam
-              adivinhar o que vai acontecer comigo ao vivo.
-            </p>
-
-            <p className="mono mt-6 text-[11px] uppercase tracking-[0.24em] text-[var(--color-ink-soft)]">
-              pool {formatPipetz(activeBet.totalPool)} . vocês palpitando ao vivo
-            </p>
-
-            <div className="mt-6">
-              <Link href="/apostas" className="btn-brutal accent-button px-5 py-3 text-xs">
-                {loggedIn ? "Ir para apostas ->" : "Ver apostas da live ->"}
-              </Link>
-            </div>
-          </div>
-
-          <div className="grid gap-4">
-            {activeBet.options.map((option, index) => (
-              <SpotlightOptionCard
-                key={option.id}
-                optionLabel={option.label}
-                poolAmount={option.poolAmount}
-                index={index}
-              />
-            ))}
-          </div>
+        <div className="grid gap-4 self-start">
+          {activeBet.options.map((option, index) => (
+            <BetOptionCard key={option.id} optionLabel={option.label} index={index} />
+          ))}
         </div>
       </div>
+    </section>
   );
 }
-
-type HomePageProps = {
-  searchParams: Promise<{ googleAccountProtection?: string | string[] | undefined }>;
-};
 
 export default async function Home({ searchParams }: HomePageProps) {
   const session = await auth();
@@ -552,263 +424,26 @@ export default async function Home({ searchParams }: HomePageProps) {
     getSessionAccountProtectionStatus(session) ?? getAccountProtectionStatusFromSearchParams(resolvedSearchParams);
   const hasUsableSession = hasUsableAppSession(session) && !accountProtectionStatus;
   const activeViewerId = hasUsableSession ? session?.user?.activeViewerId ?? null : null;
-  const [catalog, leaderboard, bets, isLive, currentGame] = await Promise.all([
-    getCatalog(),
-    getLeaderboard(),
+  const [bets, isLive, currentGame] = await Promise.all([
     listBets(activeViewerId),
     isStreamerbotLivestreamActive(),
     getCurrentGame(),
   ]);
-  const activeBets = bets.filter((bet) => bet.status === "open");
+  const activeBet = bets.find((bet) => bet.status === "open");
+  const viewerName = hasUsableSession ? session?.user?.activeViewerDisplayName ?? session?.user?.name ?? null : null;
 
-  let dashboard: Awaited<ReturnType<typeof getViewerDashboard>> | null = null;
-  if (activeViewerId) {
-    dashboard = await getViewerDashboard(activeViewerId);
-  }
-
-  const viewerRank = dashboard
-    ? leaderboard.findIndex((entry) => {
-        const viewer = "viewer" in entry ? entry.viewer : entry;
-        return viewer.id === dashboard!.viewer.id;
-      }) + 1
-    : null;
-
-  const publicMetrics: HomeMetric[] = [
-    {
-      label: "resgates",
-      value: `${catalog.length}`,
-      note: "efeitos que entram na live",
-      bg: "bg-[var(--color-blue)]",
-    },
-    {
-      label: "apostas",
-      value: `${activeBets.length}`,
-      note: "pools abertos para entrar",
-      bg: "bg-[var(--color-pink)]",
-    },
-    {
-      label: "viewers",
-      value: `${leaderboard.length}`,
-      note: "comunidade empilhando pipetz",
-      bg: "bg-[var(--color-purple)]",
-    },
-    {
-      label: "comunidade",
-      value: "24/7",
-      note: "ritmo constante de live",
-      bg: "bg-[var(--color-mint)]",
-    },
-  ];
-
-  const authedMetrics: HomeMetric[] = [
-    {
-      label: "saldo atual",
-      value: dashboard ? formatPipetz(dashboard.balance.currentBalance) : "--",
-      note: "pronto para apostar e resgatar",
-      bg: "bg-[var(--color-purple)]",
-    },
-    {
-      label: "seu ranking",
-      value: viewerRank ? `#${viewerRank}` : "--",
-      note: viewerRank ? "posição atual na disputa" : "sincronize sua conta",
-      bg: "bg-[var(--color-blue)]",
-    },
-    {
-      label: "ganhos",
-      value: dashboard ? formatPipetz(dashboard.balance.lifetimeEarned) : "--",
-      note: "pipetz que já passaram pela conta",
-      bg: "bg-[var(--color-pink)]",
-    },
-    {
-      label: "resgates",
-      value: `${catalog.length}`,
-      note: "atalhos para agir agora",
-      bg: "bg-[var(--color-mint)]",
-    },
-  ];
-
-  const features: FeatureCard[] = [
-    {
-      symbol: "++",
-      eyebrow: "assistindo a live",
-      title: "Ganhe assistindo",
-      body: "Enquanto você assiste à minha live, seus pipetz vão acumulando para apostar, resgatar e entrar no ranking.",
-      bg: "bg-[var(--color-blue)]",
-    },
-    {
-      symbol: "$$",
-      eyebrow: "palpite do chat",
-      title: "Aposte ao vivo",
-      body: "Quando eu abrir uma aposta, escolhe seu lado e vem ver se o chat me conhece mesmo.",
-      bg: "bg-[var(--color-purple)]",
-    },
-    {
-      symbol: "->",
-      eyebrow: "bagunça organizada",
-      title: "Acione resgates",
-      body: "Se quiser me trollar com carinho, os resgates viram efeitos e caos ao vivo na stream.",
-      bg: "bg-[var(--color-pink)]",
-    },
-  ];
-
-  const heroTitle: ReactNode = hasUsableSession ? (
-    <>
-      Você já está na minha live.{" "}
-      <span className="micro-flat inline-block border-[3px] border-[var(--color-ink)] bg-[var(--color-pink)] px-3 py-1 text-[var(--color-accent-ink)] shadow-[4px_4px_0_var(--shadow-color)]">
-        Agora vem jogar comigo.
-      </span>
-    </>
-  ) : (
-    <>
-      Oi, eu sou a ludylops.{" "}
-      <span className="micro-flat inline-block border-[3px] border-[var(--color-ink)] bg-[var(--color-pink)] px-3 py-1 text-[var(--color-accent-ink)] shadow-[4px_4px_0_var(--shadow-color)]">
-        Bem-vindos à minha live.
-      </span>
-    </>
-  );
-
-  const heroDescription = accountProtectionStatus
-    ? accountProtectionStatus === "google_signin_blocked"
-      ? "Seu acesso com Google foi colocado em espera por um evento de segurança. Eu mantive o painel público disponível enquanto você revisa a conta."
-      : "Sua sessão local foi encerrada por segurança. Assim que você entrar de novo, o painel volta a mostrar seus dados normalmente."
-    : hasUsableSession
-      ? dashboard
-        ? "Seu saldo, seu ranking e o que está rolando comigo ao vivo ficam aqui para você entrar na brincadeira sem se perder."
-        : "Sua conta entrou, mas ainda falta sincronizar seus dados da live para eu te liberar tudo por aqui."
-      : "Aqui o chat ganha pipetz, entra nas apostas e ativa resgates que aparecem durante a minha live.";
-
-  const heroPosterHeading = hasUsableSession ? dashboard?.viewer.youtubeDisplayName ?? "Conta conectada" : "LUDYLOPS";
-
-  const heroPosterDescription = hasUsableSession
-    ? "Esse é o seu cantinho para acompanhar saldo, ranking e o que está rolando comigo ao vivo."
-    : "Esse painel é o cantinho da minha live para o chat apostar, resgatar e acompanhar o ranking.";
-
-  const metrics = hasUsableSession ? authedMetrics : publicMetrics;
   return (
-    <div className="flex w-full flex-col">
-      <section className="landing-plane surface-hero relative py-8 sm:py-10 lg:py-12">
-        <div className="bg-micro-grid pointer-events-none absolute inset-0 opacity-30" />
-        <StickerBadge
-          variant="bolt"
-          className="absolute right-4 top-4 hidden h-16 w-16 rotate-[8deg] lg:inline-flex"
-          label="decorative bolt"
-        />
-        <StickerBadge
-          variant="heart"
-          className="absolute bottom-4 left-[46%] hidden h-16 w-16 rotate-[-12deg] lg:inline-flex"
-          label="decorative heart"
-        />
+    <div className="flex w-full flex-col overflow-x-hidden">
+      <HomeHero
+        accountProtectionStatus={accountProtectionStatus}
+        currentGame={currentGame}
+        hasUsableSession={hasUsableSession}
+        isLive={isLive}
+        viewerName={viewerName}
+      />
 
-        <div className="relative mx-auto grid w-full max-w-[1520px] gap-8 px-4 sm:px-6 lg:grid-cols-[1.02fr_0.98fr] lg:items-center lg:px-10">
-          <div className="max-w-3xl">
-            <div>
-              <LivestreamIndicator isLive={isLive} />
-            </div>
-
-            <h1
-              className="mt-5 max-w-4xl text-5xl leading-[0.9] sm:text-6xl lg:text-[5.5rem]"
-              style={{ fontFamily: "var(--font-display)" }}
-            >
-              {heroTitle}
-            </h1>
-
-            <p className="mt-5 max-w-xl text-base leading-8 text-[var(--color-ink-soft)] sm:text-lg">
-              {heroDescription}
-            </p>
-
-            {accountProtectionStatus ? <AccountProtectionNotice status={accountProtectionStatus} /> : null}
-
-            <div className="mt-8 flex flex-wrap items-center gap-3">
-              {hasUsableSession ? (
-                <>
-                <Link href="/apostas" className="btn-brutal accent-button px-6 py-3 text-sm">
-                    Ir para apostas {"->"}
-                  </Link>
-                  <Link href="/ranking" className="btn-brutal ink-button px-6 py-3 text-sm">
-                    Ver ranking {"->"}
-                  </Link>
-                </>
-              ) : (
-                <>
-                  <AuthButtons />
-                  <Link href="/ranking" className="btn-brutal accent-button px-6 py-3 text-sm">
-                    Ver ranking {"->"}
-                  </Link>
-                </>
-              )}
-            </div>
-
-            <p className="mt-4 text-sm font-medium leading-6 text-[var(--color-ink-soft)]">
-              Ao usar o login Google, você pode revisar nossa{" "}
-              <Link href="/privacy" className="font-black underline decoration-[3px] underline-offset-4">
-                Política de Privacidade
-              </Link>
-              .
-            </p>
-
-          </div>
-
-          <HeroPoster
-            heading={heroPosterHeading}
-            description={heroPosterDescription}
-            loggedIn={hasUsableSession}
-            metrics={metrics}
-          />
-        </div>
-      </section>
-
-      <FeatureShowcase features={features} />
-
-      <CurrentGameSpotlight game={currentGame} />
-
-      <LiveThermometerSection metrics={metrics} loggedIn={hasUsableSession} />
-
-      {false ? (
-        <QuickNavGrid
-          items={[
-            {
-              href: "/apostas",
-              label: "Apostas",
-              value: `${activeBets.length} abertas`,
-              sublabel: "Palpite no que eu vou fazer",
-              emoji: "LIVE",
-              bg: "bg-[var(--color-pink)]",
-            },
-            {
-              href: "/jogos",
-              label: "Jogos",
-              value: "Sugira próximos",
-              sublabel: "Me empurre pro proximo caos",
-              emoji: "PLAY",
-              bg: "bg-[var(--color-blue)]",
-            },
-            {
-              href: "/ranking",
-              label: "Ranking",
-              value: viewerRank ? `#${viewerRank}` : "--",
-              sublabel: "Veja onde você está",
-              emoji: "TOP",
-              bg: "bg-[var(--color-mint)]",
-            },
-          ]}
-        />
-      ) : null}
-
-      <section className="landing-plane landing-divider bg-[var(--color-paper-pink)] py-8 sm:py-10">
-        <div className="mx-auto w-full max-w-[1520px] px-4 sm:px-6 lg:px-10">
-          <RankingHeroCard leaderboard={leaderboard} viewerRank={viewerRank} />
-        </div>
-      </section>
-
-      {activeBets[0] ? (
-        <section className="landing-plane landing-divider bg-[var(--color-paper)] py-8 sm:py-10">
-          <div className="mx-auto w-full max-w-[1520px] px-4 sm:px-6 lg:px-10">
-            <LiveSpotlight activeBet={activeBets[0]} loggedIn={hasUsableSession} />
-          </div>
-        </section>
-      ) : null}
-
+      <LiveActionSection activeBet={activeBet} hasUsableSession={hasUsableSession} />
+      <LiveBetSpotlight activeBet={activeBet} loggedIn={hasUsableSession} />
     </div>
   );
 }
-

--- a/src/components/admin-current-game-panel.tsx
+++ b/src/components/admin-current-game-panel.tsx
@@ -44,6 +44,7 @@ export function AdminCurrentGamePanel({
   const searchContainerRef = useRef<HTMLDivElement>(null);
   const [currentGame, setCurrentGame] = useState(initialGame);
   const [query, setQuery] = useState(initialGame?.name ?? "");
+  const [customCoverUrl, setCustomCoverUrl] = useState(initialGame?.coverImageUrl ?? "");
   const [results, setResults] = useState<GameSearchResult[]>([]);
   const [selectedGame, setSelectedGame] = useState<GameSearchResult | null>(null);
   const [isSearching, setIsSearching] = useState(false);
@@ -131,6 +132,7 @@ export function AdminCurrentGamePanel({
   function selectGame(game: GameSearchResult) {
     setSelectedGame(game);
     setQuery(game.name);
+    setCustomCoverUrl(game.coverImageUrl ?? "");
     setResults([]);
     setIsResultsOpen(false);
   }
@@ -153,7 +155,7 @@ export function AdminCurrentGamePanel({
           igdbId: selectedGame.igdbId,
           name: selectedGame.name,
           releaseYear: selectedGame.releaseYear,
-          coverImageUrl: selectedGame.coverImageUrl,
+          coverImageUrl: customCoverUrl.trim() || selectedGame.coverImageUrl,
           platforms: selectedGame.platforms,
           genres: selectedGame.genres,
         }),
@@ -204,6 +206,7 @@ export function AdminCurrentGamePanel({
       setCurrentGame(null);
       setSelectedGame(null);
       setQuery("");
+      setCustomCoverUrl("");
       setResults([]);
       setIsResultsOpen(false);
       setFeedback("Jogo atual removido.");
@@ -212,6 +215,7 @@ export function AdminCurrentGamePanel({
   }
 
   const previewGame = selectedGame ?? currentGame;
+  const previewCoverUrl = customCoverUrl.trim() || previewGame?.coverImageUrl || null;
 
   return (
     <div className="panel surface-section p-6">
@@ -224,9 +228,9 @@ export function AdminCurrentGamePanel({
 
       <div className="mt-5 grid gap-4 lg:grid-cols-[150px_1fr]">
         <div className="min-h-48 border-2 border-[var(--color-ink)] bg-[var(--color-lavender)]">
-          {previewGame?.coverImageUrl ? (
+          {previewCoverUrl ? (
             // eslint-disable-next-line @next/next/no-img-element
-            <img src={previewGame.coverImageUrl} alt="" className="h-full min-h-48 w-full object-cover" />
+            <img src={previewCoverUrl} alt="" className="h-full min-h-48 w-full object-cover" />
           ) : (
             <div className="flex h-full min-h-48 items-center justify-center px-4 text-center text-sm font-black uppercase text-[var(--color-ink-soft)]">
               Sem capa
@@ -309,6 +313,21 @@ export function AdminCurrentGamePanel({
                 ))}
               </div>
             ) : null}
+          </div>
+
+          <div className="mt-4">
+            <label className="mono text-[10px] uppercase tracking-[0.28em] text-[var(--color-ink-soft)]">
+              Capa personalizada (URL)
+            </label>
+            <Input
+              value={customCoverUrl}
+              onChange={(event) => setCustomCoverUrl(event.target.value)}
+              placeholder="https://image.api.playstation.com/..."
+              className="mt-2"
+            />
+            <p className="mt-2 text-xs leading-5 text-[var(--color-ink-soft)]">
+              Opcional. Cole uma imagem em alta qualidade (ex.: arte da PS Store) para usar no lugar da capa do IGDB.
+            </p>
           </div>
 
           <div className="mt-4 flex flex-wrap gap-2">

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useSyncExternalStore } from "react";
+import { Moon, Sun } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -54,12 +55,17 @@ export function ThemeToggle({ initialTheme = null }: { initialTheme?: ThemeMode 
       onClick={handleToggle}
       variant="accent"
       size="xs"
-      className="min-w-[104px]"
+      className="min-w-0 px-3 sm:min-w-[104px]"
       aria-label={isDark ? "Ativar modo claro" : "Ativar modo escuro"}
       aria-pressed={isDark}
       suppressHydrationWarning
     >
-      <span className="mono tracking-[0.18em]" suppressHydrationWarning>
+      {isDark ? (
+        <Sun className="size-4" aria-hidden="true" />
+      ) : (
+        <Moon className="size-4" aria-hidden="true" />
+      )}
+      <span className="mono hidden tracking-[0.18em] sm:inline" suppressHydrationWarning>
         {isDark ? "LIGHT ->" : "DARK ->"}
       </span>
     </Button>


### PR DESCRIPTION
## Summary
Rebuilds the landing page as a full-bleed hero featuring the current game, with a soft curved (wave) transition into the content sections, plus several polish fixes found while reviewing it.

## Changes
- **Hero**: full-bleed current-game backdrop with a brighter image overlay; a soft full-width wave replaces the straight divider into the next section.
- **Buttons**: fixed the white-on-white "Sugerir Jogo"/"Ver Jogos" hero buttons in light mode (the anchor text color was overridden by an unlayered `a { color: inherit }` reset; now uses a mint background that the existing rule colors reliably in both themes).
- **Dark mode**: the "jogando agora" game-name card now adapts to dark mode.
- **Copy**: removed the self-referential "Primeiro a live, depois o painel" section and rewrote copy that referred to the site itself; added a "Website Voice (No Self-Reference)" rule to `AGENTS.md`.
- **Admin**: the Current Game panel can now set a custom high-quality cover URL, overriding IGDB's low-res `t_cover_big` cover.

## Testing
- `tsc --noEmit`, `eslint`, and `vitest` (256 tests) all pass.
- Verified the hero, buttons, dark-mode card, copy, and full-width curve live on the dev server in both light and dark mode.

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)