### PR TITLE
Fix daily death counter reset

### DIFF
--- a/src/components/counter-board.tsx
+++ b/src/components/counter-board.tsx
@@ -2,6 +2,8 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { StreamerbotCounterSummaryRecord } from "@/lib/types";
 import { formatPipetz } from "@/lib/utils";
 
+const DEATH_COUNTER_KEY = "death_count";
+
 function scopeHeading(scopeKey: string, scopeLabel: string | null) {
   return scopeLabel ?? scopeKey.replace(/[_-]+/g, " ");
 }
@@ -73,7 +75,6 @@ export function CounterBoard({
   counters: StreamerbotCounterSummaryRecord[];
   currentScopeKey?: string | null;
 }) {
-  const globalCounters = counters.filter((counter) => counter.scopeType === "global");
   const gameGroups = counters
     .filter((counter) => counter.scopeType === "game")
     .reduce<Map<string, StreamerbotCounterSummaryRecord[]>>((groups, counter) => {
@@ -86,6 +87,14 @@ export function CounterBoard({
   const currentGameGroup = currentScopeKey
     ? gameGroupEntries.find(([scopeKey]) => scopeKey === currentScopeKey)
     : undefined;
+  const currentGameHasDeathCounter = currentGameGroup?.[1].some(
+    (counter) => counter.key === DEATH_COUNTER_KEY,
+  );
+  const globalCounters = counters.filter(
+    (counter) =>
+      counter.scopeType === "global" &&
+      !(currentGameHasDeathCounter && counter.key === DEATH_COUNTER_KEY),
+  );
   const otherGameGroups = currentScopeKey
     ? gameGroupEntries.filter(([scopeKey]) => scopeKey !== currentScopeKey)
     : gameGroupEntries;

--- a/src/lib/db/repository.test.ts
+++ b/src/lib/db/repository.test.ts
@@ -1974,6 +1974,16 @@ describe("runStreamerbotCounterCommand", () => {
           },
         },
         {
+          key: "creator_area_beta_access",
+          value: 1,
+          lastResetAt: null,
+          updatedAt: new Date("2026-04-07T11:03:30.000Z"),
+          metadata: {
+            allowedEmails: ["creator@example.com"],
+            updatedBy: "admin@example.com",
+          },
+        },
+        {
           key: "death_count_daily",
           value: 18,
           lastResetAt: null,
@@ -2193,6 +2203,42 @@ describe("runStreamerbotCounterCommand", () => {
 
     expect(result.count).toBe(3);
     expect(result.replyMessage).toBe("Ludy, contador geral de mortes: 3. Contador de mortes do dia: 3.");
+  });
+
+  it("resets daily deaths in database mode at midnight in Sao Paulo", async () => {
+    const { db, rows } = createStreamerbotCounterDb();
+    getDbMock.mockReturnValue(db);
+
+    await runDeathCounterCommand({
+      action: "increment",
+      amount: 2,
+      occurredAt: "2026-04-08T02:30:00.000Z",
+    });
+
+    const afterMidnight = await runDeathCounterCommand({
+      action: "get",
+      occurredAt: "2026-04-08T03:01:00.000Z",
+    });
+
+    expect(afterMidnight.replyMessage).toBe("contador geral de mortes: 2. Contador de mortes do dia: 0.");
+    expect(rows.find((row) => row.key === "death_count_daily")).toMatchObject({
+      value: 0,
+      metadata: expect.objectContaining({
+        hiddenFromPublic: true,
+        trackingDate: "2026-04-08",
+      }),
+    });
+
+    await runDeathCounterCommand({
+      action: "increment",
+      amount: 1,
+      occurredAt: "2026-04-08T03:02:00.000Z",
+    });
+
+    expect(rows.find((row) => row.key === "death_count_daily")).toMatchObject({
+      value: 1,
+      metadata: expect.objectContaining({ trackingDate: "2026-04-08" }),
+    });
   });
 
   it("uses the current stream game even when an explicit game scope is provided", async () => {

--- a/src/lib/db/repository.ts
+++ b/src/lib/db/repository.ts
@@ -256,6 +256,7 @@ function buildSpendingHistory(input: {
 }
 const DEFAULT_DEATH_COUNTER_LABEL = "mortes";
 const DAILY_DEATH_COUNTER_LABEL = "mortes do dia";
+const DAILY_DEATH_COUNTER_TIME_ZONE = "America/Sao_Paulo";
 const GLOBAL_COUNTER_SCOPE_TYPE = "global";
 const GLOBAL_COUNTER_SCOPE_KEY = "global";
 const STREAMERBOT_COUNTER_STORAGE_SEPARATOR = "::";
@@ -596,7 +597,22 @@ type StreamerbotCounterCommandResult = {
 };
 
 function buildCounterDateKey(occurredAt: Date) {
-  return occurredAt.toISOString().slice(0, 10);
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: DAILY_DEATH_COUNTER_TIME_ZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(occurredAt);
+  const values = new Map(parts.map((part) => [part.type, part.value]));
+  const year = values.get("year");
+  const month = values.get("month");
+  const day = values.get("day");
+
+  if (!year || !month || !day) {
+    throw new Error("daily_death_counter_date_unavailable");
+  }
+
+  return `${year}-${month}-${day}`;
 }
 
 function isGlobalCounterScope(scope: { scopeType?: string | null }) {
@@ -610,6 +626,40 @@ function buildDeathCountersReply(input: {
 }) {
   const prefix = input.requestedBy ? `${input.requestedBy}, ` : "";
   return `${prefix}contador geral de mortes: ${input.globalCount}. Contador de mortes do dia: ${input.dailyCount}.`;
+}
+
+async function ensureDailyDeathCounterForDate(input: { occurredAt: Date; trackingDate: string }) {
+  const occurredAt = input.occurredAt.toISOString();
+  const dailyMetadata = {
+    hiddenFromPublic: true,
+    trackingDate: input.trackingDate,
+  };
+  const dailyCounter = await runStreamerbotCounterCommand({
+    action: "get",
+    counterKey: DAILY_DEATH_COUNTER_KEY,
+    counterLabel: DAILY_DEATH_COUNTER_LABEL,
+    scopeType: GLOBAL_COUNTER_SCOPE_TYPE,
+    occurredAt,
+  });
+  const trackedDate =
+    typeof dailyCounter.counter.metadata.trackingDate === "string"
+      ? dailyCounter.counter.metadata.trackingDate
+      : null;
+
+  if (trackedDate === input.trackingDate) {
+    return dailyCounter;
+  }
+
+  return runStreamerbotCounterCommand({
+    action: "reset",
+    counterKey: DAILY_DEATH_COUNTER_KEY,
+    counterLabel: DAILY_DEATH_COUNTER_LABEL,
+    scopeType: GLOBAL_COUNTER_SCOPE_TYPE,
+    occurredAt,
+    confirmReset: true,
+    resetReason: "new_day",
+    metadata: dailyMetadata,
+  });
 }
 
 function buildStreamerbotCounterSummary(counter: StreamerbotCounterRecord): StreamerbotCounterSummaryRecord {
@@ -955,6 +1005,7 @@ function sanitizePublicCounterSummaries(
     "obs_overlay_style",
     DAILY_DEATH_COUNTER_KEY,
     "current_stream_game",
+    "creator_area_beta_access",
   ]);
 
   return counters
@@ -8323,10 +8374,7 @@ export async function runDeathCounterCommand(input: {
   const currentGame = await getCurrentGame();
   const occurredAt = input.occurredAt ? new Date(input.occurredAt) : new Date();
   const counterDateKey = buildCounterDateKey(occurredAt);
-  const dailyMetadata = {
-    hiddenFromPublic: true,
-    trackingDate: counterDateKey,
-  };
+  const dailyMetadata = { hiddenFromPublic: true, trackingDate: counterDateKey };
   const resolvedScope = currentGame
     ? {
         scopeType: "game" as const,
@@ -8360,15 +8408,9 @@ export async function runDeathCounterCommand(input: {
           counterLabel: DEFAULT_DEATH_COUNTER_LABEL,
           scopeType: GLOBAL_COUNTER_SCOPE_TYPE,
         });
-    const dailyCounter = await runStreamerbotCounterCommand({
-      action: "get",
-      requestedBy: input.requestedBy,
-      source: input.source,
-      occurredAt: input.occurredAt,
-      counterKey: DAILY_DEATH_COUNTER_KEY,
-      counterLabel: DAILY_DEATH_COUNTER_LABEL,
-      scopeType: GLOBAL_COUNTER_SCOPE_TYPE,
-      metadata: dailyMetadata,
+    const dailyCounter = await ensureDailyDeathCounterForDate({
+      occurredAt,
+      trackingDate: counterDateKey,
     });
 
     return {
@@ -8390,37 +8432,14 @@ export async function runDeathCounterCommand(input: {
         counterLabel: DEFAULT_DEATH_COUNTER_LABEL,
       });
     }
-    const dailyCounter = await runStreamerbotCounterCommand({
-      action: "get",
-      counterKey: DAILY_DEATH_COUNTER_KEY,
-      counterLabel: DAILY_DEATH_COUNTER_LABEL,
-      scopeType: GLOBAL_COUNTER_SCOPE_TYPE,
-      occurredAt: input.occurredAt,
-      metadata: dailyMetadata,
-    });
-    const trackedDate =
-      typeof dailyCounter.counter.metadata.trackingDate === "string"
-        ? dailyCounter.counter.metadata.trackingDate
-        : null;
-
-    if (trackedDate && trackedDate !== counterDateKey) {
-      await runStreamerbotCounterCommand({
-        action: "reset",
-        counterKey: DAILY_DEATH_COUNTER_KEY,
-        counterLabel: DAILY_DEATH_COUNTER_LABEL,
-        scopeType: GLOBAL_COUNTER_SCOPE_TYPE,
-        occurredAt: input.occurredAt,
-        confirmReset: true,
-        resetReason: "new_day",
-        metadata: dailyMetadata,
-      });
-    }
+    await ensureDailyDeathCounterForDate({ occurredAt, trackingDate: counterDateKey });
 
     await runStreamerbotCounterCommand({
       ...input,
       scopeType: GLOBAL_COUNTER_SCOPE_TYPE,
       counterKey: DAILY_DEATH_COUNTER_KEY,
       counterLabel: DAILY_DEATH_COUNTER_LABEL,
+      occurredAt: occurredAt.toISOString(),
       metadata: dailyMetadata,
     });
   }


### PR DESCRIPTION
## What changed

- Hide internal creator beta access data from the public counter list.
- Avoid rendering the global death total beside the active game's death counter.
- Reset daily deaths on the first `!deaths` or death update after a São Paulo day changes.

## Why

The daily counter compared the current date after overwriting the stored tracking date, so production never detected a new day. It also used UTC instead of the stream's São Paulo day boundary.

## Validation

- `npm.cmd test`
- `npm.cmd run typecheck`
- `npx.cmd eslint src/components/counter-board.tsx src/lib/db/repository.ts src/lib/db/repository.test.ts`
- `npm.cmd run build`