### PR TITLE
Fix client-bundle crash white-screening /owner and /criar-area

### DIFF
--- a/src/components/creator-area-create-form.tsx
+++ b/src/components/creator-area-create-form.tsx
@@ -9,7 +9,7 @@ import {
   createCreatorAreaSchema,
   flattenCreatorAreaSchemaErrors,
   formatCreateCreatorAreaError,
-} from "@/lib/creators/service";
+} from "@/lib/creators/area-form";
 
 type FieldErrors = Partial<Record<"displayName" | "slug" | "primaryColor" | "accentColor", string>>;
 

--- a/src/lib/creators/area-form.ts
+++ b/src/lib/creators/area-form.ts
@@ -1,0 +1,59 @@
+import { z, ZodError } from "zod";
+
+import { DEFAULT_CREATOR_BRANDING } from "@/lib/creators/defaults";
+
+// Client-safe validation and error formatting for the creator-area form.
+// This module must NOT import server-only code (database client, env, node
+// built-ins): it is bundled into the "use client" CreatorAreaCreateForm, and
+// anything it pulls in ships to the browser. Keep the server logic in
+// service.ts, which re-exports these helpers for its own use.
+
+const creatorColorSchema = z
+  .string()
+  .trim()
+  .regex(/^#[0-9a-fA-F]{6}$/u, "Use uma cor em hexadecimal, como #c7a2e9.");
+
+export const createCreatorAreaSchema = z.object({
+  displayName: z.string().trim().min(2, "Informe o nome do criador.").max(80, "Use até 80 caracteres."),
+  slug: z.string().trim().max(64, "Use até 64 caracteres.").optional(),
+  primaryColor: creatorColorSchema.default(DEFAULT_CREATOR_BRANDING.primaryColor),
+  accentColor: creatorColorSchema.default(DEFAULT_CREATOR_BRANDING.accentColor),
+});
+
+export type CreateCreatorAreaInput = z.infer<typeof createCreatorAreaSchema>;
+
+function formatCreatorAreaSchemaError(error: ZodError) {
+  return error.issues[0]?.message ?? "Dados inválidos.";
+}
+
+export function formatCreateCreatorAreaError(error: unknown) {
+  if (error instanceof ZodError) {
+    return formatCreatorAreaSchemaError(error);
+  }
+
+  const message = error instanceof Error ? error.message : "Falha ao criar área.";
+  switch (message) {
+    case "creator_slug_exists":
+      return "Esse endereço já está em uso.";
+    case "creator_slug_reserved":
+      return "Esse endereço é reservado.";
+    case "invalid_creator_slug":
+      return "Use um endereço com letras, números e hífens.";
+    case "missing_creator_owner":
+      return "Entre novamente para criar a área.";
+    case "creator_schema_missing":
+      return "A estrutura de criadores ainda não foi aplicada no banco. Rode as migrações antes de criar áreas.";
+    default:
+      return message;
+  }
+}
+
+export function flattenCreatorAreaSchemaErrors(error: ZodError) {
+  return error.issues.reduce<Partial<Record<keyof CreateCreatorAreaInput, string>>>((acc, issue) => {
+    const field = issue.path[0];
+    if (typeof field === "string" && !acc[field as keyof CreateCreatorAreaInput]) {
+      acc[field as keyof CreateCreatorAreaInput] = issue.message;
+    }
+    return acc;
+  }, {});
+}

--- a/src/lib/creators/service.ts
+++ b/src/lib/creators/service.ts
@@ -1,8 +1,13 @@
 import { randomUUID } from "node:crypto";
 
 import { desc, eq } from "drizzle-orm";
-import { z, ZodError } from "zod";
 
+import {
+  createCreatorAreaSchema,
+  flattenCreatorAreaSchemaErrors,
+  formatCreateCreatorAreaError,
+  type CreateCreatorAreaInput,
+} from "@/lib/creators/area-form";
 import { DEFAULT_CREATOR_BRANDING, DEFAULT_CREATOR_DOMAIN } from "@/lib/creators/defaults";
 import {
   buildDemoCreatorModules,
@@ -17,19 +22,16 @@ import { getDb } from "@/lib/db/client";
 import { creatorBranding, creatorDomains, creatorModules, creators } from "@/lib/db/schema";
 import type { CreatorRecord, CreatorTenantRecord } from "@/lib/types";
 
-const creatorColorSchema = z
-  .string()
-  .trim()
-  .regex(/^#[0-9a-fA-F]{6}$/u, "Use uma cor em hexadecimal, como #c7a2e9.");
-
-export const createCreatorAreaSchema = z.object({
-  displayName: z.string().trim().min(2, "Informe o nome do criador.").max(80, "Use até 80 caracteres."),
-  slug: z.string().trim().max(64, "Use até 64 caracteres.").optional(),
-  primaryColor: creatorColorSchema.default(DEFAULT_CREATOR_BRANDING.primaryColor),
-  accentColor: creatorColorSchema.default(DEFAULT_CREATOR_BRANDING.accentColor),
-});
-
-export type CreateCreatorAreaInput = z.infer<typeof createCreatorAreaSchema>;
+// Client-safe validation/formatting lives in area-form.ts so the "use client"
+// CreatorAreaCreateForm can import it without dragging this server module (and
+// its db/env dependencies) into the browser bundle. Re-exported here so
+// existing server-side imports from "@/lib/creators/service" keep working.
+export {
+  createCreatorAreaSchema,
+  formatCreateCreatorAreaError,
+  flattenCreatorAreaSchemaErrors,
+  type CreateCreatorAreaInput,
+};
 
 export type CreatorAreaSummary = CreatorRecord & {
   publicPath: string;
@@ -62,10 +64,6 @@ function toAreaSummary(creator: CreatorRecord): CreatorAreaSummary {
     publicPath: `/c/${creator.slug}`,
     publicHostname: `${creator.slug}.${DEFAULT_CREATOR_DOMAIN}`,
   };
-}
-
-function formatCreatorAreaSchemaError(error: ZodError) {
-  return error.issues[0]?.message ?? "Dados inválidos.";
 }
 
 function isMissingCreatorSchemaError(error: unknown) {
@@ -113,37 +111,6 @@ function isMissingCreatorSchemaError(error: unknown) {
   return false;
 }
 
-export function formatCreateCreatorAreaError(error: unknown) {
-  if (error instanceof ZodError) {
-    return formatCreatorAreaSchemaError(error);
-  }
-
-  const message = error instanceof Error ? error.message : "Falha ao criar área.";
-  switch (message) {
-    case "creator_slug_exists":
-      return "Esse endereço já está em uso.";
-    case "creator_slug_reserved":
-      return "Esse endereço é reservado.";
-    case "invalid_creator_slug":
-      return "Use um endereço com letras, números e hífens.";
-    case "missing_creator_owner":
-      return "Entre novamente para criar a área.";
-    case "creator_schema_missing":
-      return "A estrutura de criadores ainda não foi aplicada no banco. Rode as migrações antes de criar áreas.";
-    default:
-      return message;
-  }
-}
-
-export function flattenCreatorAreaSchemaErrors(error: ZodError) {
-  return error.issues.reduce<Partial<Record<keyof CreateCreatorAreaInput, string>>>((acc, issue) => {
-    const field = issue.path[0];
-    if (typeof field === "string" && !acc[field as keyof CreateCreatorAreaInput]) {
-      acc[field as keyof CreateCreatorAreaInput] = issue.message;
-    }
-    return acc;
-  }, {});
-}
 
 function parseCreatorAreaInput(input: unknown) {
   const parsed = createCreatorAreaSchema.parse(input);

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -67,7 +67,12 @@ export const platformOwnerEmails = parseEmailSet(env.PLATFORM_OWNER_EMAILS ?? en
 export const isDemoMode = !env.DATABASE_URL;
 export const isDemoAuthEnabled = isDemoMode;
 
-if (isProduction && !env.NEXTAUTH_SECRET) {
+// Guard against evaluating server-only env validation in the browser: this
+// module must never be part of a client bundle, but if it accidentally is
+// (e.g. a "use client" component transitively imports it), NEXTAUTH_SECRET is
+// absent client-side and this throw would crash the page during hydration.
+// The server-side check is the one that matters; keep it scoped to the server.
+if (typeof window === "undefined" && isProduction && !env.NEXTAUTH_SECRET) {
   throw new Error(
     "[env] NEXTAUTH_SECRET is required in production. " +
       "Set it in the deployment environment before starting the app.",


### PR DESCRIPTION
## Production outage fix — `/owner` and `/criar-area` white-screening

Both pages showed the browser's "This page couldn't load" with **no Vercel logs**, because the crash was client-side, not server-side.

### Root cause

The `"use client"` `CreatorAreaCreateForm` imported the creator-area zod schema and error formatters from `@/lib/creators/service`. That import chain is:

```
creator-area-create-form.tsx ("use client")
  → @/lib/creators/service   (imports getDb)
  → @/lib/db/client          (imports { env })
  → @/lib/env                → throws at module eval if NEXTAUTH_SECRET missing in production
```

Bundled into the client, `env.ts`'s production guard runs **in the browser**, where `NEXTAUTH_SECRET` doesn't exist (it's a server-only secret). It throws during module evaluation, React can't hydrate, and the page white-screens. The server never errors — hence no Vercel logs, and `curl` returns a perfect 200. Only `/owner` and `/criar-area` broke because both statically import `CreatorAreaCreateForm`; the home page doesn't.

Confirmed via the browser console on production:
```
Error: [env] NEXTAUTH_SECRET is required in production...
  at module evaluation (https://ludylops.live/_next/static/chunks/…js)
```

### The fix

- **Extract client-safe code** — `createCreatorAreaSchema`, `formatCreateCreatorAreaError`, `flattenCreatorAreaSchemaErrors` (pure zod/formatting, no db/env) move to a new `src/lib/creators/area-form.ts`. The client form imports from there; `service.ts` re-exports them so server callers are unchanged.
- **Defense-in-depth** — scope `env.ts`'s production `NEXTAUTH_SECRET` throw to the server (`typeof window === "undefined"`), so a future accidental client import degrades instead of crashing hydration.

### Verification

- `npx tsc --noEmit` — exit 0
- `npm run lint` — exit 0
- `npm test` — 300/300 pass
- `npm run build` — exit 0
- **`grep "NEXTAUTH_SECRET is required" .next/static/chunks/` → no matches** (before this fix, a client chunk contained it). The env throw is no longer in any client bundle.

Final confirmation will be on the Vercel preview deploy: open `/criar-area` (logged out) and `/owner` (as a platform owner) — both should render with a clean console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
