### PR TITLE
[codex] add selectable OBS overlay styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Mais detalhes ficam em `bridge/README.md`.
 - `/obs/quotes`: browser source para quotes no OBS.
 - `/obs/bets`: browser source para apostas abertas no OBS.
 - `/obs/subscribers`: browser source para alertas de novas inscrições no canal.
+- O estilo ativo dos overlays é escolhido no admin, sem trocar a URL usada no OBS. `?style=obscur` continua disponível como override manual para teste.
 
 ## Setup local
 

--- a/docs/streamerbot-live-rewards.md
+++ b/docs/streamerbot-live-rewards.md
@@ -21,6 +21,7 @@ Esta integração usa `POST /api/internal/streamerbot/events` com HMAC, como os 
 
 - Abra `/obs/subscribers` como Browser Source no OBS ou em ferramenta equivalente.
 - Use `/obs/subscribers?demo=1` para testar o visual e o som sem depender de eventos reais.
+- O estilo usado pelo OBS é escolhido no admin, sem alterar essa URL. Para testar manualmente o visual minimalista, use `/obs/subscribers?demo=1&style=obscur`.
 - O overlay consulta `GET /api/obs/subscribers/current` a cada segundo e enfileira localmente os eventos novos recebidos nos últimos 2 minutos.
 - Cada alerta toca o som uma vez, fica visível por 7 segundos por padrão e sai automaticamente. Eventos consecutivos são exibidos em sequência.
 - Parâmetros opcionais do Browser Source:
@@ -30,6 +31,7 @@ Esta integração usa `POST /api/internal/streamerbot/events` com HMAC, como os 
   - `title`: texto do selo principal. Padrão: `Nova inscrição`.
   - `subtitle`: texto abaixo do nome. Padrão: `chegou no canal`.
   - `volume`: volume do `soundUrl`, de `0` a `1`.
+  - `style`: override manual opcional; use `obscur`, `minimal` ou `minimalista` para o visual mais leve.
 
 ## Metas de likes
 
@@ -43,12 +45,14 @@ Esta integração usa `POST /api/internal/streamerbot/events` com HMAC, como os 
   - `occurredAt`: data em ISO
 - Critério de presença: viewers com ledger `presence_tick` na mesma `broadcastId` do evento de likes, desde o início da live até o momento em que a meta bateu.
 - Overlay do OBS: use `/obs/likes` como browser source. Para testar o visual sem live, use `/obs/likes?demo=1`.
+- O estilo ativo é escolhido no admin. Para demo manual do visual minimalista, use `/obs/likes?demo=1&style=obscur`.
 - Feed do overlay: `/api/obs/likes/current`, atualizado pelo último `like_count_update` recebido.
 
 ### Overlay da meta de likes
 
 - Abra `/obs/likes` como Browser Source no OBS ou em ferramenta equivalente.
 - Use `/obs/likes?demo=1` para testar o visual sem depender de eventos reais.
+- Escolha o estilo minimalista no admin para ocupar menos tela sem alterar a URL do OBS.
 - O overlay lê a meta ativa cadastrada no admin e o último `like_count_update` aceito pela API.
 - Para atualizar o progresso ao vivo, mantenha o script `streamerbot/like-count-update.cs` em uma action ligada ao trigger `YouTube > Broadcast > Statistics Updated`.
 

--- a/docs/twitch-wheel.md
+++ b/docs/twitch-wheel.md
@@ -5,6 +5,7 @@
 - Admin: `/admin`, aba `Operação`, painel `Roleta da live`.
 - Overlay para OBS: `/obs/wheel`.
 - Demo visual do overlay: `/obs/wheel?demo=1`.
+- O estilo ativo é escolhido no admin. Demo manual do visual minimalista: `/obs/wheel?demo=1&style=obscur`.
 - Feed JSON do overlay: `GET /api/obs/wheel/current`.
 - Giro assinado pelo Streamer.bot: `POST /api/internal/streamerbot/wheel`.
 
@@ -22,6 +23,7 @@ O app salva a configuração em `streamerbot_counters`, na chave `twitch_wheel_c
 ## OBS
 
 Adicione um `Browser Source` apontando para `/obs/wheel`.
+Para ocupar menos tela, escolha o estilo minimalista no admin sem trocar a URL no OBS.
 
 Sugestão de cena:
 

--- a/src/app/api/admin/obs-overlays/route.ts
+++ b/src/app/api/admin/obs-overlays/route.ts
@@ -6,9 +6,11 @@ import {
   getObsOverlayAdminStatus,
   setObsOverlayPaused,
 } from "@/lib/db/repository";
+import { updateObsOverlayStyleConfig } from "@/lib/obs-overlay-settings";
 
 const obsOverlayActionSchema = z.object({
-  action: z.enum(["pause", "resume", "cancel_queue"]),
+  action: z.enum(["pause", "resume", "cancel_queue", "set_style"]),
+  style: z.enum(["classic", "obscur"]).optional(),
 });
 
 export async function GET() {
@@ -37,6 +39,15 @@ export async function POST(request: Request) {
     }
 
     const updatedBy = session.user?.email?.toLowerCase() ?? null;
+    if (parsed.data.action === "set_style") {
+      if (!parsed.data.style) {
+        return fail("Escolha um estilo de overlay.", 400);
+      }
+
+      await updateObsOverlayStyleConfig({ style: parsed.data.style, updatedBy });
+      return ok(await getObsOverlayAdminStatus());
+    }
+
     const status =
       parsed.data.action === "pause"
         ? await setObsOverlayPaused({ paused: true, updatedBy })

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -977,6 +977,42 @@ a:focus-visible {
   transform-origin: bottom center;
 }
 
+@keyframes obscurOverlayPop {
+  0% {
+    opacity: 0;
+    filter: blur(4px);
+    transform: translateY(22px);
+  }
+
+  14% {
+    opacity: 1;
+    filter: blur(0);
+    transform: translateY(0);
+  }
+
+  84% {
+    opacity: 1;
+    filter: blur(0);
+    transform: translateY(0);
+  }
+
+  100% {
+    opacity: 0;
+    filter: blur(2px);
+    transform: translateY(-10px);
+  }
+}
+
+.obscur-overlay-pop {
+  animation: obscurOverlayPop 12s cubic-bezier(0.22, 1, 0.36, 1) both;
+  transform-origin: bottom left;
+}
+
+.obscur-subscriber-pop {
+  animation: obscurOverlayPop 7s cubic-bezier(0.22, 1, 0.36, 1) both;
+  transform-origin: bottom left;
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/src/app/obs/bets/page.tsx
+++ b/src/app/obs/bets/page.tsx
@@ -1,5 +1,10 @@
 import { ObsBetOverlay } from "@/components/obs-bet-overlay";
+import { resolveObsOverlayInitialStyle } from "@/lib/obs-overlay-settings";
 
-export default function ObsBetsPage() {
-  return <ObsBetOverlay />;
+export default async function ObsBetsPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  return <ObsBetOverlay initialStyle={await resolveObsOverlayInitialStyle(searchParams)} />;
 }

--- a/src/app/obs/likes/page.tsx
+++ b/src/app/obs/likes/page.tsx
@@ -1,5 +1,10 @@
 import { ObsLikeGoalOverlay } from "@/components/obs-like-goal-overlay";
+import { resolveObsOverlayInitialStyle } from "@/lib/obs-overlay-settings";
 
-export default function ObsLikesPage() {
-  return <ObsLikeGoalOverlay />;
+export default async function ObsLikesPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  return <ObsLikeGoalOverlay initialStyle={await resolveObsOverlayInitialStyle(searchParams)} />;
 }

--- a/src/app/obs/quotes/page.tsx
+++ b/src/app/obs/quotes/page.tsx
@@ -1,5 +1,10 @@
 import { ObsQuoteOverlay } from "@/components/obs-quote-overlay";
+import { resolveObsOverlayInitialStyle } from "@/lib/obs-overlay-settings";
 
-export default function ObsQuotesPage() {
-  return <ObsQuoteOverlay />;
+export default async function ObsQuotesPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  return <ObsQuoteOverlay initialStyle={await resolveObsOverlayInitialStyle(searchParams)} />;
 }

--- a/src/app/obs/subscribers/page.tsx
+++ b/src/app/obs/subscribers/page.tsx
@@ -1,11 +1,18 @@
 import { Suspense } from "react";
 
 import { ObsSubscriberOverlay } from "@/components/obs-subscriber-overlay";
+import { resolveObsOverlayInitialStyle } from "@/lib/obs-overlay-settings";
 
-export default function ObsSubscribersPage() {
+export default async function ObsSubscribersPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const initialStyle = await resolveObsOverlayInitialStyle(searchParams);
+
   return (
     <Suspense fallback={null}>
-      <ObsSubscriberOverlay />
+      <ObsSubscriberOverlay initialStyle={initialStyle} />
     </Suspense>
   );
 }

--- a/src/app/obs/wheel/page.tsx
+++ b/src/app/obs/wheel/page.tsx
@@ -1,5 +1,10 @@
 import { ObsWheelOverlay } from "@/components/obs-wheel-overlay";
+import { resolveObsOverlayInitialStyle } from "@/lib/obs-overlay-settings";
 
-export default function ObsWheelPage() {
-  return <ObsWheelOverlay />;
+export default async function ObsWheelPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  return <ObsWheelOverlay initialStyle={await resolveObsOverlayInitialStyle(searchParams)} />;
 }

--- a/src/components/admin-obs-overlays-panel.tsx
+++ b/src/components/admin-obs-overlays-panel.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/card";
 import type { ObsOverlayAdminStatusRecord } from "@/lib/types";
 import { formatDateTime, formatPipetz } from "@/lib/utils";
+import type { ObsOverlayStyle } from "@/lib/obs-overlay-style";
 
 const overlays = [
   {
@@ -23,6 +24,8 @@ const overlays = [
     description: "Overlay das quotes pagas em pipetz, com som embutido e visual pronto para browser source.",
     liveHref: "/obs/quotes",
     demoHref: "/obs/quotes?demo=1",
+    minimalHref: "/obs/quotes?style=obscur",
+    minimalDemoHref: "/obs/quotes?demo=1&style=obscur",
     apiHref: "/api/obs/quotes/current",
   },
   {
@@ -31,6 +34,8 @@ const overlays = [
     description: "Overlay da meta ativa de likes, com contador, progresso e recompensa exibidos ao vivo.",
     liveHref: "/obs/likes",
     demoHref: "/obs/likes?demo=1",
+    minimalHref: "/obs/likes?style=obscur",
+    minimalDemoHref: "/obs/likes?demo=1&style=obscur",
     apiHref: "/api/obs/likes/current",
   },
   {
@@ -39,6 +44,8 @@ const overlays = [
     description: "Overlay de nova inscrição, com imagem configurável, som de alerta e fila local para eventos consecutivos.",
     liveHref: "/obs/subscribers",
     demoHref: "/obs/subscribers?demo=1",
+    minimalHref: "/obs/subscribers?style=obscur",
+    minimalDemoHref: "/obs/subscribers?demo=1&style=obscur",
     apiHref: "/api/obs/subscribers/current",
   },
   {
@@ -47,6 +54,8 @@ const overlays = [
     description: "Overlay da aposta aberta, com pool, opções e distribuição dos votos atualizados automaticamente.",
     liveHref: "/obs/bets",
     demoHref: "/obs/bets?demo=1",
+    minimalHref: "/obs/bets?style=obscur",
+    minimalDemoHref: "/obs/bets?demo=1&style=obscur",
     apiHref: "/api/obs/bets/current",
   },
   {
@@ -55,6 +64,8 @@ const overlays = [
     description: "Overlay da roleta da live, com animação visual e resultado final mantido na tela.",
     liveHref: "/obs/wheel",
     demoHref: "/obs/wheel?demo=1",
+    minimalHref: "/obs/wheel?style=obscur",
+    minimalDemoHref: "/obs/wheel?demo=1&style=obscur",
     apiHref: "/api/obs/wheel/current",
   },
 ];
@@ -73,7 +84,7 @@ export function AdminObsOverlaysPanel({
   const isPaused = status.control.status === "paused";
   const hasConfigurationError = status.control.status === "error";
 
-  function submitAction(action: "pause" | "resume" | "cancel_queue") {
+  function submitAction(action: "pause" | "resume" | "cancel_queue" | "set_style", style?: ObsOverlayStyle) {
     setFeedback(null);
     startTransition(async () => {
       try {
@@ -82,7 +93,7 @@ export function AdminObsOverlaysPanel({
           headers: {
             "content-type": "application/json",
           },
-          body: JSON.stringify({ action }),
+          body: JSON.stringify({ action, style }),
         });
         const payload = (await response.json()) as {
           ok?: boolean;
@@ -97,7 +108,9 @@ export function AdminObsOverlaysPanel({
 
         setStatus(payload.data);
         setFeedback(
-          action === "pause"
+          action === "set_style"
+            ? "Estilo dos overlays atualizado."
+            : action === "pause"
             ? "Chamadas ao OBS pausadas."
             : action === "resume"
               ? "Chamadas ao OBS retomadas."
@@ -110,6 +123,10 @@ export function AdminObsOverlaysPanel({
     });
   }
 
+  function submitStyle(style: ObsOverlayStyle) {
+    submitAction("set_style", style);
+  }
+
   const content = (
     <div className="panel surface-section p-6">
           <h2
@@ -119,11 +136,11 @@ export function AdminObsOverlaysPanel({
             Seus browser sources
           </h2>
           <p className="mt-3 max-w-3xl text-sm leading-7 text-[var(--color-ink-soft)] sm:text-base">
-            Aqui ficam os overlays hospedados pelo app. Use o link real no OBS e o link de demo
-            quando quiser conferir o visual fora da live.
+            Aqui ficam os overlays hospedados pelo app. O OBS pode continuar usando os links sem
+            parâmetros; o estilo ativo é aplicado pelo app.
           </p>
 
-          <div className="mt-6 grid gap-4 lg:grid-cols-[0.85fr_1.15fr]">
+          <div className="mt-6 grid gap-4 xl:grid-cols-[0.8fr_1fr_1fr]">
             <div className="card-brutal-static surface-card-accent p-4">
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
@@ -186,6 +203,42 @@ export function AdminObsOverlaysPanel({
                 <p>Atualizado em {formatDateTime(status.control.updatedAt)}</p>
                 {status.control.updatedBy ? <p>Por {status.control.updatedBy}</p> : null}
                 {feedback ? <p className="font-bold text-[var(--color-ink)]">{feedback}</p> : null}
+              </div>
+            </div>
+
+            <div className="card-brutal-static surface-card p-4">
+              <p className="mono text-[10px] uppercase tracking-[0.24em] text-[var(--color-ink-soft)]">
+                estilo ativo
+              </p>
+              <p className="mt-2 text-2xl font-black uppercase">
+                {status.overlayStyle.style === "obscur" ? "Minimalista" : "Clássico"}
+              </p>
+              <p className="mt-3 text-sm leading-6 text-[var(--color-ink-soft)]">
+                Altera todos os Browser Sources `/obs/*` sem precisar trocar URL no OBS.
+              </p>
+              <div className="mt-4 flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  onClick={() => submitStyle("classic")}
+                  disabled={isPending || status.overlayStyle.style === "classic"}
+                  variant="neutral"
+                  size="sm"
+                >
+                  Usar clássico
+                </Button>
+                <Button
+                  type="button"
+                  onClick={() => submitStyle("obscur")}
+                  disabled={isPending || status.overlayStyle.style === "obscur"}
+                  variant="success"
+                  size="sm"
+                >
+                  Usar minimalista
+                </Button>
+              </div>
+              <div className="mt-4 grid gap-2 text-sm text-[var(--color-ink-soft)]">
+                <p>Atualizado em {formatDateTime(status.overlayStyle.updatedAt)}</p>
+                {status.overlayStyle.updatedBy ? <p>Por {status.overlayStyle.updatedBy}</p> : null}
               </div>
             </div>
 
@@ -277,6 +330,9 @@ export function AdminObsOverlaysPanel({
                   </Link>
                   <Link href={overlay.demoHref} className="btn-brutal accent-button px-4 py-2 text-xs">
                     Abrir demo
+                  </Link>
+                  <Link href={overlay.minimalDemoHref} className="btn-brutal bg-[var(--color-paper)] px-4 py-2 text-xs">
+                    Abrir demo minimalista
                   </Link>
                 </CardFooter>
               </Card>

--- a/src/components/obs-bet-overlay.tsx
+++ b/src/components/obs-bet-overlay.tsx
@@ -3,6 +3,7 @@
 import { useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 
+import { getObsOverlayStyle, type ObsOverlayStyle } from "@/lib/obs-overlay-style";
 import type { BetWithOptionsRecord } from "@/lib/types";
 import { formatPipetz } from "@/lib/utils";
 
@@ -34,9 +35,10 @@ function formatRemaining(closesAt: string, now: number) {
   return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
 }
 
-export function ObsBetOverlay() {
+export function ObsBetOverlay({ initialStyle = "classic" }: { initialStyle?: ObsOverlayStyle }) {
   const searchParams = useSearchParams();
   const isDemo = searchParams.get("demo") === "1";
+  const isObscurStyle = (getObsOverlayStyle(searchParams) ?? initialStyle) === "obscur";
   const [liveBet, setLiveBet] = useState<BetWithOptionsRecord | null>(null);
   const [now, setNow] = useState(() => Date.now());
 
@@ -91,6 +93,57 @@ export function ObsBetOverlay() {
   const bet = isDemo ? DEMO_BET : liveBet;
   const totalPool = bet?.totalPool ?? 0;
   const remaining = bet ? formatRemaining(bet.closesAt, now) : "00:00";
+
+  if (isObscurStyle) {
+    return (
+      <div className="pointer-events-none flex min-h-screen items-end justify-start p-5 text-[#f8ecd4] sm:p-8 lg:p-10">
+        {bet ? (
+          <section
+            key={bet.id}
+            className="relative w-[min(680px,92vw)] overflow-hidden border-l border-[#d8b46a]/80 bg-[linear-gradient(90deg,rgba(7,7,10,0.74),rgba(7,7,10,0.40)_72%,rgba(7,7,10,0.02))] px-5 py-4 shadow-[0_18px_48px_rgba(0,0,0,0.42)] backdrop-blur-[2px]"
+            aria-live="polite"
+          >
+            <div className="absolute inset-y-3 left-2 w-px bg-[#f3d58b]/60" />
+            <div className="relative flex flex-wrap items-center gap-x-4 gap-y-1 text-sm font-semibold text-[#d8b46a] [text-shadow:0_2px_14px_rgba(0,0,0,0.9)]">
+              <span>fecha em {remaining}</span>
+              <span>{formatPipetz(totalPool)} pipetz</span>
+            </div>
+
+            <h1
+              className="relative mt-2 max-w-[24ch] break-words text-[1.45rem] font-semibold leading-tight [text-shadow:0_2px_18px_rgba(0,0,0,0.88)] sm:text-[2rem] lg:text-[2.35rem]"
+              style={{ fontFamily: "var(--font-body)" }}
+            >
+              {bet.question}
+            </h1>
+
+            <div className="relative mt-4 grid gap-3">
+              {bet.options.map((option, index) => {
+                const percentage = totalPool > 0 ? Math.round((option.poolAmount / totalPool) * 100) : 0;
+                return (
+                  <div key={option.id}>
+                    <div className="flex items-center justify-between gap-3 text-sm font-semibold [text-shadow:0_2px_14px_rgba(0,0,0,0.9)] sm:text-base">
+                      <span className="min-w-0 break-words">
+                        {index + 1}. {option.label}
+                      </span>
+                      <span className="shrink-0 text-[#d8b46a]">
+                        {percentage}% - {formatPipetz(option.poolAmount)}
+                      </span>
+                    </div>
+                    <div className="mt-1 h-[3px] overflow-hidden bg-[#f8ecd4]/18">
+                      <div
+                        className="h-full bg-[#d8b46a] transition-[width] duration-500"
+                        style={{ width: `${Math.max(percentage, totalPool > 0 ? 4 : 0)}%` }}
+                      />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        ) : null}
+      </div>
+    );
+  }
 
   return (
     <div className="pointer-events-none flex min-h-screen items-end justify-center p-6 sm:p-10 lg:p-14">

--- a/src/components/obs-like-goal-overlay.tsx
+++ b/src/components/obs-like-goal-overlay.tsx
@@ -3,6 +3,7 @@
 import { useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 
+import { getObsOverlayStyle, type ObsOverlayStyle } from "@/lib/obs-overlay-style";
 import type { LiveLikeGoalOverlayStateRecord } from "@/lib/types";
 import { formatPipetz } from "@/lib/utils";
 
@@ -30,9 +31,10 @@ function formatNumber(value: number) {
   return new Intl.NumberFormat("pt-BR").format(value);
 }
 
-export function ObsLikeGoalOverlay() {
+export function ObsLikeGoalOverlay({ initialStyle = "classic" }: { initialStyle?: ObsOverlayStyle }) {
   const searchParams = useSearchParams();
   const isDemo = searchParams.get("demo") === "1";
+  const isObscurStyle = (getObsOverlayStyle(searchParams) ?? initialStyle) === "obscur";
   const [liveState, setLiveState] = useState<LiveLikeGoalOverlayStateRecord | null>(null);
 
   useEffect(() => {
@@ -82,6 +84,48 @@ export function ObsLikeGoalOverlay() {
   const goal = state?.goal ?? null;
   const currentLikeCount = state?.currentLikeCount ?? 0;
   const progressPercent = state?.progressPercent ?? 0;
+
+  if (isObscurStyle) {
+    return (
+      <div className="pointer-events-none flex min-h-screen items-end justify-end p-5 text-[#f8ecd4] sm:p-8 lg:p-10">
+        <section
+          className="relative w-[min(560px,92vw)] overflow-hidden border-l border-[#d8b46a]/80 bg-[linear-gradient(90deg,rgba(7,7,10,0.72),rgba(7,7,10,0.38)_72%,rgba(7,7,10,0.02))] px-5 py-4 shadow-[0_18px_48px_rgba(0,0,0,0.42)] backdrop-blur-[2px]"
+          aria-live="polite"
+        >
+          <div className="absolute inset-y-3 left-2 w-px bg-[#f3d58b]/60" />
+          {!state ? (
+            <p className="relative text-xl font-semibold [text-shadow:0_2px_16px_rgba(0,0,0,0.86)]">
+              Carregando meta de likes.
+            </p>
+          ) : goal ? (
+            <div className="relative">
+              <div className="flex items-end justify-between gap-4">
+                <p className="min-w-0 max-w-[18ch] break-words text-xl font-semibold leading-tight [text-shadow:0_2px_16px_rgba(0,0,0,0.86)] sm:text-2xl">
+                  {goal.label || `${formatNumber(goal.targetLikeCount)} likes`}
+                </p>
+                <p className="shrink-0 text-2xl font-semibold text-[#d8b46a] [text-shadow:0_2px_16px_rgba(0,0,0,0.9)] sm:text-3xl">
+                  {formatNumber(currentLikeCount)}/{formatNumber(goal.targetLikeCount)}
+                </p>
+              </div>
+              <div className="mt-3 h-[3px] overflow-hidden bg-[#f8ecd4]/20">
+                <div
+                  className="h-full bg-[#d8b46a] transition-[width] duration-500"
+                  style={{ width: `${progressPercent}%` }}
+                />
+              </div>
+              <p className="mt-2 text-sm font-semibold text-[#cdbb91] [text-shadow:0_2px_14px_rgba(0,0,0,0.9)]">
+                {formatPipetz(goal.rewardAmount)} pipetz pra cada presente
+              </p>
+            </div>
+          ) : (
+            <p className="relative text-xl font-semibold [text-shadow:0_2px_16px_rgba(0,0,0,0.86)]">
+              Configure uma meta ativa no admin.
+            </p>
+          )}
+        </section>
+      </div>
+    );
+  }
 
   return (
     <div className="pointer-events-none flex min-h-screen items-end justify-center p-6 sm:justify-end sm:p-10 lg:p-14">

--- a/src/components/obs-quote-overlay.tsx
+++ b/src/components/obs-quote-overlay.tsx
@@ -3,6 +3,8 @@
 import { useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 
+import { getObsOverlayStyle, type ObsOverlayStyle } from "@/lib/obs-overlay-style";
+
 type QuoteOverlayPayload = {
   slot: string;
   overlayId: string;
@@ -86,9 +88,10 @@ async function playQuoteOverlayChime() {
   });
 }
 
-export function ObsQuoteOverlay() {
+export function ObsQuoteOverlay({ initialStyle = "classic" }: { initialStyle?: ObsOverlayStyle }) {
   const searchParams = useSearchParams();
   const isDemo = searchParams.get("demo") === "1";
+  const isObscurStyle = (getObsOverlayStyle(searchParams) ?? initialStyle) === "obscur";
   const [liveOverlay, setLiveOverlay] = useState<QuoteOverlayPayload | null>(null);
   const [isLive, setIsLive] = useState(false);
   const lastPlayedOverlayId = useRef<string | null>(null);
@@ -231,6 +234,33 @@ export function ObsQuoteOverlay() {
       // Autoplay can be blocked in regular browsers; OBS browser source is the main target.
     });
   }, [overlay?.overlayId]);
+
+  if (isObscurStyle) {
+    return (
+      <div className="pointer-events-none flex min-h-screen items-end justify-start p-5 text-[#f8ecd4] sm:p-8 lg:p-10">
+        {overlay ? (
+          <section
+            key={overlay.overlayId}
+            className={`${isDemo ? "" : "obscur-overlay-pop "}relative w-fit max-w-[min(760px,92vw)] overflow-hidden border-l border-[#d8b46a]/80 bg-[linear-gradient(90deg,rgba(7,7,10,0.78),rgba(7,7,10,0.42)_68%,rgba(7,7,10,0.02))] px-5 py-4 shadow-[0_18px_48px_rgba(0,0,0,0.45)] backdrop-blur-[2px] sm:px-6 sm:py-5`}
+            aria-live="polite"
+          >
+            <div className="absolute inset-y-3 left-2 w-px bg-[#f3d58b]/60" />
+            <blockquote
+              className="relative max-w-[24ch] break-words text-[1.45rem] font-semibold leading-tight [text-shadow:0_2px_18px_rgba(0,0,0,0.88)] sm:text-[2.05rem] lg:text-[2.55rem]"
+              style={{ fontFamily: "var(--font-body)" }}
+            >
+              {overlay.quoteBody}
+            </blockquote>
+            <div className="relative mt-3 flex max-w-full flex-wrap items-center gap-x-3 gap-y-1 text-sm font-semibold text-[#d8b46a] [text-shadow:0_2px_14px_rgba(0,0,0,0.9)]">
+              <span>Quote #{overlay.quoteNumber}</span>
+              <span>{overlay.createdByDisplayName}</span>
+              {overlay.requestedByYoutubeHandle ? <span>{overlay.requestedByYoutubeHandle}</span> : null}
+            </div>
+          </section>
+        ) : null}
+      </div>
+    );
+  }
 
   return (
     <div className="pointer-events-none flex min-h-screen items-end justify-center p-6 sm:p-10 lg:p-14">

--- a/src/components/obs-subscriber-overlay.tsx
+++ b/src/components/obs-subscriber-overlay.tsx
@@ -3,6 +3,7 @@
 import { useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 
+import { getObsOverlayStyle, type ObsOverlayStyle } from "@/lib/obs-overlay-style";
 import type { SubscriberAlertRecord } from "@/lib/types";
 
 const DEFAULT_DURATION_MS = 7000;
@@ -99,9 +100,10 @@ async function playAlertSound(soundUrl: string | null, volume: number) {
   await playSubscriberChime();
 }
 
-export function ObsSubscriberOverlay() {
+export function ObsSubscriberOverlay({ initialStyle = "classic" }: { initialStyle?: ObsOverlayStyle }) {
   const searchParams = useSearchParams();
   const isDemo = searchParams.get("demo") === "1";
+  const isObscurStyle = (getObsOverlayStyle(searchParams) ?? initialStyle) === "obscur";
   const durationMs = clampDuration(readParam(searchParams, ["durationMs", "duration"]));
   const imageUrl = readParam(searchParams, ["imageUrl", "image"]);
   const soundUrl = readParam(searchParams, ["soundUrl", "sound"]);
@@ -199,6 +201,47 @@ export function ObsSubscriberOverlay() {
 
     return () => window.clearTimeout(timeout);
   }, [currentAlert, durationMs, soundUrl, volume]);
+
+  if (isObscurStyle) {
+    return (
+      <div className="pointer-events-none flex min-h-screen items-end justify-start p-5 text-[#f8ecd4] sm:p-8 lg:p-10">
+        {currentAlert ? (
+          <section
+            key={currentAlert.eventId}
+            className="obscur-subscriber-pop relative flex w-fit max-w-[min(620px,92vw)] items-center gap-4 overflow-hidden border-l border-[#d8b46a]/80 bg-[linear-gradient(90deg,rgba(7,7,10,0.76),rgba(7,7,10,0.40)_72%,rgba(7,7,10,0.02))] px-5 py-4 shadow-[0_18px_48px_rgba(0,0,0,0.42)] backdrop-blur-[2px]"
+            style={{ animationDuration: `${durationMs}ms` }}
+            aria-live="polite"
+          >
+            <div className="absolute inset-y-3 left-2 w-px bg-[#f3d58b]/60" />
+            {imageUrl ? (
+              <div className="relative shrink-0">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={imageUrl}
+                  alt=""
+                  className="aspect-square w-16 border border-[#d8b46a]/70 object-cover shadow-[0_12px_30px_rgba(0,0,0,0.4)] sm:w-20"
+                />
+              </div>
+            ) : null}
+            <div className="relative min-w-0">
+              <h1
+                className="max-w-[18ch] break-words text-[1.8rem] font-semibold leading-none [text-shadow:0_2px_18px_rgba(0,0,0,0.88)] sm:text-[2.5rem] lg:text-[3rem]"
+                style={{ fontFamily: "var(--font-body)" }}
+              >
+                {currentAlert.displayName}
+              </h1>
+              <p className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-sm font-semibold text-[#d8b46a] [text-shadow:0_2px_14px_rgba(0,0,0,0.9)] sm:text-base">
+                <span>
+                  {title} - {subtitle}
+                </span>
+                {currentAlert.youtubeHandle ? <span>{currentAlert.youtubeHandle}</span> : null}
+              </p>
+            </div>
+          </section>
+        ) : null}
+      </div>
+    );
+  }
 
   return (
     <div className="pointer-events-none flex min-h-screen items-end justify-center p-6 sm:p-10 lg:p-14">

--- a/src/components/obs-wheel-overlay.tsx
+++ b/src/components/obs-wheel-overlay.tsx
@@ -3,6 +3,7 @@
 import { useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 
+import { getObsOverlayStyle, type ObsOverlayStyle } from "@/lib/obs-overlay-style";
 import type { WheelConfigRecord, WheelSpinRecord } from "@/lib/types";
 
 const DEMO_CONFIG: WheelConfigRecord = {
@@ -61,9 +62,10 @@ function isSpinVisible(spin: WheelSpinRecord | null) {
   return spin ? new Date(spin.resultVisibleUntil).getTime() > Date.now() : false;
 }
 
-export function ObsWheelOverlay() {
+export function ObsWheelOverlay({ initialStyle = "classic" }: { initialStyle?: ObsOverlayStyle }) {
   const searchParams = useSearchParams();
   const isDemo = searchParams.get("demo") === "1";
+  const isObscurStyle = (getObsOverlayStyle(searchParams) ?? initialStyle) === "obscur";
   const [config, setConfig] = useState<WheelConfigRecord | null>(isDemo ? DEMO_CONFIG : null);
   const [rotation, setRotation] = useState(0);
   const [lastSpinId, setLastSpinId] = useState<string | null>(null);
@@ -123,6 +125,47 @@ export function ObsWheelOverlay() {
 
   if (!config || activeOptions.length < 2) {
     return null;
+  }
+
+  if (isObscurStyle) {
+    return (
+      <div className="pointer-events-none flex min-h-screen items-end justify-end p-5 text-[#f8ecd4] sm:p-8 lg:p-10">
+        <section
+          className="grid w-[min(700px,92vw)] items-end gap-5 sm:grid-cols-[230px_1fr]"
+          aria-live="polite"
+        >
+          <div className="relative mx-auto aspect-square w-[min(230px,48vw)] sm:w-full">
+            <div className="absolute left-1/2 top-[-10px] z-20 h-0 w-0 -translate-x-1/2 border-x-[13px] border-t-[26px] border-x-transparent border-t-[#d8b46a] drop-shadow-[0_5px_10px_rgba(0,0,0,0.65)]" />
+            <div
+              className="absolute inset-0 rounded-full border border-[#d8b46a]/85 shadow-[0_18px_45px_rgba(0,0,0,0.48)]"
+              style={{
+                background: `conic-gradient(${gradient})`,
+                filter: "saturate(0.72) brightness(0.82)",
+                transform: `rotate(${rotation}deg)`,
+                transition: `transform ${spin?.spinDurationMs ?? config.spinDurationMs}ms cubic-bezier(.12,.82,.16,1)`,
+              }}
+            >
+              <div className="absolute inset-[15%] rounded-full border border-[#d8b46a]/60 bg-[rgba(8,7,10,0.72)]" />
+              <div className="absolute inset-[41%] rounded-full bg-[#d8b46a]" />
+            </div>
+          </div>
+
+          <div className="relative overflow-hidden border-l border-[#d8b46a]/80 bg-[linear-gradient(90deg,rgba(7,7,10,0.74),rgba(7,7,10,0.40)_72%,rgba(7,7,10,0.02))] px-5 py-4 shadow-[0_18px_48px_rgba(0,0,0,0.42)] backdrop-blur-[2px]">
+            <div className="absolute inset-y-3 left-2 w-px bg-[#f3d58b]/60" />
+            <h1
+              className="relative max-w-[14ch] break-words text-[1.7rem] font-semibold leading-tight [text-shadow:0_2px_18px_rgba(0,0,0,0.88)] sm:text-[2.35rem] lg:text-[2.75rem]"
+              style={{ fontFamily: "var(--font-body)" }}
+            >
+              {visibleSpin ? visibleSpin.label : "Pronta para girar"}
+            </h1>
+            <p className="relative mt-2 flex flex-wrap gap-x-3 gap-y-1 text-sm font-semibold text-[#d8b46a] [text-shadow:0_2px_14px_rgba(0,0,0,0.9)]">
+              <span>{visibleSpin ? "Resultado final" : `${activeOptions.length} opções ativas`}</span>
+              <span>{config.title}</span>
+            </p>
+          </div>
+        </section>
+      </div>
+    );
   }
 
   return (

--- a/src/lib/db/repository.ts
+++ b/src/lib/db/repository.ts
@@ -75,6 +75,7 @@ import {
 } from "@/lib/streamerbot/live-status";
 import { getCurrentGame } from "@/lib/current-game";
 import { normalizeYoutubeHandle } from "@/lib/youtube/identity";
+import { getObsOverlayStyleConfig } from "@/lib/obs-overlay-settings";
 import { evaluateRedeemability } from "@/lib/redemptions/service";
 import {
   resolveHowLongToBeatGame,
@@ -950,6 +951,7 @@ function sanitizePublicCounterSummaries(
   const hiddenCounterKeys = new Set([
     "livestream_override",
     "death_counter_active_game",
+    "obs_overlay_style",
     DAILY_DEATH_COUNTER_KEY,
     "current_stream_game",
   ]);
@@ -3151,9 +3153,10 @@ async function requestQuoteOverlay(input: {
 export async function getObsOverlayAdminStatus(): Promise<ObsOverlayAdminStatusRecord> {
   try {
     await expireQueuedQuoteOverlays();
-    const [control, activeOverlay] = await Promise.all([
+    const [control, activeOverlay, overlayStyle] = await Promise.all([
       getObsOverlayControlRecord(),
       getActiveQuoteOverlay(),
+      getObsOverlayStyleConfig(),
     ]);
     const db = getDb();
 
@@ -3165,6 +3168,7 @@ export async function getObsOverlayAdminStatus(): Promise<ObsOverlayAdminStatusR
 
       return {
         control,
+        overlayStyle,
         activeOverlay,
         pending,
         pendingCount: pending.length,
@@ -3182,6 +3186,7 @@ export async function getObsOverlayAdminStatus(): Promise<ObsOverlayAdminStatusR
 
     return {
       control,
+      overlayStyle,
       activeOverlay,
       pending,
       pendingCount: pending.length,
@@ -3199,6 +3204,7 @@ export async function getObsOverlayAdminStatus(): Promise<ObsOverlayAdminStatusR
         status: "error",
         lastError: "Migration pendente: crie as tabelas obs_overlay_control e quote_overlay_queue.",
       },
+      overlayStyle: await getObsOverlayStyleConfig(),
       activeOverlay: await getActiveQuoteOverlay(),
       pending: [],
       pendingCount: 0,

--- a/src/lib/obs-overlay-settings.ts
+++ b/src/lib/obs-overlay-settings.ts
@@ -1,0 +1,138 @@
+import { eq } from "drizzle-orm";
+
+import { getDb } from "@/lib/db/client";
+import { streamerbotCounters } from "@/lib/db/schema";
+import { isDemoMode } from "@/lib/env";
+import {
+  type ObsOverlayStyle,
+  type ObsOverlayStyleConfigRecord,
+  getObsOverlayStyleFromSearchParamsRecord,
+  normalizeObsOverlayStyle,
+} from "@/lib/obs-overlay-style";
+
+const OBS_OVERLAY_STYLE_KEY = "obs_overlay_style";
+const OBS_OVERLAY_STYLE_SCOPE_TYPE = "setting";
+const OBS_OVERLAY_STYLE_SCOPE_KEY = "obs_overlays";
+
+const DEFAULT_OBS_OVERLAY_STYLE_CONFIG: ObsOverlayStyleConfigRecord = {
+  style: "classic",
+  updatedAt: null,
+  updatedBy: null,
+};
+
+declare global {
+  var __pipetzObsOverlayStyleConfig: ObsOverlayStyleConfigRecord | undefined;
+}
+
+function isMissingStreamerbotCountersTableError(error: unknown) {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const maybePostgresError = error as Error & {
+    code?: string;
+    cause?: { code?: string; message?: string };
+  };
+  const message = `${error.message} ${maybePostgresError.cause?.message ?? ""}`;
+
+  return (
+    maybePostgresError.code === "42P01" ||
+    maybePostgresError.cause?.code === "42P01" ||
+    message.includes('relation "streamerbot_counters" does not exist')
+  );
+}
+
+function serializeObsOverlayStyleConfig(row: typeof streamerbotCounters.$inferSelect | null) {
+  if (!row) {
+    return { ...DEFAULT_OBS_OVERLAY_STYLE_CONFIG };
+  }
+
+  const metadata = row.metadata as Record<string, unknown>;
+  return {
+    style: normalizeObsOverlayStyle(metadata.style) ?? DEFAULT_OBS_OVERLAY_STYLE_CONFIG.style,
+    updatedAt: row.updatedAt.toISOString(),
+    updatedBy: typeof metadata.updatedBy === "string" ? metadata.updatedBy : null,
+  } satisfies ObsOverlayStyleConfigRecord;
+}
+
+function getDemoObsOverlayStyleConfig() {
+  globalThis.__pipetzObsOverlayStyleConfig ??= { ...DEFAULT_OBS_OVERLAY_STYLE_CONFIG };
+  return globalThis.__pipetzObsOverlayStyleConfig;
+}
+
+export async function getObsOverlayStyleConfig(): Promise<ObsOverlayStyleConfigRecord> {
+  const db = getDb();
+  if (isDemoMode || !db) {
+    return { ...getDemoObsOverlayStyleConfig() };
+  }
+
+  try {
+    const [row] = await db
+      .select()
+      .from(streamerbotCounters)
+      .where(eq(streamerbotCounters.key, OBS_OVERLAY_STYLE_KEY))
+      .limit(1);
+
+    return serializeObsOverlayStyleConfig(row ?? null);
+  } catch (error) {
+    if (isMissingStreamerbotCountersTableError(error)) {
+      return { ...DEFAULT_OBS_OVERLAY_STYLE_CONFIG };
+    }
+    throw error;
+  }
+}
+
+export async function updateObsOverlayStyleConfig(input: {
+  style: ObsOverlayStyle;
+  updatedBy?: string | null;
+}) {
+  const now = new Date();
+  const metadata = {
+    style: input.style,
+    updatedBy: input.updatedBy ?? null,
+    scopeType: OBS_OVERLAY_STYLE_SCOPE_TYPE,
+    scopeKey: OBS_OVERLAY_STYLE_SCOPE_KEY,
+  };
+  const db = getDb();
+
+  if (isDemoMode || !db) {
+    globalThis.__pipetzObsOverlayStyleConfig = {
+      style: input.style,
+      updatedAt: now.toISOString(),
+      updatedBy: input.updatedBy ?? null,
+    };
+    return getObsOverlayStyleConfig();
+  }
+
+  await db
+    .insert(streamerbotCounters)
+    .values({
+      key: OBS_OVERLAY_STYLE_KEY,
+      value: input.style === "obscur" ? 1 : 0,
+      lastResetAt: null,
+      updatedAt: now,
+      metadata,
+    })
+    .onConflictDoUpdate({
+      target: streamerbotCounters.key,
+      set: {
+        value: input.style === "obscur" ? 1 : 0,
+        updatedAt: now,
+        metadata,
+      },
+    });
+
+  return getObsOverlayStyleConfig();
+}
+
+export async function resolveObsOverlayInitialStyle(
+  searchParams: Promise<Record<string, string | string[] | undefined>>,
+): Promise<ObsOverlayStyle> {
+  const resolvedSearchParams = await searchParams;
+  const override = getObsOverlayStyleFromSearchParamsRecord(resolvedSearchParams);
+  if (override) {
+    return override;
+  }
+
+  return (await getObsOverlayStyleConfig()).style;
+}

--- a/src/lib/obs-overlay-style.test.ts
+++ b/src/lib/obs-overlay-style.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getObsOverlayStyle,
+  getObsOverlayStyleFromSearchParamsRecord,
+  normalizeObsOverlayStyle,
+} from "@/lib/obs-overlay-style";
+
+describe("getObsOverlayStyle", () => {
+  it("does not force an override by default", () => {
+    expect(getObsOverlayStyle(new URLSearchParams())).toBeNull();
+  });
+
+  it("enables the obscur style from the style parameter", () => {
+    expect(getObsOverlayStyle(new URLSearchParams("style=obscur"))).toBe("obscur");
+  });
+
+  it("accepts minimal aliases for the second overlay style", () => {
+    expect(getObsOverlayStyle(new URLSearchParams("style=minimal"))).toBe("obscur");
+    expect(getObsOverlayStyle(new URLSearchParams("design=minimalista"))).toBe("obscur");
+    expect(getObsOverlayStyle(new URLSearchParams("variant=clair-obscur"))).toBe("obscur");
+  });
+
+  it("ignores unknown values until it finds a valid override", () => {
+    expect(getObsOverlayStyle(new URLSearchParams("style=unknown&theme=obscur"))).toBe("obscur");
+  });
+
+  it("normalizes the classic style explicitly", () => {
+    expect(normalizeObsOverlayStyle("classic")).toBe("classic");
+  });
+
+  it("reads page search params records", () => {
+    expect(getObsOverlayStyleFromSearchParamsRecord({ style: ["minimal"] })).toBe("obscur");
+  });
+});

--- a/src/lib/obs-overlay-style.ts
+++ b/src/lib/obs-overlay-style.ts
@@ -1,0 +1,51 @@
+export type ObsOverlayStyle = "classic" | "obscur";
+
+export interface ObsOverlayStyleConfigRecord {
+  style: ObsOverlayStyle;
+  updatedAt: string | null;
+  updatedBy: string | null;
+}
+
+type SearchParamReader = {
+  get(name: string): string | null;
+};
+
+const obscurStyleAliases = new Set(["obscur", "clair-obscur", "minimal", "minimalista"]);
+
+export function normalizeObsOverlayStyle(value: unknown): ObsOverlayStyle | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+
+  return obscurStyleAliases.has(normalized) ? "obscur" : normalized === "classic" ? "classic" : null;
+}
+
+export function getObsOverlayStyle(searchParams: SearchParamReader): ObsOverlayStyle | null {
+  for (const key of ["style", "design", "theme", "variant"]) {
+    const style = normalizeObsOverlayStyle(searchParams.get(key));
+    if (style) {
+      return style;
+    }
+  }
+
+  return null;
+}
+
+export function getObsOverlayStyleFromSearchParamsRecord(
+  searchParams: Record<string, string | string[] | undefined>,
+): ObsOverlayStyle | null {
+  for (const key of ["style", "design", "theme", "variant"]) {
+    const rawValue = searchParams[key];
+    const style = normalizeObsOverlayStyle(Array.isArray(rawValue) ? rawValue[0] : rawValue);
+    if (style) {
+      return style;
+    }
+  }
+
+  return null;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,5 @@
+import type { ObsOverlayStyleConfigRecord } from "@/lib/obs-overlay-style";
+
 export type CatalogItemType =
   | "onscreen_text"
   | "play_sound"
@@ -377,6 +379,7 @@ export interface QuoteOverlayQueueRecord {
 
 export interface ObsOverlayAdminStatusRecord {
   control: ObsOverlayControlRecord;
+  overlayStyle: ObsOverlayStyleConfigRecord;
   activeOverlay: QuoteOverlayStateRecord | null;
   pending: QuoteOverlayQueueRecord[];
   pendingCount: number;


### PR DESCRIPTION
## Summary

- Add a persisted global OBS overlay style setting so existing `/obs/*` Browser Source URLs can switch between classic and minimal styles without changing OBS.
- Add minimal, Clair Obscur-inspired render variants for quotes, subscribers, likes, bets, and wheel overlays.
- Expose the active style controls in the admin overlays panel and keep query-string style overrides for manual demos/testing.

## Validation

- `npm run typecheck`
- `npx vitest run src/lib/obs-overlay-style.test.ts`
- `npx eslint src/app/api/admin/obs-overlays/route.ts src/app/obs/quotes/page.tsx src/app/obs/likes/page.tsx src/app/obs/bets/page.tsx src/app/obs/subscribers/page.tsx src/app/obs/wheel/page.tsx src/components/admin-obs-overlays-panel.tsx src/components/obs-quote-overlay.tsx src/components/obs-like-goal-overlay.tsx src/components/obs-bet-overlay.tsx src/components/obs-subscriber-overlay.tsx src/components/obs-wheel-overlay.tsx src/lib/obs-overlay-style.ts src/lib/obs-overlay-settings.ts src/lib/obs-overlay-style.test.ts`
- `npm run build`