### PR TITLE
[codex] Add multi-tenant creator foundation

### DIFF
--- a/drizzle/0021_hard_riptide.sql
+++ b/drizzle/0021_hard_riptide.sql
@@ -1,0 +1,128 @@
+CREATE TABLE "creators" (
+	"id" varchar(64) PRIMARY KEY NOT NULL,
+	"slug" varchar(64) NOT NULL,
+	"display_name" varchar(255) NOT NULL,
+	"owner_user_id" varchar(64),
+	"status" varchar(32) DEFAULT 'active' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "creator_domains" (
+	"id" varchar(64) PRIMARY KEY NOT NULL,
+	"creator_id" varchar(64) NOT NULL,
+	"hostname" varchar(255) NOT NULL,
+	"is_primary" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "creator_branding" (
+	"creator_id" varchar(64) PRIMARY KEY NOT NULL,
+	"logo_url" text,
+	"avatar_url" text,
+	"primary_color" varchar(16) DEFAULT '#c7a2e9' NOT NULL,
+	"secondary_color" varchar(16) DEFAULT '#ff79c6' NOT NULL,
+	"background_color" varchar(16) DEFAULT '#f9f9f9' NOT NULL,
+	"accent_color" varchar(16) DEFAULT '#40a9ff' NOT NULL,
+	"font_heading" varchar(120) DEFAULT 'app-display' NOT NULL,
+	"font_body" varchar(120) DEFAULT 'app-body' NOT NULL,
+	"border_radius" integer DEFAULT 0 NOT NULL,
+	"theme_json" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "creator_modules" (
+	"id" varchar(64) PRIMARY KEY NOT NULL,
+	"creator_id" varchar(64) NOT NULL,
+	"module_key" varchar(64) NOT NULL,
+	"status" varchar(32) DEFAULT 'installed' NOT NULL,
+	"config_json" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"installed_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "creators" ADD CONSTRAINT "creators_owner_user_id_users_id_fk" FOREIGN KEY ("owner_user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "creator_domains" ADD CONSTRAINT "creator_domains_creator_id_creators_id_fk" FOREIGN KEY ("creator_id") REFERENCES "public"."creators"("id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "creator_branding" ADD CONSTRAINT "creator_branding_creator_id_creators_id_fk" FOREIGN KEY ("creator_id") REFERENCES "public"."creators"("id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "creator_modules" ADD CONSTRAINT "creator_modules_creator_id_creators_id_fk" FOREIGN KEY ("creator_id") REFERENCES "public"."creators"("id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "creators_slug_idx" ON "creators" USING btree ("slug");
+--> statement-breakpoint
+CREATE INDEX "creators_owner_user_id_idx" ON "creators" USING btree ("owner_user_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "creator_domains_hostname_idx" ON "creator_domains" USING btree ("hostname");
+--> statement-breakpoint
+CREATE INDEX "creator_domains_creator_id_idx" ON "creator_domains" USING btree ("creator_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "creator_modules_creator_module_idx" ON "creator_modules" USING btree ("creator_id","module_key");
+--> statement-breakpoint
+CREATE INDEX "creator_modules_creator_id_idx" ON "creator_modules" USING btree ("creator_id");
+--> statement-breakpoint
+INSERT INTO "creators" ("id", "slug", "display_name", "owner_user_id", "status")
+VALUES ('creator_ludylops', 'ludylops', 'Ludylops', NULL, 'active')
+ON CONFLICT ("id") DO UPDATE SET
+	"slug" = EXCLUDED."slug",
+	"display_name" = EXCLUDED."display_name",
+	"status" = EXCLUDED."status",
+	"updated_at" = now();
+--> statement-breakpoint
+INSERT INTO "creator_domains" ("id", "creator_id", "hostname", "is_primary")
+VALUES ('creator_domain_ludylops_live', 'creator_ludylops', 'ludylops.live', true)
+ON CONFLICT ("id") DO UPDATE SET
+	"creator_id" = EXCLUDED."creator_id",
+	"hostname" = EXCLUDED."hostname",
+	"is_primary" = EXCLUDED."is_primary";
+--> statement-breakpoint
+INSERT INTO "creator_branding" (
+	"creator_id",
+	"primary_color",
+	"secondary_color",
+	"background_color",
+	"accent_color",
+	"font_heading",
+	"font_body",
+	"border_radius",
+	"theme_json"
+)
+VALUES (
+	'creator_ludylops',
+	'#c7a2e9',
+	'#ff79c6',
+	'#f9f9f9',
+	'#40a9ff',
+	'app-display',
+	'app-body',
+	0,
+	'{}'::jsonb
+)
+ON CONFLICT ("creator_id") DO UPDATE SET
+	"primary_color" = EXCLUDED."primary_color",
+	"secondary_color" = EXCLUDED."secondary_color",
+	"background_color" = EXCLUDED."background_color",
+	"accent_color" = EXCLUDED."accent_color",
+	"font_heading" = EXCLUDED."font_heading",
+	"font_body" = EXCLUDED."font_body",
+	"border_radius" = EXCLUDED."border_radius",
+	"theme_json" = EXCLUDED."theme_json",
+	"updated_at" = now();
+--> statement-breakpoint
+INSERT INTO "creator_modules" ("id", "creator_id", "module_key", "status", "config_json")
+VALUES
+	('creator_module_ludylops_points', 'creator_ludylops', 'points', 'installed', '{"currencyLabel":"pipetz"}'::jsonb),
+	('creator_module_ludylops_ranking', 'creator_ludylops', 'ranking', 'installed', '{}'::jsonb),
+	('creator_module_ludylops_redemptions', 'creator_ludylops', 'redemptions', 'installed', '{}'::jsonb),
+	('creator_module_ludylops_bets', 'creator_ludylops', 'bets', 'installed', '{"minBet":10,"maxOptions":6}'::jsonb),
+	('creator_module_ludylops_product_recommendations', 'creator_ludylops', 'product_recommendations', 'installed', '{}'::jsonb),
+	('creator_module_ludylops_game_suggestions', 'creator_ludylops', 'game_suggestions', 'installed', '{}'::jsonb),
+	('creator_module_ludylops_video_suggestions', 'creator_ludylops', 'video_suggestions', 'installed', '{}'::jsonb),
+	('creator_module_ludylops_creator_suggestions', 'creator_ludylops', 'creator_suggestions', 'installed', '{}'::jsonb),
+	('creator_module_ludylops_quotes', 'creator_ludylops', 'quotes', 'installed', '{"displayDurationSeconds":12}'::jsonb),
+	('creator_module_ludylops_obs_overlays', 'creator_ludylops', 'obs_overlays', 'installed', '{}'::jsonb),
+	('creator_module_ludylops_streamerbot', 'creator_ludylops', 'streamerbot', 'installed', '{}'::jsonb)
+ON CONFLICT ("creator_id", "module_key") DO UPDATE SET
+	"status" = EXCLUDED."status",
+	"config_json" = EXCLUDED."config_json",
+	"updated_at" = now();

--- a/drizzle/meta/0021_snapshot.json
+++ b/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,3488 @@
+{
+  "id": "991bd172-c601-4699-988b-ac583cfbc8a7",
+  "prevId": "c76be4ef-6b7e-41f3-9e59-dc861ddc7b90",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.bet_entries": {
+      "name": "bet_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bet_id": {
+          "name": "bet_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_house_entry": {
+          "name": "is_house_entry",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payout_amount": {
+          "name": "payout_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refunded_at": {
+          "name": "refunded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bet_entries_bet_viewer_idx": {
+          "name": "bet_entries_bet_viewer_idx",
+          "columns": [
+            {
+              "expression": "bet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "viewer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bet_entries_viewer_id_idx": {
+          "name": "bet_entries_viewer_id_idx",
+          "columns": [
+            {
+              "expression": "viewer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bet_entries_bet_id_bets_id_fk": {
+          "name": "bet_entries_bet_id_bets_id_fk",
+          "tableFrom": "bet_entries",
+          "tableTo": "bets",
+          "columnsFrom": [
+            "bet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bet_entries_option_id_bet_options_id_fk": {
+          "name": "bet_entries_option_id_bet_options_id_fk",
+          "tableFrom": "bet_entries",
+          "tableTo": "bet_options",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bet_entries_viewer_id_users_id_fk": {
+          "name": "bet_entries_viewer_id_users_id_fk",
+          "tableFrom": "bet_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bet_options": {
+      "name": "bet_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bet_id": {
+          "name": "bet_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pool_amount": {
+          "name": "pool_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bet_options_bet_id_bets_id_fk": {
+          "name": "bet_options_bet_id_bets_id_fk",
+          "tableFrom": "bet_options",
+          "tableTo": "bets",
+          "columnsFrom": [
+            "bet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bets": {
+      "name": "bets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closes_at": {
+          "name": "closes_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "winning_option_id": {
+          "name": "winning_option_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bridge_clients": {
+      "name": "bridge_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "machine_key": {
+          "name": "machine_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bridge_clients_machine_key_idx": {
+          "name": "bridge_clients_machine_key_idx",
+          "columns": [
+            {
+              "expression": "machine_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_items": {
+      "name": "catalog_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "global_cooldown_seconds": {
+          "name": "global_cooldown_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "viewer_cooldown_seconds": {
+          "name": "viewer_cooldown_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_image_url": {
+          "name": "preview_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accent_color": {
+          "name": "accent_color",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#b4ff39'"
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "streamerbot_action_ref": {
+          "name": "streamerbot_action_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "streamerbot_args_template": {
+          "name": "streamerbot_args_template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "catalog_items_slug_idx": {
+          "name": "catalog_items_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.creator_branding": {
+      "name": "creator_branding",
+      "schema": "",
+      "columns": {
+        "creator_id": {
+          "name": "creator_id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_color": {
+          "name": "primary_color",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#c7a2e9'"
+        },
+        "secondary_color": {
+          "name": "secondary_color",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#ff79c6'"
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#f9f9f9'"
+        },
+        "accent_color": {
+          "name": "accent_color",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#40a9ff'"
+        },
+        "font_heading": {
+          "name": "font_heading",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'app-display'"
+        },
+        "font_body": {
+          "name": "font_body",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'app-body'"
+        },
+        "border_radius": {
+          "name": "border_radius",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "theme_json": {
+          "name": "theme_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "creator_branding_creator_id_creators_id_fk": {
+          "name": "creator_branding_creator_id_creators_id_fk",
+          "tableFrom": "creator_branding",
+          "tableTo": "creators",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.creator_domains": {
+      "name": "creator_domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "creator_domains_hostname_idx": {
+          "name": "creator_domains_hostname_idx",
+          "columns": [
+            {
+              "expression": "hostname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "creator_domains_creator_id_idx": {
+          "name": "creator_domains_creator_id_idx",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "creator_domains_creator_id_creators_id_fk": {
+          "name": "creator_domains_creator_id_creators_id_fk",
+          "tableFrom": "creator_domains",
+          "tableTo": "creators",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.creator_modules": {
+      "name": "creator_modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_key": {
+          "name": "module_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'installed'"
+        },
+        "config_json": {
+          "name": "config_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "creator_modules_creator_module_idx": {
+          "name": "creator_modules_creator_module_idx",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "module_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "creator_modules_creator_id_idx": {
+          "name": "creator_modules_creator_id_idx",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "creator_modules_creator_id_creators_id_fk": {
+          "name": "creator_modules_creator_id_creators_id_fk",
+          "tableFrom": "creator_modules",
+          "tableTo": "creators",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.creator_suggestion_boosts": {
+      "name": "creator_suggestion_boosts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "suggestion_id": {
+          "name": "suggestion_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "creator_suggestion_boosts_suggestion_id_idx": {
+          "name": "creator_suggestion_boosts_suggestion_id_idx",
+          "columns": [
+            {
+              "expression": "suggestion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "creator_suggestion_boosts_viewer_id_idx": {
+          "name": "creator_suggestion_boosts_viewer_id_idx",
+          "columns": [
+            {
+              "expression": "viewer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "creator_suggestion_boosts_suggestion_id_creator_suggestions_id_fk": {
+          "name": "creator_suggestion_boosts_suggestion_id_creator_suggestions_id_fk",
+          "tableFrom": "creator_suggestion_boosts",
+          "tableTo": "creator_suggestions",
+          "columnsFrom": [
+            "suggestion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "creator_suggestion_boosts_viewer_id_users_id_fk": {
+          "name": "creator_suggestion_boosts_viewer_id_users_id_fk",
+          "tableFrom": "creator_suggestion_boosts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.creator_suggestions": {
+      "name": "creator_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_url": {
+          "name": "channel_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_votes": {
+          "name": "total_votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "creator_suggestions_viewer_id_users_id_fk": {
+          "name": "creator_suggestions_viewer_id_users_id_fk",
+          "tableFrom": "creator_suggestions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.creators": {
+      "name": "creators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "creators_slug_idx": {
+          "name": "creators_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "creators_owner_user_id_idx": {
+          "name": "creators_owner_user_id_idx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "creators_owner_user_id_users_id_fk": {
+          "name": "creators_owner_user_id_users_id_fk",
+          "tableFrom": "creators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_suggestion_boosts": {
+      "name": "game_suggestion_boosts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "suggestion_id": {
+          "name": "suggestion_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_suggestion_boosts_suggestion_id_idx": {
+          "name": "game_suggestion_boosts_suggestion_id_idx",
+          "columns": [
+            {
+              "expression": "suggestion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "game_suggestion_boosts_viewer_id_idx": {
+          "name": "game_suggestion_boosts_viewer_id_idx",
+          "columns": [
+            {
+              "expression": "viewer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_suggestion_boosts_suggestion_id_game_suggestions_id_fk": {
+          "name": "game_suggestion_boosts_suggestion_id_game_suggestions_id_fk",
+          "tableFrom": "game_suggestion_boosts",
+          "tableTo": "game_suggestions",
+          "columnsFrom": [
+            "suggestion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_suggestion_boosts_viewer_id_users_id_fk": {
+          "name": "game_suggestion_boosts_viewer_id_users_id_fk",
+          "tableFrom": "game_suggestion_boosts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_suggestions": {
+      "name": "game_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "igdb_id": {
+          "name": "igdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_name": {
+          "name": "canonical_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platforms": {
+          "name": "platforms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "hltb_id": {
+          "name": "hltb_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hltb_name": {
+          "name": "hltb_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hltb_main_story_minutes": {
+          "name": "hltb_main_story_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hltb_main_extra_minutes": {
+          "name": "hltb_main_extra_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hltb_completionist_minutes": {
+          "name": "hltb_completionist_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hltb_similarity": {
+          "name": "hltb_similarity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hltb_fetched_at": {
+          "name": "hltb_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ps_plus_available": {
+          "name": "ps_plus_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ps_plus_region": {
+          "name": "ps_plus_region",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ps_plus_tier": {
+          "name": "ps_plus_tier",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ps_plus_product_id": {
+          "name": "ps_plus_product_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ps_plus_title_id": {
+          "name": "ps_plus_title_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ps_plus_product_url": {
+          "name": "ps_plus_product_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ps_plus_checked_at": {
+          "name": "ps_plus_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ps_plus_last_seen_at": {
+          "name": "ps_plus_last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_app_id": {
+          "name": "steam_app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_name": {
+          "name": "steam_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_store_url": {
+          "name": "steam_store_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_currency": {
+          "name": "steam_currency",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_initial_price": {
+          "name": "steam_initial_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_final_price": {
+          "name": "steam_final_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_discount_percent": {
+          "name": "steam_discount_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_is_free": {
+          "name": "steam_is_free",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "steam_match_confidence": {
+          "name": "steam_match_confidence",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_checked_at": {
+          "name": "steam_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_last_price_at": {
+          "name": "steam_last_price_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_votes": {
+          "name": "total_votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_suggestions_viewer_id_users_id_fk": {
+          "name": "game_suggestions_viewer_id_users_id_fk",
+          "tableFrom": "game_suggestions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_account_viewers": {
+      "name": "google_account_viewers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_account_id": {
+          "name": "google_account_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "google_account_viewers_account_viewer_idx": {
+          "name": "google_account_viewers_account_viewer_idx",
+          "columns": [
+            {
+              "expression": "google_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "viewer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "google_account_viewers_viewer_id_idx": {
+          "name": "google_account_viewers_viewer_id_idx",
+          "columns": [
+            {
+              "expression": "viewer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_account_viewers_google_account_id_google_accounts_id_fk": {
+          "name": "google_account_viewers_google_account_id_google_accounts_id_fk",
+          "tableFrom": "google_account_viewers",
+          "tableTo": "google_accounts",
+          "columnsFrom": [
+            "google_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "google_account_viewers_viewer_id_users_id_fk": {
+          "name": "google_account_viewers_viewer_id_users_id_fk",
+          "tableFrom": "google_account_viewers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_accounts": {
+      "name": "google_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_user_id": {
+          "name": "google_user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_viewer_id": {
+          "name": "active_viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cross_account_protection_state": {
+          "name": "cross_account_protection_state",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ok'"
+        },
+        "cross_account_protection_event": {
+          "name": "cross_account_protection_event",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cross_account_protection_reason": {
+          "name": "cross_account_protection_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cross_account_protection_updated_at": {
+          "name": "cross_account_protection_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sessions_revoked_at": {
+          "name": "sessions_revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "google_accounts_google_user_id_idx": {
+          "name": "google_accounts_google_user_id_idx",
+          "columns": [
+            {
+              "expression": "google_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "google_accounts_email_idx": {
+          "name": "google_accounts_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_accounts_active_viewer_id_users_id_fk": {
+          "name": "google_accounts_active_viewer_id_users_id_fk",
+          "tableFrom": "google_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "active_viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_risc_deliveries": {
+      "name": "google_risc_deliveries",
+      "schema": "",
+      "columns": {
+        "jti": {
+          "name": "jti",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_types": {
+          "name": "event_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_account_count": {
+          "name": "matched_account_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.live_like_goal_rewards": {
+      "name": "live_like_goal_rewards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "broadcast_id": {
+          "name": "broadcast_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reward_amount": {
+          "name": "reward_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rewarded_viewer_count": {
+          "name": "rewarded_viewer_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "live_like_goal_rewards_goal_broadcast_idx": {
+          "name": "live_like_goal_rewards_goal_broadcast_idx",
+          "columns": [
+            {
+              "expression": "goal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "broadcast_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "live_like_goal_rewards_goal_id_live_like_goals_id_fk": {
+          "name": "live_like_goal_rewards_goal_id_live_like_goals_id_fk",
+          "tableFrom": "live_like_goal_rewards",
+          "tableTo": "live_like_goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.live_like_goals": {
+      "name": "live_like_goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_like_count": {
+          "name": "target_like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reward_amount": {
+          "name": "reward_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.obs_overlay_control": {
+      "name": "obs_overlay_control",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumed_at": {
+          "name": "resumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.point_ledger": {
+      "name": "point_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "point_ledger_external_event_idx": {
+          "name": "point_ledger_external_event_idx",
+          "columns": [
+            {
+              "expression": "external_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "point_ledger_viewer_created_idx": {
+          "name": "point_ledger_viewer_created_idx",
+          "columns": [
+            {
+              "expression": "viewer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "point_ledger_viewer_id_users_id_fk": {
+          "name": "point_ledger_viewer_id_users_id_fk",
+          "tableFrom": "point_ledger",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_recommendations": {
+      "name": "product_recommendations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "href": {
+          "name": "href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "store_label": {
+          "name": "store_label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_kind": {
+          "name": "link_kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_status": {
+          "name": "moderation_status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'approved'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "product_recommendations_slug_idx": {
+          "name": "product_recommendations_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "product_recommendations_moderation_status_idx": {
+          "name": "product_recommendations_moderation_status_idx",
+          "columns": [
+            {
+              "expression": "moderation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ps_plus_catalog_items": {
+      "name": "ps_plus_catalog_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(160)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_id": {
+          "name": "title_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_url": {
+          "name": "product_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platforms": {
+          "name": "platforms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ps_plus_catalog_items_region_product_idx": {
+          "name": "ps_plus_catalog_items_region_product_idx",
+          "columns": [
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ps_plus_catalog_items_region_normalized_name_idx": {
+          "name": "ps_plus_catalog_items_region_normalized_name_idx",
+          "columns": [
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ps_plus_catalog_sync_state": {
+      "name": "ps_plus_catalog_sync_state",
+      "schema": "",
+      "columns": {
+        "region": {
+          "name": "region",
+          "type": "varchar(16)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_count": {
+          "name": "item_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_sync_at": {
+          "name": "next_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_overlay_queue": {
+      "name": "quote_overlay_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_number": {
+          "name": "quote_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_body": {
+          "name": "quote_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_display_name": {
+          "name": "created_by_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_youtube_handle": {
+          "name": "created_by_youtube_handle",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_viewer_id": {
+          "name": "requested_by_viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_display_name": {
+          "name": "requested_by_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_youtube_handle": {
+          "name": "requested_by_youtube_handle",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'streamerbot_chat'"
+        },
+        "cost": {
+          "name": "cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_duration_seconds": {
+          "name": "display_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quote_overlay_queue_requested_by_viewer_id_users_id_fk": {
+          "name": "quote_overlay_queue_requested_by_viewer_id_users_id_fk",
+          "tableFrom": "quote_overlay_queue",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_overlay_state": {
+      "name": "quote_overlay_state",
+      "schema": "",
+      "columns": {
+        "slot": {
+          "name": "slot",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "overlay_id": {
+          "name": "overlay_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_number": {
+          "name": "quote_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_body": {
+          "name": "quote_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_display_name": {
+          "name": "created_by_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_youtube_handle": {
+          "name": "created_by_youtube_handle",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_viewer_id": {
+          "name": "requested_by_viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_display_name": {
+          "name": "requested_by_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_youtube_handle": {
+          "name": "requested_by_youtube_handle",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'streamerbot_chat'"
+        },
+        "cost": {
+          "name": "cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quote_overlay_state_requested_by_viewer_id_users_id_fk": {
+          "name": "quote_overlay_state_requested_by_viewer_id_users_id_fk",
+          "tableFrom": "quote_overlay_state",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quotes": {
+      "name": "quotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_number": {
+          "name": "quote_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_viewer_id": {
+          "name": "created_by_viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_display_name": {
+          "name": "created_by_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_youtube_handle": {
+          "name": "created_by_youtube_handle",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'streamerbot_chat'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quotes_quote_number_idx": {
+          "name": "quotes_quote_number_idx",
+          "columns": [
+            {
+              "expression": "quote_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quotes_created_by_viewer_id_users_id_fk": {
+          "name": "quotes_created_by_viewer_id_users_id_fk",
+          "tableFrom": "quotes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.redemptions": {
+      "name": "redemptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_item_id": {
+          "name": "catalog_item_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_at_purchase": {
+          "name": "cost_at_purchase",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_source": {
+          "name": "request_source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'web'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bridge_attempt_count": {
+          "name": "bridge_attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claimed_by_bridge_id": {
+          "name": "claimed_by_bridge_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "redemptions_viewer_id_idx": {
+          "name": "redemptions_viewer_id_idx",
+          "columns": [
+            {
+              "expression": "viewer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "redemptions_status_queued_at_idx": {
+          "name": "redemptions_status_queued_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "queued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "redemptions_viewer_id_users_id_fk": {
+          "name": "redemptions_viewer_id_users_id_fk",
+          "tableFrom": "redemptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "redemptions_catalog_item_id_catalog_items_id_fk": {
+          "name": "redemptions_catalog_item_id_catalog_items_id_fk",
+          "tableFrom": "redemptions",
+          "tableTo": "catalog_items",
+          "columnsFrom": [
+            "catalog_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.streamerbot_counters": {
+      "name": "streamerbot_counters",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_reset_at": {
+          "name": "last_reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.streamerbot_event_log": {
+      "name": "streamerbot_event_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_external_id": {
+          "name": "viewer_external_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature_valid": {
+          "name": "signature_valid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "streamerbot_event_id_idx": {
+          "name": "streamerbot_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_user_id": {
+          "name": "google_user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_channel_id": {
+          "name": "youtube_channel_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "youtube_display_name": {
+          "name": "youtube_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "youtube_handle": {
+          "name": "youtube_handle",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_linked": {
+          "name": "is_linked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "exclude_from_ranking": {
+          "name": "exclude_from_ranking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_youtube_channel_id_idx": {
+          "name": "users_youtube_channel_id_idx",
+          "columns": [
+            {
+              "expression": "youtube_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.video_suggestion_boosts": {
+      "name": "video_suggestion_boosts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "suggestion_id": {
+          "name": "suggestion_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "video_suggestion_boosts_suggestion_id_idx": {
+          "name": "video_suggestion_boosts_suggestion_id_idx",
+          "columns": [
+            {
+              "expression": "suggestion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "video_suggestion_boosts_viewer_id_idx": {
+          "name": "video_suggestion_boosts_viewer_id_idx",
+          "columns": [
+            {
+              "expression": "viewer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "video_suggestion_boosts_suggestion_id_video_suggestions_id_fk": {
+          "name": "video_suggestion_boosts_suggestion_id_video_suggestions_id_fk",
+          "tableFrom": "video_suggestion_boosts",
+          "tableTo": "video_suggestions",
+          "columnsFrom": [
+            "suggestion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "video_suggestion_boosts_viewer_id_users_id_fk": {
+          "name": "video_suggestion_boosts_viewer_id_users_id_fk",
+          "tableFrom": "video_suggestion_boosts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.video_suggestions": {
+      "name": "video_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "youtube_video_id": {
+          "name": "youtube_video_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_name": {
+          "name": "creator_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_votes": {
+          "name": "total_votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "video_suggestions_viewer_id_users_id_fk": {
+          "name": "video_suggestions_viewer_id_users_id_fk",
+          "tableFrom": "video_suggestions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.viewer_balances": {
+      "name": "viewer_balances",
+      "schema": "",
+      "columns": {
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "current_balance": {
+          "name": "current_balance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lifetime_earned": {
+          "name": "lifetime_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lifetime_spent": {
+          "name": "lifetime_spent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "viewer_balances_viewer_id_users_id_fk": {
+          "name": "viewer_balances_viewer_id_users_id_fk",
+          "tableFrom": "viewer_balances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.viewer_links": {
+      "name": "viewer_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_account_id": {
+          "name": "google_account_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_code": {
+          "name": "link_code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "viewer_links_google_account_id_idx": {
+          "name": "viewer_links_google_account_id_idx",
+          "columns": [
+            {
+              "expression": "google_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "viewer_links_code_idx": {
+          "name": "viewer_links_code_idx",
+          "columns": [
+            {
+              "expression": "link_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "viewer_links_google_account_id_google_accounts_id_fk": {
+          "name": "viewer_links_google_account_id_google_accounts_id_fk",
+          "tableFrom": "viewer_links",
+          "tableTo": "google_accounts",
+          "columnsFrom": [
+            "google_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1782019200000,
       "tag": "0020_product_recommendation_moderation",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1782737747335,
+      "tag": "0021_hard_riptide",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/creators/defaults.ts
+++ b/src/lib/creators/defaults.ts
@@ -1,0 +1,53 @@
+import type { CreatorBrandingRecord, CreatorDomainRecord, CreatorModuleRecord, CreatorRecord } from "@/lib/types";
+
+import { creatorModuleCatalog } from "@/lib/creators/modules";
+
+export const DEFAULT_CREATOR_ID = "creator_ludylops";
+export const DEFAULT_CREATOR_SLUG = "ludylops";
+export const DEFAULT_CREATOR_DISPLAY_NAME = "Ludylops";
+export const DEFAULT_CREATOR_DOMAIN = "ludylops.live";
+
+export const DEFAULT_CREATOR: CreatorRecord = {
+  id: DEFAULT_CREATOR_ID,
+  slug: DEFAULT_CREATOR_SLUG,
+  displayName: DEFAULT_CREATOR_DISPLAY_NAME,
+  ownerUserId: null,
+  status: "active",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+export const DEFAULT_CREATOR_BRANDING: CreatorBrandingRecord = {
+  creatorId: DEFAULT_CREATOR_ID,
+  logoUrl: null,
+  avatarUrl: null,
+  primaryColor: "#c7a2e9",
+  secondaryColor: "#ff79c6",
+  backgroundColor: "#f9f9f9",
+  accentColor: "#40a9ff",
+  fontHeading: "app-display",
+  fontBody: "app-body",
+  borderRadius: 0,
+  themeJson: {},
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+export const DEFAULT_CREATOR_DOMAINS: CreatorDomainRecord[] = [
+  {
+    id: "creator_domain_ludylops_live",
+    creatorId: DEFAULT_CREATOR_ID,
+    hostname: DEFAULT_CREATOR_DOMAIN,
+    isPrimary: true,
+    createdAt: "2026-01-01T00:00:00.000Z",
+  },
+];
+
+export const DEFAULT_CREATOR_MODULES: CreatorModuleRecord[] = creatorModuleCatalog.map((module) => ({
+  id: `creator_module_ludylops_${module.key}`,
+  creatorId: DEFAULT_CREATOR_ID,
+  moduleKey: module.key,
+  status: "installed",
+  configJson: module.defaultConfig,
+  installedAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+}));

--- a/src/lib/creators/modules.ts
+++ b/src/lib/creators/modules.ts
@@ -155,8 +155,8 @@ export function getEnabledCreatorModules(modules: CreatorModuleRecord[]) {
 export function getEnabledModuleNav(modules: CreatorModuleRecord[]): CreatorModuleNavItem[] {
   const navItems: CreatorModuleNavItem[] = [];
 
-  for (const module of getEnabledCreatorModules(modules)) {
-    const manifest = getCreatorModuleManifest(module.moduleKey);
+  for (const creatorModule of getEnabledCreatorModules(modules)) {
+    const manifest = getCreatorModuleManifest(creatorModule.moduleKey);
     const href = manifest?.publicRoutes[0];
     if (!manifest || !href) {
       continue;

--- a/src/lib/creators/modules.ts
+++ b/src/lib/creators/modules.ts
@@ -1,0 +1,173 @@
+import type { CreatorModuleRecord } from "@/lib/types";
+
+export type CreatorModuleKey =
+  | "points"
+  | "redemptions"
+  | "bets"
+  | "ranking"
+  | "product_recommendations"
+  | "game_suggestions"
+  | "video_suggestions"
+  | "creator_suggestions"
+  | "quotes"
+  | "obs_overlays"
+  | "streamerbot";
+
+export type CreatorModuleManifest = {
+  key: CreatorModuleKey;
+  label: string;
+  publicRoutes: string[];
+  adminPanels: string[];
+  obsRoutes: string[];
+  requiredCapabilities: CreatorModuleKey[];
+  defaultConfig: Record<string, unknown>;
+};
+
+export type CreatorModuleNavItem = {
+  key: CreatorModuleKey;
+  label: string;
+  href: string;
+};
+
+export const creatorModuleCatalog = [
+  {
+    key: "points",
+    label: "Pipetz",
+    publicRoutes: ["/me"],
+    adminPanels: ["pipetz-pricing", "pipetz-airdrop"],
+    obsRoutes: [],
+    requiredCapabilities: [],
+    defaultConfig: {
+      currencyLabel: "pipetz",
+    },
+  },
+  {
+    key: "ranking",
+    label: "Ranking",
+    publicRoutes: ["/ranking"],
+    adminPanels: [],
+    obsRoutes: [],
+    requiredCapabilities: ["points"],
+    defaultConfig: {},
+  },
+  {
+    key: "redemptions",
+    label: "Resgates",
+    publicRoutes: ["/"],
+    adminPanels: ["catalog"],
+    obsRoutes: [],
+    requiredCapabilities: ["points", "streamerbot"],
+    defaultConfig: {},
+  },
+  {
+    key: "bets",
+    label: "Apostas",
+    publicRoutes: ["/apostas"],
+    adminPanels: ["bets"],
+    obsRoutes: ["/obs/bets"],
+    requiredCapabilities: ["points", "streamerbot"],
+    defaultConfig: {
+      minBet: 10,
+      maxOptions: 6,
+    },
+  },
+  {
+    key: "product_recommendations",
+    label: "Produtinhos",
+    publicRoutes: ["/produtinhos"],
+    adminPanels: ["product-recommendations"],
+    obsRoutes: [],
+    requiredCapabilities: [],
+    defaultConfig: {},
+  },
+  {
+    key: "game_suggestions",
+    label: "Jogos",
+    publicRoutes: ["/jogos"],
+    adminPanels: ["game-suggestions"],
+    obsRoutes: [],
+    requiredCapabilities: ["points"],
+    defaultConfig: {},
+  },
+  {
+    key: "video_suggestions",
+    label: "Vídeos",
+    publicRoutes: ["/videos"],
+    adminPanels: ["video-suggestions"],
+    obsRoutes: [],
+    requiredCapabilities: ["points"],
+    defaultConfig: {},
+  },
+  {
+    key: "creator_suggestions",
+    label: "Inspirações",
+    publicRoutes: ["/indicacoes"],
+    adminPanels: ["creator-suggestions"],
+    obsRoutes: [],
+    requiredCapabilities: ["points"],
+    defaultConfig: {},
+  },
+  {
+    key: "quotes",
+    label: "Quotes",
+    publicRoutes: ["/quotes"],
+    adminPanels: ["quotes"],
+    obsRoutes: ["/obs/quote"],
+    requiredCapabilities: ["points", "streamerbot", "obs_overlays"],
+    defaultConfig: {
+      displayDurationSeconds: 12,
+    },
+  },
+  {
+    key: "obs_overlays",
+    label: "Overlays OBS",
+    publicRoutes: [],
+    adminPanels: ["obs-overlays"],
+    obsRoutes: ["/obs/bets", "/obs/likes", "/obs/quote", "/obs/subscriber-alert"],
+    requiredCapabilities: ["streamerbot"],
+    defaultConfig: {},
+  },
+  {
+    key: "streamerbot",
+    label: "Streamer.bot",
+    publicRoutes: ["/contadores"],
+    adminPanels: ["streamerbot-scripts", "death-counter-game"],
+    obsRoutes: [],
+    requiredCapabilities: [],
+    defaultConfig: {},
+  },
+] as const satisfies readonly CreatorModuleManifest[];
+
+export const defaultCreatorModuleKeys = creatorModuleCatalog.map((module) => module.key);
+
+export function getCreatorModuleManifest(moduleKey: string) {
+  return creatorModuleCatalog.find((module) => module.key === moduleKey) ?? null;
+}
+
+export function isKnownCreatorModuleKey(moduleKey: string): moduleKey is CreatorModuleKey {
+  return getCreatorModuleManifest(moduleKey) !== null;
+}
+
+export function getEnabledCreatorModules(modules: CreatorModuleRecord[]) {
+  return modules.filter((module) => module.status === "installed" && isKnownCreatorModuleKey(module.moduleKey));
+}
+
+export function getEnabledModuleNav(modules: CreatorModuleRecord[]): CreatorModuleNavItem[] {
+  const navItems: CreatorModuleNavItem[] = [];
+
+  for (const module of getEnabledCreatorModules(modules)) {
+    const manifest = getCreatorModuleManifest(module.moduleKey);
+    const href = manifest?.publicRoutes[0];
+    if (!manifest || !href) {
+      continue;
+    }
+
+    navItems.push({
+      key: manifest.key,
+      label: manifest.label,
+      href,
+    });
+  }
+
+  return navItems;
+}

--- a/src/lib/creators/tenant.test.ts
+++ b/src/lib/creators/tenant.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getDbMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/db/client", () => ({
+  getDb: getDbMock,
+}));
+
+import { DEFAULT_CREATOR_ID, DEFAULT_CREATOR_SLUG } from "@/lib/creators/defaults";
+import { getEnabledModuleNav } from "@/lib/creators/modules";
+import { defaultCreatorTenant, resolveCreatorFromRequest } from "@/lib/creators/tenant";
+import { creatorBranding, creatorDomains, creatorModules, creators } from "@/lib/db/schema";
+
+type CreatorRow = typeof creators.$inferSelect;
+type CreatorDomainRow = typeof creatorDomains.$inferSelect;
+type CreatorBrandingRow = typeof creatorBranding.$inferSelect;
+type CreatorModuleRow = typeof creatorModules.$inferSelect;
+
+function getStringValueFromWhereClause(whereClause: unknown) {
+  if (!whereClause || typeof whereClause !== "object" || !("queryChunks" in whereClause)) {
+    return null;
+  }
+
+  const queryChunks = (whereClause as { queryChunks?: unknown[] }).queryChunks;
+  if (!Array.isArray(queryChunks)) {
+    return null;
+  }
+
+  for (const chunk of queryChunks) {
+    if (chunk && typeof chunk === "object" && "value" in chunk) {
+      const value = (chunk as { value?: unknown }).value;
+      if (typeof value === "string") {
+        return value;
+      }
+    }
+  }
+
+  return null;
+}
+
+function createCreatorDb({
+  creatorRows = [],
+  domainRows = [],
+  brandingRows = [],
+  moduleRows = [],
+  error,
+}: {
+  creatorRows?: CreatorRow[];
+  domainRows?: CreatorDomainRow[];
+  brandingRows?: CreatorBrandingRow[];
+  moduleRows?: CreatorModuleRow[];
+  error?: Error;
+}) {
+  function rowsForTable(table: unknown, whereClause?: unknown) {
+    if (error) {
+      throw error;
+    }
+
+    const value = getStringValueFromWhereClause(whereClause);
+
+    if (table === creators) {
+      return value
+        ? creatorRows.filter((row) => row.id === value || row.slug === value)
+        : creatorRows;
+    }
+
+    if (table === creatorDomains) {
+      return value
+        ? domainRows.filter((row) => row.creatorId === value || row.hostname === value)
+        : domainRows;
+    }
+
+    if (table === creatorBranding) {
+      return value ? brandingRows.filter((row) => row.creatorId === value) : brandingRows;
+    }
+
+    if (table === creatorModules) {
+      return value ? moduleRows.filter((row) => row.creatorId === value) : moduleRows;
+    }
+
+    throw new Error("Unexpected table in creator db test stub.");
+  }
+
+  return {
+    select() {
+      return {
+        from(table: unknown) {
+          return {
+            where(whereClause: unknown) {
+              const rows = rowsForTable(table, whereClause);
+              return Object.assign(rows, {
+                limit: async (count: number) => rows.slice(0, count),
+              });
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+function creatorRow(input: Partial<CreatorRow> = {}): CreatorRow {
+  return {
+    id: DEFAULT_CREATOR_ID,
+    slug: DEFAULT_CREATOR_SLUG,
+    displayName: "Ludylops",
+    ownerUserId: null,
+    status: "active",
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    ...input,
+  };
+}
+
+describe("creator tenant resolution", () => {
+  beforeEach(() => {
+    getDbMock.mockReset();
+  });
+
+  it("falls back to the default creator without a database", async () => {
+    getDbMock.mockReturnValue(null);
+
+    const tenant = await resolveCreatorFromRequest();
+
+    expect(tenant.creator.slug).toBe("ludylops");
+    expect(tenant.modules.map((module) => module.moduleKey)).toContain("product_recommendations");
+  });
+
+  it("resolves a creator by custom domain", async () => {
+    getDbMock.mockReturnValue(
+      createCreatorDb({
+        creatorRows: [
+          creatorRow({
+            id: "creator_cozy",
+            slug: "cozygames",
+            displayName: "Cozy Games",
+          }),
+          creatorRow(),
+        ],
+        domainRows: [
+          {
+            id: "domain_cozy",
+            creatorId: "creator_cozy",
+            hostname: "cozy.example.com",
+            isPrimary: true,
+            createdAt: new Date("2026-01-02T00:00:00.000Z"),
+          },
+        ],
+      }),
+    );
+
+    const tenant = await resolveCreatorFromRequest({
+      hostname: "cozy.example.com",
+    });
+
+    expect(tenant.creator).toMatchObject({
+      id: "creator_cozy",
+      slug: "cozygames",
+      displayName: "Cozy Games",
+    });
+  });
+
+  it("resolves a local dev creator by /c/:slug", async () => {
+    getDbMock.mockReturnValue(
+      createCreatorDb({
+        creatorRows: [
+          creatorRow({
+            id: "creator_teste",
+            slug: "teste",
+            displayName: "Criador Teste",
+          }),
+          creatorRow(),
+        ],
+      }),
+    );
+
+    const request = new Request("http://localhost:3000/c/teste/produtinhos");
+    const tenant = await resolveCreatorFromRequest(request);
+
+    expect(tenant.creator).toMatchObject({
+      id: "creator_teste",
+      slug: "teste",
+    });
+  });
+
+  it("keeps the default creator available while the creator schema is missing", async () => {
+    getDbMock.mockReturnValue(
+      createCreatorDb({
+        error: new Error('Failed query: select * from "creators": relation "creators" does not exist'),
+      }),
+    );
+
+    const tenant = await resolveCreatorFromRequest({
+      hostname: "ludylops.live",
+    });
+
+    expect(tenant).toBe(defaultCreatorTenant);
+  });
+
+  it("derives public navigation from installed modules", () => {
+    const nav = getEnabledModuleNav([
+      {
+        id: "creator_module_test_bets",
+        creatorId: "creator_test",
+        moduleKey: "bets",
+        status: "installed",
+        configJson: {},
+        installedAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+      {
+        id: "creator_module_test_quotes",
+        creatorId: "creator_test",
+        moduleKey: "quotes",
+        status: "disabled",
+        configJson: {},
+        installedAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    expect(nav).toEqual([
+      {
+        key: "bets",
+        label: "Apostas",
+        href: "/apostas",
+      },
+    ]);
+  });
+});

--- a/src/lib/creators/tenant.ts
+++ b/src/lib/creators/tenant.ts
@@ -1,0 +1,312 @@
+import { eq } from "drizzle-orm";
+
+import {
+  DEFAULT_CREATOR,
+  DEFAULT_CREATOR_BRANDING,
+  DEFAULT_CREATOR_DOMAIN,
+  DEFAULT_CREATOR_DOMAINS,
+  DEFAULT_CREATOR_ID,
+  DEFAULT_CREATOR_MODULES,
+  DEFAULT_CREATOR_SLUG,
+} from "@/lib/creators/defaults";
+import { getDb } from "@/lib/db/client";
+import { creatorBranding, creatorDomains, creatorModules, creators } from "@/lib/db/schema";
+import type {
+  CreatorBrandingRecord,
+  CreatorDomainRecord,
+  CreatorModuleRecord,
+  CreatorRecord,
+  CreatorTenantRecord,
+} from "@/lib/types";
+
+type CreatorDb = Pick<NonNullable<ReturnType<typeof getDb>>, "select">;
+
+type ResolveCreatorOptions = {
+  request?: Request | null;
+  hostname?: string | null;
+  slug?: string | null;
+  pathname?: string | null;
+};
+
+const LOCAL_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1"]);
+
+export const defaultCreatorTenant: CreatorTenantRecord = {
+  creator: DEFAULT_CREATOR,
+  branding: DEFAULT_CREATOR_BRANDING,
+  domains: DEFAULT_CREATOR_DOMAINS,
+  modules: DEFAULT_CREATOR_MODULES,
+};
+
+function toIsoDate(value: Date | string) {
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function normalizeHostname(value?: string | null) {
+  const hostname = value?.split(",")[0]?.trim().toLowerCase() ?? "";
+  if (!hostname) {
+    return null;
+  }
+
+  const withoutProtocol = hostname.replace(/^https?:\/\//u, "");
+  const withoutPath = withoutProtocol.split("/")[0] ?? "";
+  const withoutPort =
+    withoutPath.startsWith("[") && withoutPath.includes("]")
+      ? withoutPath.slice(1, withoutPath.indexOf("]"))
+      : withoutPath.split(":")[0];
+
+  return withoutPort || null;
+}
+
+function normalizeCreatorSlug(value?: string | null) {
+  const slug = value?.trim().toLowerCase() ?? "";
+  return /^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$/u.test(slug) || /^[a-z0-9]$/u.test(slug)
+    ? slug
+    : null;
+}
+
+function getRequestHostname(request?: Request | null) {
+  if (!request) {
+    return null;
+  }
+
+  const forwardedHost = request.headers.get("x-forwarded-host");
+  const host = forwardedHost ?? request.headers.get("host");
+  if (host) {
+    return normalizeHostname(host);
+  }
+
+  try {
+    return normalizeHostname(new URL(request.url).host);
+  } catch {
+    return null;
+  }
+}
+
+function getRequestPathname(request?: Request | null) {
+  if (!request) {
+    return null;
+  }
+
+  try {
+    return new URL(request.url).pathname;
+  } catch {
+    return null;
+  }
+}
+
+function extractCreatorSlugFromPathname(pathname?: string | null) {
+  const [, prefix, slug] = pathname?.split("/") ?? [];
+  return prefix === "c" ? normalizeCreatorSlug(slug) : null;
+}
+
+function extractCreatorSlugFromSubdomain(hostname?: string | null) {
+  if (!hostname || hostname === DEFAULT_CREATOR_DOMAIN || !hostname.endsWith(`.${DEFAULT_CREATOR_DOMAIN}`)) {
+    return null;
+  }
+
+  const subdomain = hostname.slice(0, -DEFAULT_CREATOR_DOMAIN.length - 1);
+  return subdomain === "www" ? null : normalizeCreatorSlug(subdomain);
+}
+
+function isLocalHostname(hostname?: string | null) {
+  return Boolean(hostname && LOCAL_HOSTNAMES.has(hostname));
+}
+
+function isMissingCreatorSchemaError(error: unknown) {
+  const tableNames = [
+    '"creators"',
+    '"creator_domains"',
+    '"creator_branding"',
+    '"creator_modules"',
+    "creators",
+    "creator_domains",
+    "creator_branding",
+    "creator_modules",
+  ];
+  const queue: unknown[] = [error];
+  const visited = new Set<unknown>();
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current || visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+
+    const message = current instanceof Error ? current.message : typeof current === "string" ? current : "";
+    const normalized = message.toLowerCase();
+    const mentionsTable = tableNames.some((tableName) => normalized.includes(tableName));
+
+    if (
+      mentionsTable &&
+      (normalized.includes("does not exist") ||
+        normalized.includes("relation") ||
+        normalized.includes("table") ||
+        normalized.includes("failed query"))
+    ) {
+      return true;
+    }
+
+    if (typeof current === "object" && current && "cause" in current) {
+      queue.push((current as { cause?: unknown }).cause);
+    }
+  }
+
+  return false;
+}
+
+function serializeCreator(row: typeof creators.$inferSelect): CreatorRecord {
+  return {
+    id: row.id,
+    slug: row.slug,
+    displayName: row.displayName,
+    ownerUserId: row.ownerUserId,
+    status: row.status as CreatorRecord["status"],
+    createdAt: toIsoDate(row.createdAt),
+    updatedAt: toIsoDate(row.updatedAt),
+  };
+}
+
+function serializeCreatorBranding(row: typeof creatorBranding.$inferSelect): CreatorBrandingRecord {
+  return {
+    creatorId: row.creatorId,
+    logoUrl: row.logoUrl,
+    avatarUrl: row.avatarUrl,
+    primaryColor: row.primaryColor,
+    secondaryColor: row.secondaryColor,
+    backgroundColor: row.backgroundColor,
+    accentColor: row.accentColor,
+    fontHeading: row.fontHeading,
+    fontBody: row.fontBody,
+    borderRadius: row.borderRadius,
+    themeJson: row.themeJson as Record<string, unknown>,
+    updatedAt: toIsoDate(row.updatedAt),
+  };
+}
+
+function serializeCreatorDomain(row: typeof creatorDomains.$inferSelect): CreatorDomainRecord {
+  return {
+    id: row.id,
+    creatorId: row.creatorId,
+    hostname: row.hostname,
+    isPrimary: row.isPrimary,
+    createdAt: toIsoDate(row.createdAt),
+  };
+}
+
+function serializeCreatorModule(row: typeof creatorModules.$inferSelect): CreatorModuleRecord {
+  return {
+    id: row.id,
+    creatorId: row.creatorId,
+    moduleKey: row.moduleKey,
+    status: row.status as CreatorModuleRecord["status"],
+    configJson: row.configJson as Record<string, unknown>,
+    installedAt: toIsoDate(row.installedAt),
+    updatedAt: toIsoDate(row.updatedAt),
+  };
+}
+
+function withDefaultTenantParts(input: {
+  creator: CreatorRecord;
+  branding: CreatorBrandingRecord | null;
+  domains: CreatorDomainRecord[];
+  modules: CreatorModuleRecord[];
+}): CreatorTenantRecord {
+  const isDefaultCreator = input.creator.id === DEFAULT_CREATOR_ID;
+
+  return {
+    creator: input.creator,
+    branding:
+      input.branding ??
+      (isDefaultCreator
+        ? DEFAULT_CREATOR_BRANDING
+        : {
+            ...DEFAULT_CREATOR_BRANDING,
+            creatorId: input.creator.id,
+          }),
+    domains: input.domains.length > 0 ? input.domains : isDefaultCreator ? DEFAULT_CREATOR_DOMAINS : [],
+    modules: input.modules.length > 0 ? input.modules : isDefaultCreator ? DEFAULT_CREATOR_MODULES : [],
+  };
+}
+
+async function loadCreatorTenant(db: CreatorDb, creator: CreatorRecord) {
+  const [brandingRows, domainRows, moduleRows] = await Promise.all([
+    db.select().from(creatorBranding).where(eq(creatorBranding.creatorId, creator.id)).limit(1),
+    db.select().from(creatorDomains).where(eq(creatorDomains.creatorId, creator.id)),
+    db.select().from(creatorModules).where(eq(creatorModules.creatorId, creator.id)),
+  ]);
+
+  return withDefaultTenantParts({
+    creator,
+    branding: brandingRows[0] ? serializeCreatorBranding(brandingRows[0]) : null,
+    domains: domainRows.map(serializeCreatorDomain),
+    modules: moduleRows.map(serializeCreatorModule),
+  });
+}
+
+async function findCreatorBySlug(db: CreatorDb, slug: string) {
+  const [row] = await db.select().from(creators).where(eq(creators.slug, slug)).limit(1);
+  return row ? serializeCreator(row) : null;
+}
+
+async function findCreatorByHostname(db: CreatorDb, hostname: string) {
+  const [domainRow] = await db
+    .select()
+    .from(creatorDomains)
+    .where(eq(creatorDomains.hostname, hostname))
+    .limit(1);
+
+  if (!domainRow) {
+    return null;
+  }
+
+  const [creatorRow] = await db
+    .select()
+    .from(creators)
+    .where(eq(creators.id, domainRow.creatorId))
+    .limit(1);
+
+  return creatorRow ? serializeCreator(creatorRow) : null;
+}
+
+export async function resolveCreatorFromRequest(
+  input?: Request | ResolveCreatorOptions | null,
+): Promise<CreatorTenantRecord> {
+  const options: ResolveCreatorOptions =
+    input instanceof Request
+      ? { request: input }
+      : input && typeof input === "object"
+        ? input
+        : {};
+  const request = options.request ?? null;
+  const hostname = normalizeHostname(options.hostname) ?? getRequestHostname(request);
+  const explicitSlug =
+    normalizeCreatorSlug(options.slug) ??
+    normalizeCreatorSlug(request?.headers.get("x-creator-slug")) ??
+    extractCreatorSlugFromPathname(options.pathname ?? getRequestPathname(request));
+  const subdomainSlug = extractCreatorSlugFromSubdomain(hostname);
+  const db = getDb();
+
+  if (!db) {
+    return defaultCreatorTenant;
+  }
+
+  try {
+    const slugForResolution = explicitSlug && (options.slug || isLocalHostname(hostname)) ? explicitSlug : subdomainSlug;
+    const creator =
+      (hostname && !slugForResolution ? await findCreatorByHostname(db, hostname) : null) ??
+      (slugForResolution ? await findCreatorBySlug(db, slugForResolution) : null) ??
+      (await findCreatorBySlug(db, DEFAULT_CREATOR_SLUG));
+
+    return creator ? loadCreatorTenant(db, creator) : defaultCreatorTenant;
+  } catch (error) {
+    if (isMissingCreatorSchemaError(error)) {
+      return defaultCreatorTenant;
+    }
+    throw error;
+  }
+}
+
+export async function requireCreator(input?: Request | ResolveCreatorOptions | null) {
+  return resolveCreatorFromRequest(input);
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -29,6 +29,79 @@ export const users = pgTable(
   }),
 );
 
+export const creators = pgTable(
+  "creators",
+  {
+    id: varchar("id", { length: 64 }).primaryKey(),
+    slug: varchar("slug", { length: 64 }).notNull(),
+    displayName: varchar("display_name", { length: 255 }).notNull(),
+    ownerUserId: varchar("owner_user_id", { length: 64 }).references(() => users.id),
+    status: varchar("status", { length: 32 }).default("active").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => ({
+    slugIdx: uniqueIndex("creators_slug_idx").on(table.slug),
+    ownerUserIdIdx: index("creators_owner_user_id_idx").on(table.ownerUserId),
+  }),
+);
+
+export const creatorDomains = pgTable(
+  "creator_domains",
+  {
+    id: varchar("id", { length: 64 }).primaryKey(),
+    creatorId: varchar("creator_id", { length: 64 })
+      .references(() => creators.id)
+      .notNull(),
+    hostname: varchar("hostname", { length: 255 }).notNull(),
+    isPrimary: boolean("is_primary").default(false).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => ({
+    hostnameIdx: uniqueIndex("creator_domains_hostname_idx").on(table.hostname),
+    creatorIdIdx: index("creator_domains_creator_id_idx").on(table.creatorId),
+  }),
+);
+
+export const creatorBranding = pgTable("creator_branding", {
+  creatorId: varchar("creator_id", { length: 64 })
+    .primaryKey()
+    .references(() => creators.id),
+  logoUrl: text("logo_url"),
+  avatarUrl: text("avatar_url"),
+  primaryColor: varchar("primary_color", { length: 16 }).default("#c7a2e9").notNull(),
+  secondaryColor: varchar("secondary_color", { length: 16 }).default("#ff79c6").notNull(),
+  backgroundColor: varchar("background_color", { length: 16 }).default("#f9f9f9").notNull(),
+  accentColor: varchar("accent_color", { length: 16 }).default("#40a9ff").notNull(),
+  fontHeading: varchar("font_heading", { length: 120 }).default("app-display").notNull(),
+  fontBody: varchar("font_body", { length: 120 }).default("app-body").notNull(),
+  borderRadius: integer("border_radius").default(0).notNull(),
+  themeJson: jsonb("theme_json").default({}).notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+export const creatorModules = pgTable(
+  "creator_modules",
+  {
+    id: varchar("id", { length: 64 }).primaryKey(),
+    creatorId: varchar("creator_id", { length: 64 })
+      .references(() => creators.id)
+      .notNull(),
+    moduleKey: varchar("module_key", { length: 64 }).notNull(),
+    status: varchar("status", { length: 32 }).default("installed").notNull(),
+    configJson: jsonb("config_json").default({}).notNull(),
+    installedAt: timestamp("installed_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => ({
+    creatorModuleIdx: uniqueIndex("creator_modules_creator_module_idx").on(
+      table.creatorId,
+      table.moduleKey,
+    ),
+    creatorIdIdx: index("creator_modules_creator_id_idx").on(table.creatorId),
+  }),
+);
+
 export const googleAccounts = pgTable(
   "google_accounts",
   {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -81,6 +81,66 @@ export type ProductRecommendationModerationStatus =
   | "approved"
   | "rejected";
 
+export type CreatorStatus =
+  | "active"
+  | "disabled"
+  | "archived";
+
+export type CreatorModuleStatus =
+  | "installed"
+  | "disabled"
+  | "archived";
+
+export interface CreatorRecord {
+  id: string;
+  slug: string;
+  displayName: string;
+  ownerUserId: string | null;
+  status: CreatorStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreatorDomainRecord {
+  id: string;
+  creatorId: string;
+  hostname: string;
+  isPrimary: boolean;
+  createdAt: string;
+}
+
+export interface CreatorBrandingRecord {
+  creatorId: string;
+  logoUrl: string | null;
+  avatarUrl: string | null;
+  primaryColor: string;
+  secondaryColor: string;
+  backgroundColor: string;
+  accentColor: string;
+  fontHeading: string;
+  fontBody: string;
+  borderRadius: number;
+  themeJson: Record<string, unknown>;
+  updatedAt: string;
+}
+
+export interface CreatorModuleRecord {
+  id: string;
+  creatorId: string;
+  moduleKey: string;
+  status: CreatorModuleStatus;
+  configJson: Record<string, unknown>;
+  installedAt: string;
+  updatedAt: string;
+}
+
+export interface CreatorTenantRecord {
+  creator: CreatorRecord;
+  branding: CreatorBrandingRecord;
+  modules: CreatorModuleRecord[];
+  domains: CreatorDomainRecord[];
+}
+
 export interface ViewerRecord {
   id: string;
   googleUserId: string | null;


### PR DESCRIPTION
## What changed
- Added the initial multi-tenant creator schema: `creators`, `creator_domains`, `creator_branding`, and `creator_modules`.
- Seeded the default `ludylops` creator, primary domain, branding defaults, and installed module records.
- Added a first internal module catalog with route/admin/OBS metadata and default config per module.
- Added `resolveCreatorFromRequest()` / `requireCreator()` with domain, local `/c/:slug`, subdomain, and default fallback resolution.
- Added tests for fallback behavior, custom-domain resolution, local slug resolution, missing-schema fallback, and module-derived nav.

## Scope
This is the foundation slice for the white-label platform work. It does not migrate existing feature data to `creatorId` yet, so it should not close the issue.

Refs #154

## Validation
- `npm test -- --run src/lib/creators/tenant.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run build`