### PR TITLE
Public landing page for the creator platform beta at /criar-area

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Mais detalhes ficam em `bridge/README.md`.
 - `/`: home da live, com estado da comunidade e atalhos.
 - `/me`: área do viewer logado.
 - `/owner`: área do criador aprovado no beta fechado.
-- `/criar-area`: redireciona para `/owner`.
+- `/criar-area`: landing pública da plataforma white label, com criação de área para emails aprovados no beta.
 - `/c/:slug`: entrada pública da área de um criador.
 - `/ranking`: ranking público de pipetz.
 - `/apostas`: apostas abertas e histórico.

--- a/src/app/(viewer)/criar-area/page.tsx
+++ b/src/app/(viewer)/criar-area/page.tsx
@@ -1,19 +1,92 @@
+import type { Metadata } from "next";
 import Link from "next/link";
-import { notFound } from "next/navigation";
+import { Coins, Palette, Sparkles, Ticket, type LucideIcon } from "lucide-react";
 
+import { auth } from "@/auth";
 import { CreatorAreaCreateForm } from "@/components/creator-area-create-form";
-import { requireSession } from "@/lib/auth/session";
+import { CreatorLandingCta } from "@/components/creator-landing-cta";
 import { canCreateCreatorArea } from "@/lib/creators/access";
+import { PLATFORM_NAME, resolveCreatorLandingState } from "@/lib/creators/platform";
 import { listCreatorAreasForOwner } from "@/lib/creators/service";
 
-export default async function CreateCreatorAreaPage() {
-  const session = await requireSession();
-  const isAllowed = await canCreateCreatorArea(session.user!.email);
-  if (!isAllowed) {
-    notFound();
-  }
+export const metadata: Metadata = {
+  title: `${PLATFORM_NAME} — crie a área da sua comunidade`,
+};
 
-  const creatorAreas = await listCreatorAreasForOwner(session.user!.activeViewerId);
+type CommunityStep = {
+  title: string;
+  body: string;
+  icon: LucideIcon;
+  bg: string;
+};
+
+const COMMUNITY_STEPS: CommunityStep[] = [
+  {
+    title: "Pontos acumulados",
+    body: "Sua comunidade acumula pontos enquanto assiste, direto na live.",
+    icon: Coins,
+    bg: "bg-[var(--color-mint)]",
+  },
+  {
+    title: "Bolões ao vivo",
+    body: "Ela aposta nos rumos do jogo enquanto a partida acontece.",
+    icon: Ticket,
+    bg: "bg-[var(--color-pink)]",
+  },
+  {
+    title: "Resgates com efeito",
+    body: "Ela troca pontos por efeitos que aparecem na sua transmissão.",
+    icon: Sparkles,
+    bg: "bg-[var(--color-blue)]",
+  },
+  {
+    title: "Sua identidade",
+    body: "Tudo com o nome e as cores do seu canal, no seu próprio endereço.",
+    icon: Palette,
+    bg: "bg-[var(--color-purple)]",
+  },
+];
+
+function CommunitySection() {
+  return (
+    <section className="mt-10">
+      <div className="grid gap-4 sm:grid-cols-2">
+        {COMMUNITY_STEPS.map((step) => {
+          const Icon = step.icon;
+
+          return (
+            <article
+              key={step.title}
+              className={`flex h-full min-w-0 flex-col border-[3px] border-[var(--color-ink)] p-5 text-[var(--color-accent-ink)] shadow-[5px_5px_0_var(--shadow-color)] ${step.bg}`}
+            >
+              <div className="flex size-12 items-center justify-center border-[3px] border-[var(--color-ink)] bg-[var(--color-paper)] text-[var(--color-ink)]">
+                <Icon className="size-6" aria-hidden="true" />
+              </div>
+              <h3
+                className="mt-5 text-2xl uppercase leading-[0.95]"
+                style={{ fontFamily: "var(--font-display)" }}
+              >
+                {step.title}
+              </h3>
+              <p className="mt-3 text-sm font-medium leading-6 text-[var(--color-accent-ink-soft)]">
+                {step.body}
+              </p>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+export default async function CreateCreatorAreaPage() {
+  const session = await auth();
+  const hasUsableSession = Boolean(session?.user?.email && session.user.activeViewerId);
+  const canCreateArea = hasUsableSession ? await canCreateCreatorArea(session!.user!.email) : false;
+  const landingState = resolveCreatorLandingState({ hasUsableSession, canCreateArea });
+
+  const creatorAreas =
+    landingState === "approved" ? await listCreatorAreasForOwner(session!.user!.activeViewerId) : [];
 
   return (
     <div className="surface-section flex w-full flex-col">
@@ -23,13 +96,16 @@ export default async function CreateCreatorAreaPage() {
             className="max-w-3xl text-4xl uppercase leading-[0.9] text-pretty sm:text-5xl"
             style={{ fontFamily: "var(--font-display)" }}
           >
-            Crie um ponto de encontro para sua comunidade.
+            Sua live, sua área, sua comunidade.
           </h1>
           <p className="mt-5 max-w-2xl text-base font-medium leading-7 text-[var(--color-ink-soft)]">
-            Escolha o nome, reserve o endereço e deixe os módulos principais preparados para a sua live.
+            {PLATFORM_NAME} está em beta fechado: crie um ponto de encontro para a sua comunidade,
+            com pontos, bolões e resgates que acontecem durante a sua live.
           </p>
 
-          {creatorAreas.length > 0 ? (
+          <CommunitySection />
+
+          {landingState === "approved" && creatorAreas.length > 0 ? (
             <div className="mt-8 grid gap-3">
               <h2
                 className="text-2xl uppercase text-[var(--color-ink)]"
@@ -61,7 +137,40 @@ export default async function CreateCreatorAreaPage() {
         </div>
 
         <div className="border-[3px] border-[var(--color-ink)] bg-[var(--color-paper)] p-5 shadow-[6px_6px_0_var(--shadow-color)] sm:p-6">
-          <CreatorAreaCreateForm />
+          {landingState === "visitor" ? (
+            <div className="grid gap-4">
+              <h2
+                className="text-2xl uppercase text-[var(--color-ink)]"
+                style={{ fontFamily: "var(--font-display)" }}
+              >
+                Crie a área da sua comunidade
+              </h2>
+              <p className="text-sm font-medium leading-6 text-[var(--color-ink-soft)]">
+                A criação de novas áreas está em beta fechado. Entre com sua conta Google para ver
+                se o seu email já está liberado.
+              </p>
+              <CreatorLandingCta />
+            </div>
+          ) : null}
+
+          {landingState === "closed_beta" ? (
+            <div className="grid gap-4">
+              <h2
+                className="text-2xl uppercase text-[var(--color-ink)]"
+                style={{ fontFamily: "var(--font-display)" }}
+              >
+                Beta fechado
+              </h2>
+              <p className="text-sm font-medium leading-6 text-[var(--color-ink-soft)]">
+                Novas áreas estão em beta fechado e o acesso é liberado por convite. O email da
+                conta Google usada no login (<strong>{session?.user?.email}</strong>) ainda não
+                está na lista de aprovados. Peça para liberar esse endereço e tente novamente
+                depois.
+              </p>
+            </div>
+          ) : null}
+
+          {landingState === "approved" ? <CreatorAreaCreateForm /> : null}
         </div>
       </section>
     </div>

--- a/src/components/creator-landing-cta.tsx
+++ b/src/components/creator-landing-cta.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { getProviders, signIn } from "next-auth/react";
+import { startTransition, useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { GOOGLE_AUTHORIZATION_PARAMS } from "@/lib/auth/google";
+
+const CREATOR_AREA_CALLBACK_URL = "/criar-area";
+
+export function CreatorLandingCta() {
+  const [providers, setProviders] = useState<Record<string, { id: string; name: string }> | null>(
+    null,
+  );
+
+  useEffect(() => {
+    startTransition(() => {
+      getProviders().then((result) => {
+        if (result) {
+          setProviders(result);
+        }
+      });
+    });
+  }, []);
+
+  const hasGoogle = Boolean(providers?.google);
+  const hasCredentials = Boolean(providers?.credentials);
+
+  const handleGoogleSignIn = () => {
+    void signIn("google", { callbackUrl: CREATOR_AREA_CALLBACK_URL }, GOOGLE_AUTHORIZATION_PARAMS);
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-2 sm:flex-row">
+        {hasGoogle ? (
+          <Button type="button" onClick={handleGoogleSignIn} variant="accent">
+            Criar a minha área
+          </Button>
+        ) : null}
+        {hasCredentials ? (
+          <Button
+            type="button"
+            onClick={() =>
+              signIn("credentials", { email: "ana@example.com", callbackUrl: CREATOR_AREA_CALLBACK_URL })
+            }
+            variant="accent"
+            size="sm"
+          >
+            Modo demo
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/creators/platform.test.ts
+++ b/src/lib/creators/platform.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveCreatorLandingState } from "@/lib/creators/platform";
+
+describe("resolveCreatorLandingState", () => {
+  it("returns visitor when there is no usable session, regardless of access", () => {
+    expect(resolveCreatorLandingState({ hasUsableSession: false, canCreateArea: false })).toBe("visitor");
+    expect(resolveCreatorLandingState({ hasUsableSession: false, canCreateArea: true })).toBe("visitor");
+  });
+
+  it("returns closed_beta when the session is usable but the email is not allowed", () => {
+    expect(resolveCreatorLandingState({ hasUsableSession: true, canCreateArea: false })).toBe("closed_beta");
+  });
+
+  it("returns approved when the session is usable and the email is allowed", () => {
+    expect(resolveCreatorLandingState({ hasUsableSession: true, canCreateArea: true })).toBe("approved");
+  });
+});

--- a/src/lib/creators/platform.ts
+++ b/src/lib/creators/platform.ts
@@ -1,0 +1,15 @@
+// Nome provisório da plataforma white label. O nome definitivo ainda não foi
+// decidido: quando for, trocar apenas esta constante.
+export const PLATFORM_NAME = "[nome da plataforma]";
+
+export type CreatorLandingState = "visitor" | "closed_beta" | "approved";
+
+export function resolveCreatorLandingState(input: {
+  hasUsableSession: boolean;
+  canCreateArea: boolean;
+}): CreatorLandingState {
+  if (!input.hasUsableSession) {
+    return "visitor";
+  }
+  return input.canCreateArea ? "approved" : "closed_beta";
+}


### PR DESCRIPTION
## What this does

Turns `/criar-area` into a public landing page for the creator platform beta, so the white-label offering finally has an entry point. Previously the route required login and returned a 404 to anyone not on the beta allowlist, and nothing explained what the product is.

The page now renders in three states:

- **Visitor (logged out):** hero pitch + "what your community gets" cards (points while watching, live bets, on-stream redemption effects, the creator's own branding/address) + a Google sign-in CTA that returns to `/criar-area`.
- **Closed beta (logged in, not approved):** the same pitch plus a "Beta fechado" notice showing which email needs approval — no more 404.
- **Approved:** the existing area list + creation form, unchanged.

The platform name is a deliberate placeholder (`PLATFORM_NAME = "[nome da plataforma]"` in `src/lib/creators/platform.ts`) — the final name isn't decided yet, so renaming later is a one-line change.

Server-side enforcement is untouched: `canCreateCreatorArea` still gates `GET/POST /api/me/creator-area` with a 403, so making the page public is safe.

## Changes

- `src/lib/creators/platform.ts` (new) — placeholder name constant + landing-state helper
- `src/lib/creators/platform.test.ts` (new) — 3 tests for the state helper
- `src/components/creator-landing-cta.tsx` (new) — Google/demo sign-in CTA
- `src/app/(viewer)/criar-area/page.tsx` — rewritten as the public landing
- `README.md` — corrected the stale `/criar-area` route description

## Verification

- `npm run lint` — exit 0
- `npx tsc --noEmit` — exit 0
- `npm test` — 300/300 pass (3 new)
- `npm run build` — exit 0
- Logged-out request to `/criar-area` returns HTTP 200 with the pitch (previously redirected)

Implemented from `plans/007-creator-platform-landing-page.md`.

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)
