### PR TITLE
[codex] Fix offline home hero copy

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/lib/auth/session-state";
 import { getCurrentGame } from "@/lib/current-game";
 import { listBets } from "@/lib/db/repository";
+import { getHomeHeroCopy } from "@/lib/home-hero-copy";
 import { isStreamerbotLivestreamActive } from "@/lib/streamerbot/live-status";
 import type { BetWithOptionsRecord, CurrentGameRecord } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -138,17 +139,19 @@ function AccountProtectionNotice({ status }: { status: AccountProtectionStatus }
 
 function HeroGameLabel({ game, isLive }: { game: CurrentGameRecord | null; isLive: boolean }) {
   const metadata = getGameMetadataParts(game);
+  const eyebrow = game ? (isLive ? "jogando agora" : "campanha atual") : isLive ? "ao vivo" : "próxima live";
+  const title = game?.name ?? (isLive ? "Live da Ludylops" : "Canal da Ludylops");
 
   return (
     <div className="mt-8 w-full max-w-[calc(100vw-2rem)] border-l-[6px] border-[var(--color-pink)] bg-white/90 p-4 text-black shadow-[5px_5px_0_rgba(255,255,255,0.22)] backdrop-blur dark:bg-black/70 dark:text-white dark:shadow-[5px_5px_0_rgba(0,0,0,0.45)] sm:max-w-2xl">
       <p className="mono text-[10px] font-black uppercase tracking-[0.24em] text-black/65 dark:text-white/65">
-        {game ? (isLive ? "jogando agora" : "campanha atual") : "ao vivo"}
+        {eyebrow}
       </p>
       <h2
         className="mt-2 break-words text-3xl uppercase leading-[0.9] sm:text-4xl"
         style={{ fontFamily: "var(--font-display)" }}
       >
-        {game?.name ?? "Live da Ludylops"}
+        {title}
       </h2>
       {metadata.length > 0 ? (
         <div className="mt-3 flex flex-wrap gap-2">
@@ -273,20 +276,11 @@ function HomeHero({
   isLive: boolean;
   viewerName: string | null;
 }) {
-  const title = hasUsableSession
-    ? "Estou online, vem pra live!"
-    : isLive
-      ? "A live já começou."
-      : "Oi, eu sou a Ludylops. Eu jogo, o chat palpita.";
-  const description = accountProtectionStatus
-    ? accountProtectionStatus === "google_signin_blocked"
-      ? "Seu acesso com Google foi colocado em espera por segurança. Você ainda pode acompanhar a live enquanto revisa a conta."
-      : "Sua sessão local foi encerrada por segurança. Quando você entrar de novo, os caminhos da live voltam para a sua conta."
-    : hasUsableSession
-      ? "Entre nas apostas, acione resgates e leve suas sugestões para o que acontece ao vivo."
-      : isLive
-        ? "Entre no YouTube para assistir, e faça login aqui pra participar dos palpites e usar seus pipetz com resgates de interação comigo."
-        : "Faço lives e vídeos de jogos no YouTube, com campanhas longas, sugestões do chat e muito bate-papo! Aqui você acompanha o jogo atual, junta pipetz e participa do que acontece ao vivo.";
+  const { title, description } = getHomeHeroCopy({
+    accountProtectionStatus,
+    hasUsableSession,
+    isLive,
+  });
 
   return (
     <section className="landing-plane relative isolate overflow-hidden bg-black text-white">

--- a/src/lib/home-hero-copy.test.ts
+++ b/src/lib/home-hero-copy.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { getHomeHeroCopy } from "@/lib/home-hero-copy";
+
+describe("getHomeHeroCopy", () => {
+  it("does not say the stream is online for a signed-in viewer while offline", () => {
+    const copy = getHomeHeroCopy({
+      accountProtectionStatus: null,
+      hasUsableSession: true,
+      isLive: false,
+    });
+
+    expect(copy.title).toBe("A live está offline agora.");
+    expect(copy.description).toBe(
+      "Enquanto eu não abro a live, você pode conferir seu painel, sugerir jogos e deixar tudo pronto para a próxima transmissão.",
+    );
+  });
+
+  it("uses the online call to action for a signed-in viewer while live", () => {
+    const copy = getHomeHeroCopy({
+      accountProtectionStatus: null,
+      hasUsableSession: true,
+      isLive: true,
+    });
+
+    expect(copy.title).toBe("Estou online, vem pra live!");
+    expect(copy.description).toBe(
+      "Entre nas apostas, acione resgates e leve suas sugestões para o que acontece ao vivo.",
+    );
+  });
+
+  it("keeps the public offline introduction for visitors", () => {
+    const copy = getHomeHeroCopy({
+      accountProtectionStatus: null,
+      hasUsableSession: false,
+      isLive: false,
+    });
+
+    expect(copy.title).toBe("Oi, eu sou a Ludylops. Eu jogo, o chat palpita.");
+  });
+});

--- a/src/lib/home-hero-copy.ts
+++ b/src/lib/home-hero-copy.ts
@@ -1,0 +1,52 @@
+import type { AccountProtectionStatus } from "@/lib/auth/session-state";
+
+type HomeHeroCopyInput = {
+  accountProtectionStatus: AccountProtectionStatus | null;
+  hasUsableSession: boolean;
+  isLive: boolean;
+};
+
+type HomeHeroCopy = {
+  title: string;
+  description: string;
+};
+
+export function getHomeHeroCopy({
+  accountProtectionStatus,
+  hasUsableSession,
+  isLive,
+}: HomeHeroCopyInput): HomeHeroCopy {
+  const title = hasUsableSession
+    ? isLive
+      ? "Estou online, vem pra live!"
+      : "A live está offline agora."
+    : isLive
+      ? "A live já começou."
+      : "Oi, eu sou a Ludylops. Eu jogo, o chat palpita.";
+
+  if (accountProtectionStatus) {
+    return {
+      title,
+      description:
+        accountProtectionStatus === "google_signin_blocked"
+          ? "Seu acesso com Google foi colocado em espera por segurança. Você ainda pode acompanhar a live enquanto revisa a conta."
+          : "Sua sessão local foi encerrada por segurança. Quando você entrar de novo, os caminhos da live voltam para a sua conta.",
+    };
+  }
+
+  if (hasUsableSession) {
+    return {
+      title,
+      description: isLive
+        ? "Entre nas apostas, acione resgates e leve suas sugestões para o que acontece ao vivo."
+        : "Enquanto eu não abro a live, você pode conferir seu painel, sugerir jogos e deixar tudo pronto para a próxima transmissão.",
+    };
+  }
+
+  return {
+    title,
+    description: isLive
+      ? "Entre no YouTube para assistir, e faça login aqui pra participar dos palpites e usar seus pipetz com resgates de interação comigo."
+      : "Faço lives e vídeos de jogos no YouTube, com campanhas longas, sugestões do chat e muito bate-papo! Aqui você acompanha o jogo atual, junta pipetz e participa do que acontece ao vivo.",
+  };
+}


### PR DESCRIPTION
## What changed

- Moved the home hero title/description decision into `getHomeHeroCopy`.
- Made signed-in offline visitors see offline copy instead of "Estou online, vem pra live!".
- Adjusted the no-game hero label so it does not say "ao vivo" while the stream is offline.
- Added focused tests for signed-in offline, signed-in live, and public offline hero copy.

## Why

Production could show an `OFFLINE` badge while the main hero text still said the stream was online. The root cause was that the signed-in branch of the hero copy ignored `isLive`.

## Validation

- `npm.cmd test -- home-hero-copy`
- `npm.cmd test`
- `npm.cmd run typecheck`
- `npm.cmd run build`