### PR TITLE
[codex] Add daily death counters and update social links

### DIFF
--- a/src/lib/db/repository.test.ts
+++ b/src/lib/db/repository.test.ts
@@ -658,15 +658,42 @@ function createStreamerbotCounterDb({
 } = {}) {
   const rows = counterRows ? [...counterRows] : [];
 
+  function getCounterKeyFromWhereClause(whereClause: unknown) {
+    if (!whereClause || typeof whereClause !== "object" || !("queryChunks" in whereClause)) {
+      return null;
+    }
+
+    const queryChunks = (whereClause as { queryChunks?: unknown[] }).queryChunks;
+    if (!Array.isArray(queryChunks)) {
+      return null;
+    }
+
+    for (const chunk of queryChunks) {
+      if (chunk && typeof chunk === "object" && "value" in chunk) {
+        const value = (chunk as { value?: unknown }).value;
+        if (typeof value === "string") {
+          return value;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  function findRows(whereClause?: unknown) {
+    const key = getCounterKeyFromWhereClause(whereClause);
+    return key ? rows.filter((entry) => entry.key === key) : rows;
+  }
+
   const tx = {
     select() {
       return {
         from(table: unknown) {
           if (table === streamerbotCounters) {
             return Object.assign(rows, {
-              where() {
+              where(whereClause?: unknown) {
                 return {
-                  limit: async () => rows,
+                  limit: async () => findRows(whereClause),
                 };
               },
             });
@@ -706,12 +733,13 @@ function createStreamerbotCounterDb({
         return {
           set(values: Partial<(typeof rows)[number]>) {
             return {
-              where: async () => {
-                if (!rows[0]) {
+              where: async (whereClause?: unknown) => {
+                const [target] = findRows(whereClause);
+                if (!target) {
                   throw new Error("Expected a counter row before update.");
                 }
 
-                Object.assign(rows[0], values);
+                Object.assign(target, values);
               },
             };
           },
@@ -1663,6 +1691,10 @@ describe("runStreamerbotCounterCommand", () => {
   it("lists public counters with global and game scopes in demo mode", async () => {
     getDbMock.mockReturnValue(null);
 
+    await runDeathCounterCommand({
+      action: "increment",
+      amount: 2,
+    });
     await runStreamerbotCounterCommand({
       counterKey: "win_count",
       counterLabel: "vitorias",
@@ -1688,6 +1720,13 @@ describe("runStreamerbotCounterCommand", () => {
       scopeKey: counter.scopeKey,
       value: counter.value,
     }))).toEqual([
+      {
+        key: "death_count",
+        label: "mortes",
+        scopeType: "global",
+        scopeKey: "global",
+        value: 2,
+      },
       {
         key: "win_count",
         label: "vitorias",
@@ -1867,6 +1906,20 @@ describe("runStreamerbotCounterCommand", () => {
           },
         },
         {
+          key: "death_count_daily",
+          value: 18,
+          lastResetAt: null,
+          updatedAt: new Date("2026-04-07T11:04:00.000Z"),
+          metadata: {
+            counterKey: "death_count_daily",
+            counterLabel: "mortes do dia",
+            scopeType: "global",
+            scopeKey: "global",
+            trackingDate: "2026-04-07",
+            hiddenFromPublic: true,
+          },
+        },
+        {
           key: "death_count",
           value: 154,
           lastResetAt: null,
@@ -1970,6 +2023,7 @@ describe("runStreamerbotCounterCommand", () => {
       action: "increment",
       amount: 3,
       requestedBy: "Mod",
+      occurredAt: "2026-04-07T12:00:00.000Z",
     });
 
     expect(result).toMatchObject({
@@ -1978,17 +2032,99 @@ describe("runStreamerbotCounterCommand", () => {
       count: 3,
       replyMessage: "Mod, contador de mortes em Hollow Knight: Silksong: 3 (+3).",
     });
-    expect(rows[0]).toMatchObject({
-      key: "game::hollow-knight-silksong::death_count",
-      value: 3,
-      metadata: {
-        counterKey: "death_count",
-        counterLabel: "mortes",
-        scopeType: "game",
-        scopeKey: "hollow-knight-silksong",
-        scopeLabel: "Hollow Knight: Silksong",
-      },
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "game::hollow-knight-silksong::death_count",
+          value: 3,
+          metadata: expect.objectContaining({
+            counterKey: "death_count",
+            counterLabel: "mortes",
+            scopeType: "game",
+            scopeKey: "hollow-knight-silksong",
+            scopeLabel: "Hollow Knight: Silksong",
+          }),
+        }),
+        expect.objectContaining({
+          key: "death_count",
+          value: 3,
+          metadata: expect.objectContaining({
+            counterKey: "death_count",
+            counterLabel: "mortes",
+            scopeType: "global",
+            scopeKey: "global",
+          }),
+        }),
+        expect.objectContaining({
+          key: "death_count_daily",
+          value: 3,
+          metadata: expect.objectContaining({
+            counterKey: "death_count_daily",
+            counterLabel: "mortes do dia",
+            trackingDate: "2026-04-07",
+            hiddenFromPublic: true,
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("resets the hidden daily death counter when a new day starts", async () => {
+    getDbMock.mockReturnValue(null);
+
+    await runDeathCounterCommand({
+      action: "increment",
+      amount: 2,
+      occurredAt: "2026-04-07T23:30:00.000Z",
     });
+
+    await runDeathCounterCommand({
+      action: "increment",
+      amount: 1,
+      occurredAt: "2026-04-08T10:00:00.000Z",
+    });
+
+    const counters = await listStreamerbotCounters();
+    const globalDeaths = counters.find((counter) => counter.key === "death_count" && counter.scopeType === "global");
+    expect(globalDeaths?.value).toBe(3);
+
+    const dailyHidden = await runStreamerbotCounterCommand({
+      action: "get",
+      counterKey: "death_count_daily",
+      counterLabel: "mortes do dia",
+      scopeType: "global",
+    });
+
+    expect(dailyHidden.count).toBe(1);
+    expect(dailyHidden.counter.metadata).toMatchObject({
+      trackingDate: "2026-04-08",
+      hiddenFromPublic: true,
+    });
+  });
+
+  it("shows the global and daily death counters on get", async () => {
+    getDbMock.mockReturnValue(null);
+
+    await runDeathCounterCommand({
+      action: "increment",
+      amount: 2,
+      occurredAt: "2026-04-07T10:00:00.000Z",
+    });
+    await runDeathCounterCommand({
+      action: "increment",
+      amount: 1,
+      occurredAt: "2026-04-07T11:00:00.000Z",
+      requestedBy: "Ludy",
+    });
+
+    const result = await runDeathCounterCommand({
+      action: "get",
+      occurredAt: "2026-04-07T12:00:00.000Z",
+      requestedBy: "Ludy",
+    });
+
+    expect(result.count).toBe(3);
+    expect(result.replyMessage).toBe("Ludy, contador geral de mortes: 3. Contador de mortes do dia: 3.");
   });
 
   it("uses the current stream game even when an explicit game scope is provided", async () => {
@@ -2014,7 +2150,46 @@ describe("runStreamerbotCounterCommand", () => {
     });
 
     expect(result.replyMessage).toBe("contador de mortes em Silksong: 1.");
-    expect(rows[0]?.key).toBe("game::silksong::death_count");
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "game::silksong::death_count",
+          value: 1,
+        }),
+        expect.objectContaining({
+          key: "death_count",
+          value: 1,
+        }),
+      ]),
+    );
+  });
+
+  it("shows the global and daily death counters on get even with an active current game", async () => {
+    const { db } = createStreamerbotCounterDb();
+    getDbMock.mockReturnValue(db);
+    getCurrentGameMock.mockResolvedValue({
+      igdbId: 103837,
+      name: "Silksong",
+      releaseYear: 2025,
+      coverImageUrl: null,
+      platforms: [],
+      genres: [],
+      updatedAt: "2026-04-07T10:00:00.000Z",
+      updatedBy: "admin@example.com",
+    });
+
+    await runDeathCounterCommand({
+      action: "increment",
+      amount: 2,
+      occurredAt: "2026-04-07T10:00:00.000Z",
+    });
+
+    const result = await runDeathCounterCommand({
+      action: "get",
+      occurredAt: "2026-04-07T12:00:00.000Z",
+    });
+
+    expect(result.replyMessage).toBe("contador geral de mortes: 2. Contador de mortes do dia: 2.");
   });
 });
 

--- a/src/lib/db/repository.ts
+++ b/src/lib/db/repository.ts
@@ -155,6 +155,7 @@ function shouldExcludeFromRanking(email: string | null) {
 }
 
 const DEFAULT_DEATH_COUNTER_KEY = "death_count";
+const DAILY_DEATH_COUNTER_KEY = "death_count_daily";
 const HOWLONGTOBEAT_CACHE_TTL_MS = 1000 * 60 * 60 * 24 * 30;
 const HOWLONGTOBEAT_MISSING_CACHE_TTL_MS = 1000 * 60 * 15;
 const HOWLONGTOBEAT_REFRESH_BATCH_LIMIT = 8;
@@ -252,6 +253,7 @@ function buildSpendingHistory(input: {
   ].sort((a, b) => +new Date(b.occurredAt) - +new Date(a.occurredAt));
 }
 const DEFAULT_DEATH_COUNTER_LABEL = "mortes";
+const DAILY_DEATH_COUNTER_LABEL = "mortes do dia";
 const GLOBAL_COUNTER_SCOPE_TYPE = "global";
 const GLOBAL_COUNTER_SCOPE_KEY = "global";
 const STREAMERBOT_COUNTER_STORAGE_SEPARATOR = "::";
@@ -590,6 +592,23 @@ type StreamerbotCounterCommandResult = {
   counter: StreamerbotCounterRecord;
   replyMessage: string;
 };
+
+function buildCounterDateKey(occurredAt: Date) {
+  return occurredAt.toISOString().slice(0, 10);
+}
+
+function isGlobalCounterScope(scope: { scopeType?: string | null }) {
+  return scope.scopeType === GLOBAL_COUNTER_SCOPE_TYPE;
+}
+
+function buildDeathCountersReply(input: {
+  requestedBy?: string | null;
+  globalCount: number;
+  dailyCount: number;
+}) {
+  const prefix = input.requestedBy ? `${input.requestedBy}, ` : "";
+  return `${prefix}contador geral de mortes: ${input.globalCount}. Contador de mortes do dia: ${input.dailyCount}.`;
+}
 
 function buildStreamerbotCounterSummary(counter: StreamerbotCounterRecord): StreamerbotCounterSummaryRecord {
   const scope = normalizeStreamerbotCounterScope({
@@ -931,6 +950,7 @@ function sanitizePublicCounterSummaries(
   const hiddenCounterKeys = new Set([
     "livestream_override",
     "death_counter_active_game",
+    DAILY_DEATH_COUNTER_KEY,
     "current_stream_game",
   ]);
 
@@ -7845,6 +7865,7 @@ export async function runStreamerbotCounterCommand(input: {
   occurredAt?: string | null;
   confirmReset?: boolean;
   resetReason?: string | null;
+  metadata?: Record<string, unknown> | null;
 }): Promise<StreamerbotCounterCommandResult> {
   const counterKey = input.counterKey.trim().toLowerCase();
   const amount = input.amount ?? 1;
@@ -7889,6 +7910,7 @@ export async function runStreamerbotCounterCommand(input: {
         scopeType: scope.scopeType,
         scopeKey: scope.scopeKey,
         scopeLabel: scope.scopeLabel,
+        ...(input.metadata ?? {}),
       };
     } else if (input.action === "decrement") {
       appliedAmount = Math.min(amount, counter.value);
@@ -7903,6 +7925,7 @@ export async function runStreamerbotCounterCommand(input: {
         scopeType: scope.scopeType,
         scopeKey: scope.scopeKey,
         scopeLabel: scope.scopeLabel,
+        ...(input.metadata ?? {}),
       };
     } else if (input.action === "reset") {
       const previousValue = counter.value;
@@ -7919,6 +7942,7 @@ export async function runStreamerbotCounterCommand(input: {
         scopeKey: scope.scopeKey,
         scopeLabel: scope.scopeLabel,
         resetReason: input.resetReason ?? null,
+        ...(input.metadata ?? {}),
       };
     }
 
@@ -7962,6 +7986,7 @@ export async function runStreamerbotCounterCommand(input: {
           scopeType: scope.scopeType,
           scopeKey: scope.scopeKey,
           scopeLabel: scope.scopeLabel,
+          ...(input.metadata ?? {}),
         },
       },
       replyMessage: buildStreamerbotCounterReply({
@@ -8021,6 +8046,7 @@ export async function runStreamerbotCounterCommand(input: {
             scopeType: scope.scopeType,
             scopeKey: scope.scopeKey,
             scopeLabel: scope.scopeLabel,
+            ...(input.metadata ?? {}),
           }
         : input.action === "decrement"
           ? {
@@ -8033,6 +8059,7 @@ export async function runStreamerbotCounterCommand(input: {
               scopeType: scope.scopeType,
               scopeKey: scope.scopeKey,
               scopeLabel: scope.scopeLabel,
+              ...(input.metadata ?? {}),
             }
           : {
               lastAction: "reset",
@@ -8045,6 +8072,7 @@ export async function runStreamerbotCounterCommand(input: {
               scopeKey: scope.scopeKey,
               scopeLabel: scope.scopeLabel,
               resetReason: input.resetReason ?? null,
+              ...(input.metadata ?? {}),
             };
 
     await tx
@@ -8121,22 +8149,111 @@ export async function runDeathCounterCommand(input: {
   resetReason?: string | null;
 }) {
   const currentGame = await getCurrentGame();
-  const currentGameScope = currentGame
+  const occurredAt = input.occurredAt ? new Date(input.occurredAt) : new Date();
+  const counterDateKey = buildCounterDateKey(occurredAt);
+  const dailyMetadata = {
+    hiddenFromPublic: true,
+    trackingDate: counterDateKey,
+  };
+  const resolvedScope = currentGame
     ? {
         scopeType: "game" as const,
         scopeKey: slugify(currentGame.name) || String(currentGame.igdbId),
         scopeLabel: currentGame.name,
       }
-    : null;
+    : normalizeStreamerbotCounterScope({
+        scopeType: input.scopeType,
+        scopeKey: input.scopeKey,
+        scopeLabel: input.scopeLabel,
+      });
 
-  return runStreamerbotCounterCommand({
+  const primaryResult = await runStreamerbotCounterCommand({
     ...input,
-    scopeType: currentGameScope?.scopeType ?? input.scopeType,
-    scopeKey: currentGameScope?.scopeKey ?? input.scopeKey,
-    scopeLabel: currentGameScope?.scopeLabel ?? input.scopeLabel,
+    scopeType: resolvedScope.scopeType,
+    scopeKey: resolvedScope.scopeKey,
+    scopeLabel: resolvedScope.scopeLabel,
     counterKey: DEFAULT_DEATH_COUNTER_KEY,
     counterLabel: DEFAULT_DEATH_COUNTER_LABEL,
   });
+
+  if (input.action === "get") {
+    const globalCounter = isGlobalCounterScope(resolvedScope)
+      ? primaryResult
+      : await runStreamerbotCounterCommand({
+          action: "get",
+          requestedBy: input.requestedBy,
+          source: input.source,
+          occurredAt: input.occurredAt,
+          counterKey: DEFAULT_DEATH_COUNTER_KEY,
+          counterLabel: DEFAULT_DEATH_COUNTER_LABEL,
+          scopeType: GLOBAL_COUNTER_SCOPE_TYPE,
+        });
+    const dailyCounter = await runStreamerbotCounterCommand({
+      action: "get",
+      requestedBy: input.requestedBy,
+      source: input.source,
+      occurredAt: input.occurredAt,
+      counterKey: DAILY_DEATH_COUNTER_KEY,
+      counterLabel: DAILY_DEATH_COUNTER_LABEL,
+      scopeType: GLOBAL_COUNTER_SCOPE_TYPE,
+      metadata: dailyMetadata,
+    });
+
+    return {
+      ...primaryResult,
+      replyMessage: buildDeathCountersReply({
+        requestedBy: input.requestedBy,
+        globalCount: globalCounter.count,
+        dailyCount: dailyCounter.count,
+      }),
+    };
+  }
+
+  if (input.action === "increment" || input.action === "decrement") {
+    if (!isGlobalCounterScope(resolvedScope)) {
+      await runStreamerbotCounterCommand({
+        ...input,
+        scopeType: GLOBAL_COUNTER_SCOPE_TYPE,
+        counterKey: DEFAULT_DEATH_COUNTER_KEY,
+        counterLabel: DEFAULT_DEATH_COUNTER_LABEL,
+      });
+    }
+    const dailyCounter = await runStreamerbotCounterCommand({
+      action: "get",
+      counterKey: DAILY_DEATH_COUNTER_KEY,
+      counterLabel: DAILY_DEATH_COUNTER_LABEL,
+      scopeType: GLOBAL_COUNTER_SCOPE_TYPE,
+      occurredAt: input.occurredAt,
+      metadata: dailyMetadata,
+    });
+    const trackedDate =
+      typeof dailyCounter.counter.metadata.trackingDate === "string"
+        ? dailyCounter.counter.metadata.trackingDate
+        : null;
+
+    if (trackedDate && trackedDate !== counterDateKey) {
+      await runStreamerbotCounterCommand({
+        action: "reset",
+        counterKey: DAILY_DEATH_COUNTER_KEY,
+        counterLabel: DAILY_DEATH_COUNTER_LABEL,
+        scopeType: GLOBAL_COUNTER_SCOPE_TYPE,
+        occurredAt: input.occurredAt,
+        confirmReset: true,
+        resetReason: "new_day",
+        metadata: dailyMetadata,
+      });
+    }
+
+    await runStreamerbotCounterCommand({
+      ...input,
+      scopeType: GLOBAL_COUNTER_SCOPE_TYPE,
+      counterKey: DAILY_DEATH_COUNTER_KEY,
+      counterLabel: DAILY_DEATH_COUNTER_LABEL,
+      metadata: dailyMetadata,
+    });
+  }
+
+  return primaryResult;
 }
 
 export async function lockBet(betId: string) {

--- a/src/lib/social-links.ts
+++ b/src/lib/social-links.ts
@@ -1,4 +1,4 @@
-import { FaBluesky, FaGithub, FaInstagram, FaThreads, FaXTwitter, FaYoutube } from "react-icons/fa6";
+import { FaBluesky, FaDiscord, FaGithub, FaInstagram, FaThreads, FaXTwitter, FaYoutube } from "react-icons/fa6";
 import { TbWorld } from "react-icons/tb";
 
 export const socialLinks = [
@@ -19,8 +19,13 @@ export const socialLinks = [
   },
   {
     label: "Instagram",
-    href: "https://www.instagram.com/ludylops",
+    href: "https://www.instagram.com/ludylopsGames",
     Icon: FaInstagram,
+  },
+  {
+    label: "Discord",
+    href: "https://discord.gg/qGHZxtXDAK",
+    Icon: FaDiscord,
   },
   {
     label: "Bluesky",


### PR DESCRIPTION
## What changed
- added a hidden daily death counter that is updated alongside the existing death counter flow
- updated `!deaths` to report both the global death total and the daily death total
- kept the daily counter out of the public counters page while preserving test coverage for the new behavior
- updated social links to add Discord and point Instagram to `ludylopsGames`

## Why
The local death-count flow needed a per-live-day number to support max-deaths bets without exposing another visible counter on the site. The social links also needed to match the current Discord invite and Instagram handle.

## Impact
- `!death+` and `!death-` now keep the general and daily death tracking in sync
- `!deaths` returns the two totals that matter for live moderation and betting
- the public counters page stays unchanged visually
- footer/social link consumers now use the updated Discord and Instagram destinations

## Validation
- `npm test -- --run src/lib/db/repository.test.ts`
- `npm test -- --run src/app/api/internal/streamerbot/streamerbot-routes.test.ts`